### PR TITLE
fix(init): truthful index report + trustworthy style-miner signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The style miner no longer learns commit conventions from squash/PR-merge commits (subjects ending in `(#123)`). These are tool-generated, not hand-written, so counting them taught the profile the merge format instead of the author's voice; in a squash-merged repo the commit-voice rules now correctly emit nothing rather than a wrong rule.
+- `mastermind miner profile` and `init` now report which identity they mined as and that repo's contribution (`enriched as \`<author>\` … (+N commits here)`), so a wrong author (e.g. a misconfigured `git user.name`) is visible instead of silent.
+
 ### Fixed
 - `mastermind init` no longer prints `indexed 0 files, 0 symbols, 0 edges` when the index already exists and nothing changed. An incremental re-index is a no-op (0 files re-parsed), but the index stays fully populated — the old message read as if it were empty. It now reports the index totals from the db (`index up to date — N files, M symbols (0 reindexed, …)`), matching `mastermind status`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `mastermind init` no longer prints `indexed 0 files, 0 symbols, 0 edges` when the index already exists and nothing changed. An incremental re-index is a no-op (0 files re-parsed), but the index stays fully populated — the old message read as if it were empty. It now reports the index totals from the db (`index up to date — N files, M symbols (0 reindexed, …)`), matching `mastermind status`.
+
 ## [0.34.0] - 2026-06-27
 
 ### Added

--- a/mcp/servers/mmcg/src/commands/init.rs
+++ b/mcp/servers/mmcg/src/commands/init.rs
@@ -145,10 +145,24 @@ pub fn do_init(root: &Path, opts: InitOpts) -> Result<(), Box<dyn std::error::Er
         let mut store = Store::open(&db_path)?;
         let indexer = Indexer::new(root);
         match indexer.index_all(&mut store, false) {
-            Ok(stats) => created.push(format!(
-                "indexed {} files, {} symbols, {} edges ({} ms)",
-                stats.files_indexed, stats.symbols_total, stats.edges_total, stats.duration_ms
-            )),
+            Ok(stats) => {
+                // Report the index's *totals* (from the db), not just this run's
+                // delta — an incremental no-op indexes 0 files but the index is
+                // still fully populated, and "indexed 0 files" reads as empty.
+                let files = store.file_count().unwrap_or(stats.files_indexed);
+                let symbols = store.symbol_count().unwrap_or(stats.symbols_total);
+                if stats.files_indexed == 0 {
+                    created.push(format!(
+                        "index up to date — {files} files, {symbols} symbols (0 reindexed, {} ms)",
+                        stats.duration_ms
+                    ));
+                } else {
+                    created.push(format!(
+                        "indexed {} files, {symbols} symbols total ({} ms)",
+                        stats.files_indexed, stats.duration_ms
+                    ));
+                }
+            }
             Err(e) => warnings.push(format!(
                 "index build failed: {e} — run `mastermind index .` manually"
             )),

--- a/mcp/servers/mmcg/src/commands/init.rs
+++ b/mcp/servers/mmcg/src/commands/init.rs
@@ -204,9 +204,16 @@ pub fn do_init(root: &Path, opts: InitOpts) -> Result<(), Box<dyn std::error::Er
 
     if seed_style {
         match mmcg::miner::profile::mine(root, None, false, false) {
-            Ok(mmcg::miner::profile::SeedOutcome::Enriched { repos, rules, .. }) => created.push(
-                format!("~/.mastermind/style.md ({rules} rule(s) across {repos} repo(s))"),
-            ),
+            Ok(mmcg::miner::profile::SeedOutcome::Enriched {
+                author,
+                repo_commits,
+                repos,
+                rules,
+                ..
+            }) => created.push(format!(
+                "~/.mastermind/style.md — as `{author}` ({rules} rule(s), {repos} repo(s), \
+                 +{repo_commits} commits here)"
+            )),
             Ok(mmcg::miner::profile::SeedOutcome::NoCommits { .. }) => {
                 skipped.push("~/.mastermind/style.md (no commits by you in this repo yet)".into())
             }

--- a/mcp/servers/mmcg/src/miner/profile.rs
+++ b/mcp/servers/mmcg/src/miner/profile.rs
@@ -35,6 +35,10 @@ const STALE_COMMITS: usize = 25;
 /// What [`mine`] did, so callers (the CLI, `init`) can report it their own way.
 pub enum SeedOutcome {
     Enriched {
+        /// The resolved author this run mined as (git user.name, or `--author`).
+        author: String,
+        /// Commits by `author` in *this* repo — its contribution this run.
+        repo_commits: i64,
         /// Repos now contributing to the global profile.
         repos: usize,
         rules: usize,
@@ -136,6 +140,8 @@ pub fn mine(
     std::fs::write(&path, &markdown)?;
 
     Ok(SeedOutcome::Enriched {
+        repo_commits: prov.commits_total as i64,
+        author,
         repos: agg.repos,
         rules: rules.len(),
         commits: agg.commits_total,
@@ -191,6 +197,8 @@ pub fn run(
             );
         }
         SeedOutcome::Enriched {
+            author,
+            repo_commits,
             repos,
             rules,
             commits,
@@ -199,7 +207,8 @@ pub fn run(
             empty,
         } => {
             println!(
-                "Enriched {} — {rules} rule(s) across {repos} repo(s), {commits} commit(s).",
+                "Enriched {} as `{author}` — {rules} rule(s) across {repos} repo(s), \
+                 {commits} commit(s) (+{repo_commits} from here).",
                 path.display(),
             );
             if pruned > 0 {
@@ -985,8 +994,29 @@ fn has_conventional_prefix(subject: &str) -> bool {
 }
 
 /// Commit conventions in one pass — prefix, subject length, body presence.
+/// A squash/PR-merge subject ends with `(#123)` — GitHub/GitLab append the PR
+/// number on merge, so it's the tool's format, not the author's hand-written
+/// voice. Counting these would teach the profile the merge convention.
+fn is_squash_merge(subject: &str) -> bool {
+    let Some(inner) = subject.trim_end().strip_suffix(')') else {
+        return false;
+    };
+    match inner.rfind("(#") {
+        Some(i) => {
+            let digits = &inner[i + 2..];
+            !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+        }
+        None => false,
+    }
+}
+
 fn acc_commits(commits: &[Commit], c: &mut Counts) {
     for cm in commits {
+        // Skip tool-generated squash/merge subjects — commit-voice rules should
+        // reflect commits the person actually wrote, not the merge format.
+        if is_squash_merge(&cm.subject) {
+            continue;
+        }
         bump(c, "commit.total", 1);
         if has_conventional_prefix(&cm.subject) {
             bump(c, "commit.prefix_with", 1);
@@ -1492,6 +1522,37 @@ diff --git a/app/bar.ts b/app/bar.ts
         assert!(has_conventional_prefix("fix(api)!: y"));
         assert!(!has_conventional_prefix("Merge branch main"));
         assert!(!has_conventional_prefix("WIP: stuff"));
+    }
+
+    #[test]
+    fn squash_merge_subjects() {
+        assert!(is_squash_merge("KSK-5781 workbench: rename (#13)"));
+        assert!(is_squash_merge("feat: thing (#48866)"));
+        assert!(is_squash_merge("trailing space (#9) "));
+        assert!(!is_squash_merge("feat: add x"));
+        assert!(!is_squash_merge("fix: handle (#) empty"));
+        assert!(!is_squash_merge("note (#12) mid-subject"));
+    }
+
+    #[test]
+    fn acc_commits_skips_squash_merges() {
+        let commits = vec![
+            Commit {
+                subject: "feat: hand-written".to_string(),
+                body: String::new(),
+            },
+            Commit {
+                subject: "KSK-1 squashed (#42)".to_string(),
+                body: String::new(),
+            },
+        ];
+        let mut c = Counts::new();
+        acc_commits(&commits, &mut c);
+        assert_eq!(
+            cget(&c, "commit.total"),
+            1,
+            "only the hand-written commit counts"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two reporting/signal fixes surfaced while dogfooding `init` and the style miner on real repos.

## `init` index report
`init` printed `indexed 0 files, 0 symbols, 0 edges` whenever the index already existed and nothing had changed — an incremental re-index is a no-op (0 files re-parsed), but the index is still fully populated. The line read as if the index were empty. It now reports the db totals, matching `mastermind status`:

```
+ index up to date — 35164 files, 248405 symbols (0 reindexed, 11 ms)
```

## Style-miner signal
- **Skip squash/PR-merge commits** in commit-voice mining (subjects ending in `(#123)`). They're tool-generated, not hand-written, so counting them taught the profile the merge format. In a squash-merged repo the commit-voice rules now correctly emit nothing instead of a wrong rule.
- **Name the mined identity** in the report (`enriched as <author> … (+N commits here)`), so a wrong author (a misconfigured `git user.name`) is visible instead of silent — the operator sees who was profiled and decides, no heuristics.

## Testing
`cargo test` + `cargo clippy -- -D warnings` + `cargo fmt --check` clean. Live-verified on real repos: index totals on a 35k-file monorepo, squash filter dropping commit-voice in a copybara-mirrored repo.

Independent of #20 (disjoint regions of `init.rs`); both add a CHANGELOG `[Unreleased]` entry, so the second to merge may need a trivial touch-up.
