### PR TITLE
feat(init): stack detection as runtime + framework + polyglot monorepos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `mastermind init` now detects a polyglot monorepo as its own CONTEXT.md profile instead of labelling it `generic`. When the repo root has no manifest of its own but subpackages carry manifests across ≥2 ecosystems, it reports `monorepo (go, java, python, …)` (enumerating the stacks from `git ls-files`) and scaffolds a monorepo CONTEXT.md — one that says each package owns its stack and tells the agent to read the nearest manifest / per-service CLAUDE.md rather than assume a single root toolchain.
+- `mastermind init` stack detection is now **runtime + detected framework** instead of a handful of narrow profiles. It reports a rich label — `rust`, `rust (tauri desktop)`, `node (react)`, `node (vue)`, `node (next.js)`, `node (api)`, `python (fastapi)`, `python (django)`, `go`, etc. — and picks the best lean CONTEXT.md template for it (the bespoke TypeScript-API / FastAPI / React-Native / Rust templates where they fit, the generic scaffold otherwise).
+- Polyglot monorepos are detected as their own profile rather than `generic`: a bare root whose subpackages carry manifests across ≥2 ecosystems reports `monorepo (go, python, typescript, …)` (enumerated from `git ls-files`) and scaffolds a monorepo CONTEXT.md that says each package owns its stack and tells the agent to read the nearest manifest / per-service CLAUDE.md.
+
+### Changed
+- The `rust-cli` profile is now just `rust` — it was mislabelling Rust services and libraries as CLIs. Template renamed `rust-cli.md` → `rust.md` and generalized.
 
 ## [0.34.0] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `mastermind init` now detects a polyglot monorepo as its own CONTEXT.md profile instead of labelling it `generic`. When the repo root has no manifest of its own but subpackages carry manifests across ≥2 ecosystems, it reports `monorepo (go, java, python, …)` (enumerating the stacks from `git ls-files`) and scaffolds a monorepo CONTEXT.md — one that says each package owns its stack and tells the agent to read the nearest manifest / per-service CLAUDE.md rather than assume a single root toolchain.
+
 ## [0.34.0] - 2026-06-27
 
 ### Added

--- a/mcp/servers/mmcg/src/commands/init.rs
+++ b/mcp/servers/mmcg/src/commands/init.rs
@@ -8,6 +8,7 @@ use mmcg::indexer::Indexer;
 use mmcg::store::Store;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 use crate::{templates, Profile};
 
@@ -42,9 +43,19 @@ pub fn do_init(root: &Path, opts: InitOpts) -> Result<(), Box<dyn std::error::Er
 
     // Batteries-included: auto-detect the CONTEXT.md stack profile from the repo.
     let profile = detect_stack(root);
+    // For a monorepo, name the ecosystems so "monorepo" reads as a finding, not
+    // a fallback — the bare root has no single stack but the subpackages do.
+    let stack_note = match profile {
+        Profile::Monorepo => match monorepo_ecosystems(root) {
+            langs if langs.is_empty() => String::new(),
+            langs => format!(" ({})", langs.join(", ")),
+        },
+        _ => String::new(),
+    };
     created.push(format!(
-        "auto-detected stack: {} CONTEXT.md profile",
-        templates::profile_label(profile)
+        "auto-detected stack: {}{} CONTEXT.md profile",
+        templates::profile_label(profile),
+        stack_note,
     ));
 
     let mastermind_dir = root.join(".mastermind");
@@ -269,7 +280,71 @@ fn detect_stack(root: &Path) -> Profile {
     if exists("Cargo.toml") && (read("Cargo.toml").contains("[[bin]]") || exists("src/main.rs")) {
         return Profile::RustCli;
     }
+    // No single root stack. A bare root whose subpackages carry manifests across
+    // ≥2 ecosystems is a polyglot monorepo, not a featureless "generic" repo.
+    if !root_has_manifest(root) && monorepo_ecosystems(root).len() >= 2 {
+        return Profile::Monorepo;
+    }
     Profile::Generic
+}
+
+/// Any root-level manifest means the repo has its own stack (one package), so it
+/// isn't a bare-root monorepo even when subdirectories also carry manifests.
+fn root_has_manifest(root: &Path) -> bool {
+    const MANIFESTS: &[&str] = &[
+        "package.json",
+        "Cargo.toml",
+        "pyproject.toml",
+        "requirements.txt",
+        "go.mod",
+        "composer.json",
+        "pom.xml",
+        "build.gradle",
+    ];
+    MANIFESTS.iter().any(|m| root.join(m).exists())
+}
+
+/// Distinct language ecosystems whose manifest lives in a *subdirectory*, via
+/// `git ls-files` (tracked files only). Python's two manifest kinds fold to one.
+/// Empty when `root` isn't a git repo. ≥2 with a bare root ⇒ polyglot monorepo.
+fn monorepo_ecosystems(root: &Path) -> Vec<&'static str> {
+    let out = match Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args([
+            "ls-files",
+            "*/package.json",
+            "*/Cargo.toml",
+            "*/pyproject.toml",
+            "*/requirements.txt",
+            "*/go.mod",
+            "*/composer.json",
+            "*/pom.xml",
+            "*/build.gradle",
+        ])
+        .output()
+    {
+        Ok(o) if o.status.success() => o.stdout,
+        _ => return Vec::new(),
+    };
+    let listing = String::from_utf8_lossy(&out).to_ascii_lowercase();
+    let mut ecos = std::collections::BTreeSet::new();
+    for line in listing.lines() {
+        if line.ends_with("/package.json") {
+            ecos.insert("javascript");
+        } else if line.ends_with("/cargo.toml") {
+            ecos.insert("rust");
+        } else if line.ends_with("/pyproject.toml") || line.ends_with("/requirements.txt") {
+            ecos.insert("python");
+        } else if line.ends_with("/go.mod") {
+            ecos.insert("go");
+        } else if line.ends_with("/composer.json") {
+            ecos.insert("php");
+        } else if line.ends_with("/pom.xml") || line.ends_with("/build.gradle") {
+            ecos.insert("java");
+        }
+    }
+    ecos.into_iter().collect()
 }
 
 fn write_if_absent(
@@ -491,5 +566,51 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(detect_stack(d2.path()), Profile::PythonFastapi));
+    }
+
+    #[test]
+    fn detect_stack_polyglot_monorepo() {
+        let d = tempfile::tempdir().unwrap();
+        let root = d.path();
+        // Bare root; manifests across 3 ecosystems live in subpackages.
+        for (dir, file, body) in [
+            ("services/api", "pyproject.toml", "[project]\nname=\"api\""),
+            ("web", "package.json", "{}"),
+            ("cmd/sync", "go.mod", "module x"),
+        ] {
+            let p = root.join(dir);
+            fs::create_dir_all(&p).unwrap();
+            fs::write(p.join(file), body).unwrap();
+        }
+        // `git ls-files` only sees tracked files, so init + add the tree.
+        for args in [["init", "-q"].as_slice(), ["add", "-A"].as_slice()] {
+            Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(args)
+                .output()
+                .unwrap();
+        }
+        assert!(matches!(detect_stack(root), Profile::Monorepo));
+        let langs = monorepo_ecosystems(root);
+        assert_eq!(langs, vec!["go", "javascript", "python"]);
+    }
+
+    #[test]
+    fn detect_stack_single_nested_ecosystem_is_generic() {
+        let d = tempfile::tempdir().unwrap();
+        let root = d.path();
+        // One nested ecosystem only — not enough to call it a polyglot monorepo.
+        fs::create_dir_all(root.join("web")).unwrap();
+        fs::write(root.join("web/package.json"), "{}").unwrap();
+        for args in [["init", "-q"].as_slice(), ["add", "-A"].as_slice()] {
+            Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(args)
+                .output()
+                .unwrap();
+        }
+        assert!(matches!(detect_stack(root), Profile::Generic));
     }
 }

--- a/mcp/servers/mmcg/src/commands/init.rs
+++ b/mcp/servers/mmcg/src/commands/init.rs
@@ -41,21 +41,11 @@ pub fn do_init(root: &Path, opts: InitOpts) -> Result<(), Box<dyn std::error::Er
     let mut warnings: Vec<String> = Vec::new();
     let mut context_fill_prompt: Option<String> = None;
 
-    // Batteries-included: auto-detect the CONTEXT.md stack profile from the repo.
-    let profile = detect_stack(root);
-    // For a monorepo, name the ecosystems so "monorepo" reads as a finding, not
-    // a fallback — the bare root has no single stack but the subpackages do.
-    let stack_note = match profile {
-        Profile::Monorepo => match monorepo_ecosystems(root) {
-            langs if langs.is_empty() => String::new(),
-            langs => format!(" ({})", langs.join(", ")),
-        },
-        _ => String::new(),
-    };
+    // Batteries-included: auto-detect the stack for the CONTEXT.md profile.
+    let stack = detect_stack(root);
     created.push(format!(
-        "auto-detected stack: {}{} CONTEXT.md profile",
-        templates::profile_label(profile),
-        stack_note,
+        "auto-detected stack: {} CONTEXT.md profile",
+        stack.label,
     ));
 
     let mastermind_dir = root.join(".mastermind");
@@ -105,17 +95,10 @@ pub fn do_init(root: &Path, opts: InitOpts) -> Result<(), Box<dyn std::error::Er
     }
 
     let context_path = root.join("CONTEXT.md");
-    let context_body = templates::strip_comment(templates::for_profile(profile));
+    let context_body = templates::strip_comment(templates::for_profile(stack.template));
     let context_created = write_if_absent(&context_path, &context_body, force)?;
     if context_created {
-        let label = match profile {
-            Profile::Generic => "CONTEXT.md".to_string(),
-            _ => format!(
-                "CONTEXT.md (profile: {})",
-                templates::profile_label(profile)
-            ),
-        };
-        created.push(label);
+        created.push(format!("CONTEXT.md (stack: {})", stack.label));
     } else {
         skipped.push("CONTEXT.md (already exists — pass --force to overwrite)".into());
     }
@@ -252,9 +235,28 @@ pub fn do_init(root: &Path, opts: InitOpts) -> Result<(), Box<dyn std::error::Er
     Ok(())
 }
 
-/// Pick a CONTEXT.md stack profile by sniffing the repo's manifests. Order
-/// matters: React Native repos also carry TypeScript, so check them first.
-fn detect_stack(root: &Path) -> Profile {
+/// A detected stack: a rich human label (`node (react)`, `python (django)`,
+/// `rust`) plus the lean CONTEXT.md template to scaffold (bespoke where we ship
+/// one, else the generic scaffold).
+struct Stack {
+    label: String,
+    template: Profile,
+}
+
+impl Stack {
+    fn new(label: impl Into<String>, template: Profile) -> Self {
+        Stack {
+            label: label.into(),
+            template,
+        }
+    }
+}
+
+/// Auto-detect the stack as runtime + framework by sniffing the repo's
+/// manifests. Order matters: most-specific runtime first (Rust/Node/Python/Go),
+/// and within Node, mobile and framework wrappers (React Native, Next, Nuxt)
+/// before the bare runtime.
+fn detect_stack(root: &Path) -> Stack {
     let exists = |name: &str| root.join(name).exists();
     let read = |name: &str| {
         fs::read_to_string(root.join(name))
@@ -262,30 +264,82 @@ fn detect_stack(root: &Path) -> Profile {
             .to_ascii_lowercase()
     };
 
+    if exists("Cargo.toml") {
+        if read("Cargo.toml").contains("tauri") {
+            return Stack::new("rust (tauri desktop)", Profile::Rust);
+        }
+        return Stack::new("rust", Profile::Rust);
+    }
+
     let pkg = read("package.json");
-    if pkg.contains("\"react-native\"") || pkg.contains("\"expo\"") {
-        return Profile::ReactNative;
+    if exists("package.json") {
+        if pkg.contains("\"react-native\"") || pkg.contains("\"expo\"") {
+            return Stack::new("react native", Profile::ReactNative);
+        }
+        if pkg.contains("\"electron\"") {
+            return Stack::new("node (electron desktop)", Profile::Generic);
+        }
+        // Frameworks, most-specific first (Next wraps React, Nuxt wraps Vue).
+        let frontend = if pkg.contains("\"next\"") {
+            Some("next.js")
+        } else if pkg.contains("\"nuxt\"") {
+            Some("nuxt")
+        } else if pkg.contains("\"@angular/core\"") {
+            Some("angular")
+        } else if pkg.contains("\"svelte\"") {
+            Some("svelte")
+        } else if pkg.contains("\"vue\"") {
+            Some("vue")
+        } else if pkg.contains("\"react\"") {
+            Some("react")
+        } else {
+            None
+        };
+        if let Some(fw) = frontend {
+            return Stack::new(format!("node ({fw})"), Profile::Generic);
+        }
+        let api = [
+            "express", "fastify", "@nestjs", "koa", "graphql", "apollo", "hapi",
+        ];
+        if api.iter().any(|f| pkg.contains(f)) {
+            return Stack::new("node (api)", Profile::TypescriptApi);
+        }
+        return Stack::new("node", Profile::Generic);
     }
-    let ts_api = [
-        "express", "fastify", "@nestjs", "koa", "graphql", "apollo", "hapi",
-    ];
-    if (exists("tsconfig.json") || pkg.contains("\"typescript\""))
-        && ts_api.iter().any(|f| pkg.contains(f))
+
+    if exists("pyproject.toml")
+        || exists("requirements.txt")
+        || exists("Pipfile")
+        || exists("setup.py")
     {
-        return Profile::TypescriptApi;
+        let py = read("pyproject.toml")
+            + &read("requirements.txt")
+            + &read("Pipfile")
+            + &read("setup.py");
+        if py.contains("fastapi") {
+            return Stack::new("python (fastapi)", Profile::PythonFastapi);
+        }
+        if py.contains("django") {
+            return Stack::new("python (django)", Profile::Generic);
+        }
+        if py.contains("flask") {
+            return Stack::new("python (flask)", Profile::Generic);
+        }
+        return Stack::new("python", Profile::Generic);
     }
-    if read("pyproject.toml").contains("fastapi") || read("requirements.txt").contains("fastapi") {
-        return Profile::PythonFastapi;
+
+    if exists("go.mod") {
+        return Stack::new("go", Profile::Generic);
     }
-    if exists("Cargo.toml") && (read("Cargo.toml").contains("[[bin]]") || exists("src/main.rs")) {
-        return Profile::RustCli;
+
+    if !root_has_manifest(root) {
+        let ecos = monorepo_ecosystems(root);
+        if ecos.len() >= 2 {
+            return Stack::new(format!("monorepo ({})", ecos.join(", ")), Profile::Monorepo);
+        }
     }
-    // No single root stack. A bare root whose subpackages carry manifests across
-    // ≥2 ecosystems is a polyglot monorepo, not a featureless "generic" repo.
-    if !root_has_manifest(root) && monorepo_ecosystems(root).len() >= 2 {
-        return Profile::Monorepo;
-    }
-    Profile::Generic
+
+    Stack::new("generic", Profile::Generic)
 }
 
 /// Any root-level manifest means the repo has its own stack (one package), so it
@@ -522,50 +576,95 @@ mod tests {
     #[test]
     fn detect_stack_empty_is_generic() {
         let d = tempfile::tempdir().unwrap();
-        assert!(matches!(detect_stack(d.path()), Profile::Generic));
+        let s = detect_stack(d.path());
+        assert!(matches!(s.template, Profile::Generic));
+        assert_eq!(s.label, "generic");
     }
 
     #[test]
-    fn detect_stack_rust_cli() {
+    fn detect_stack_rust_and_tauri() {
         let d = tempfile::tempdir().unwrap();
-        fs::write(
-            d.path().join("Cargo.toml"),
-            "[package]\nname = \"x\"\n[[bin]]\nname = \"x\"",
-        )
-        .unwrap();
-        assert!(matches!(detect_stack(d.path()), Profile::RustCli));
-    }
-
-    #[test]
-    fn detect_stack_react_native_wins_over_ts_api() {
-        let d = tempfile::tempdir().unwrap();
-        // RN repo that also carries express + typescript — RN must win.
-        fs::write(
-            d.path().join("package.json"),
-            r#"{"dependencies":{"react-native":"0.74","express":"4","typescript":"5"}}"#,
-        )
-        .unwrap();
-        fs::write(d.path().join("tsconfig.json"), "{}").unwrap();
-        assert!(matches!(detect_stack(d.path()), Profile::ReactNative));
-    }
-
-    #[test]
-    fn detect_stack_ts_api_and_fastapi() {
-        let d = tempfile::tempdir().unwrap();
-        fs::write(
-            d.path().join("package.json"),
-            r#"{"devDependencies":{"typescript":"5"},"dependencies":{"fastify":"4"}}"#,
-        )
-        .unwrap();
-        assert!(matches!(detect_stack(d.path()), Profile::TypescriptApi));
+        fs::write(d.path().join("Cargo.toml"), "[package]\nname = \"x\"").unwrap();
+        let s = detect_stack(d.path());
+        assert!(matches!(s.template, Profile::Rust));
+        assert_eq!(s.label, "rust");
 
         let d2 = tempfile::tempdir().unwrap();
         fs::write(
-            d2.path().join("requirements.txt"),
-            "fastapi==0.110\nuvicorn",
+            d2.path().join("Cargo.toml"),
+            "[dependencies]\ntauri = \"2\"",
         )
         .unwrap();
-        assert!(matches!(detect_stack(d2.path()), Profile::PythonFastapi));
+        assert_eq!(detect_stack(d2.path()).label, "rust (tauri desktop)");
+    }
+
+    #[test]
+    fn detect_stack_react_native_wins_over_frameworks() {
+        let d = tempfile::tempdir().unwrap();
+        // RN repo that also carries react + express — RN must win.
+        fs::write(
+            d.path().join("package.json"),
+            r#"{"dependencies":{"react-native":"0.74","react":"18","express":"4"}}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            detect_stack(d.path()).template,
+            Profile::ReactNative
+        ));
+    }
+
+    #[test]
+    fn detect_stack_node_frameworks() {
+        for (deps, want) in [
+            (r#"{"dependencies":{"react":"18"}}"#, "node (react)"),
+            (r#"{"dependencies":{"vue":"3"}}"#, "node (vue)"),
+            (
+                r#"{"dependencies":{"next":"14","react":"18"}}"#,
+                "node (next.js)",
+            ),
+            (r#"{"dependencies":{"express":"4"}}"#, "node (api)"),
+            (r#"{"dependencies":{"lodash":"4"}}"#, "node"),
+        ] {
+            let d = tempfile::tempdir().unwrap();
+            fs::write(d.path().join("package.json"), deps).unwrap();
+            assert_eq!(detect_stack(d.path()).label, want, "deps={deps}");
+        }
+        // A backend API maps to the bespoke TypeScript-API template.
+        let d = tempfile::tempdir().unwrap();
+        fs::write(
+            d.path().join("package.json"),
+            r#"{"dependencies":{"fastify":"4"}}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            detect_stack(d.path()).template,
+            Profile::TypescriptApi
+        ));
+    }
+
+    #[test]
+    fn detect_stack_python_frameworks() {
+        for (req, want, fastapi) in [
+            ("fastapi==0.110\nuvicorn", "python (fastapi)", true),
+            ("django==5.0", "python (django)", false),
+            ("flask==3", "python (flask)", false),
+            ("requests==2", "python", false),
+        ] {
+            let d = tempfile::tempdir().unwrap();
+            fs::write(d.path().join("requirements.txt"), req).unwrap();
+            let s = detect_stack(d.path());
+            assert_eq!(s.label, want);
+            assert_eq!(matches!(s.template, Profile::PythonFastapi), fastapi);
+        }
+    }
+
+    #[test]
+    fn detect_stack_go() {
+        let d = tempfile::tempdir().unwrap();
+        fs::write(d.path().join("go.mod"), "module x\n\ngo 1.22").unwrap();
+        let s = detect_stack(d.path());
+        assert_eq!(s.label, "go");
+        assert!(matches!(s.template, Profile::Generic));
     }
 
     #[test]
@@ -591,9 +690,9 @@ mod tests {
                 .output()
                 .unwrap();
         }
-        assert!(matches!(detect_stack(root), Profile::Monorepo));
-        let langs = monorepo_ecosystems(root);
-        assert_eq!(langs, vec!["go", "javascript", "python"]);
+        let s = detect_stack(root);
+        assert!(matches!(s.template, Profile::Monorepo));
+        assert_eq!(s.label, "monorepo (go, javascript, python)");
     }
 
     #[test]
@@ -611,6 +710,6 @@ mod tests {
                 .output()
                 .unwrap();
         }
-        assert!(matches!(detect_stack(root), Profile::Generic));
+        assert!(matches!(detect_stack(root).template, Profile::Generic));
     }
 }

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -34,6 +34,8 @@ pub enum Profile {
     PythonFastapi,
     /// Rust command-line tool.
     RustCli,
+    /// Polyglot monorepo — no single root stack; manifests live per-package.
+    Monorepo,
 }
 
 /// Which parts of a Mastermind setup `uninstall` should remove.

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -16,11 +16,10 @@ use mmcg::store::Store;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-/// CONTEXT.md profile variants. Adding a new profile:
-///   1. Add a file under `templates/profiles/`.
-///   2. Add a const in `templates.rs`.
-///   3. Add an arm in `templates::for_profile` and `templates::profile_label`.
-///   4. Add a variant here.
+/// CONTEXT.md template variants (the lean set we ship). `detect_stack` produces
+/// the rich runtime+framework label; this picks which template to scaffold.
+/// Adding one: add a file under `templates/profiles/`, a const in `templates.rs`,
+/// an arm in `templates::for_profile`, and a variant here.
 #[derive(Copy, Clone, Debug, ValueEnum)]
 #[clap(rename_all = "kebab-case")]
 pub enum Profile {
@@ -32,8 +31,8 @@ pub enum Profile {
     ReactNative,
     /// Python FastAPI async API service.
     PythonFastapi,
-    /// Rust command-line tool.
-    RustCli,
+    /// Rust project (CLI, service, or library).
+    Rust,
     /// Polyglot monorepo — no single root stack; manifests live per-package.
     Monorepo,
 }

--- a/mcp/servers/mmcg/src/templates.rs
+++ b/mcp/servers/mmcg/src/templates.rs
@@ -13,7 +13,7 @@ pub const WORKFLOW_TEMPLATE: &str = include_str!("../templates/workflow.md");
 const PROFILE_TYPESCRIPT_API: &str = include_str!("../templates/profiles/typescript-api.md");
 const PROFILE_REACT_NATIVE: &str = include_str!("../templates/profiles/react-native.md");
 const PROFILE_PYTHON_FASTAPI: &str = include_str!("../templates/profiles/python-fastapi.md");
-const PROFILE_RUST_CLI: &str = include_str!("../templates/profiles/rust-cli.md");
+const PROFILE_RUST: &str = include_str!("../templates/profiles/rust.md");
 const PROFILE_MONOREPO: &str = include_str!("../templates/profiles/monorepo.md");
 
 /// Return the raw template text for a given profile.
@@ -23,20 +23,8 @@ pub fn for_profile(profile: crate::Profile) -> &'static str {
         crate::Profile::TypescriptApi => PROFILE_TYPESCRIPT_API,
         crate::Profile::ReactNative => PROFILE_REACT_NATIVE,
         crate::Profile::PythonFastapi => PROFILE_PYTHON_FASTAPI,
-        crate::Profile::RustCli => PROFILE_RUST_CLI,
+        crate::Profile::Rust => PROFILE_RUST,
         crate::Profile::Monorepo => PROFILE_MONOREPO,
-    }
-}
-
-/// Return the kebab-case label for a profile (used in user-facing messages).
-pub fn profile_label(profile: crate::Profile) -> &'static str {
-    match profile {
-        crate::Profile::Generic => "generic",
-        crate::Profile::TypescriptApi => "typescript-api",
-        crate::Profile::ReactNative => "react-native",
-        crate::Profile::PythonFastapi => "python-fastapi",
-        crate::Profile::RustCli => "rust-cli",
-        crate::Profile::Monorepo => "monorepo",
     }
 }
 

--- a/mcp/servers/mmcg/src/templates.rs
+++ b/mcp/servers/mmcg/src/templates.rs
@@ -14,6 +14,7 @@ const PROFILE_TYPESCRIPT_API: &str = include_str!("../templates/profiles/typescr
 const PROFILE_REACT_NATIVE: &str = include_str!("../templates/profiles/react-native.md");
 const PROFILE_PYTHON_FASTAPI: &str = include_str!("../templates/profiles/python-fastapi.md");
 const PROFILE_RUST_CLI: &str = include_str!("../templates/profiles/rust-cli.md");
+const PROFILE_MONOREPO: &str = include_str!("../templates/profiles/monorepo.md");
 
 /// Return the raw template text for a given profile.
 pub fn for_profile(profile: crate::Profile) -> &'static str {
@@ -23,6 +24,7 @@ pub fn for_profile(profile: crate::Profile) -> &'static str {
         crate::Profile::ReactNative => PROFILE_REACT_NATIVE,
         crate::Profile::PythonFastapi => PROFILE_PYTHON_FASTAPI,
         crate::Profile::RustCli => PROFILE_RUST_CLI,
+        crate::Profile::Monorepo => PROFILE_MONOREPO,
     }
 }
 
@@ -34,6 +36,7 @@ pub fn profile_label(profile: crate::Profile) -> &'static str {
         crate::Profile::ReactNative => "react-native",
         crate::Profile::PythonFastapi => "python-fastapi",
         crate::Profile::RustCli => "rust-cli",
+        crate::Profile::Monorepo => "monorepo",
     }
 }
 

--- a/mcp/servers/mmcg/templates/profiles/monorepo.md
+++ b/mcp/servers/mmcg/templates/profiles/monorepo.md
@@ -1,0 +1,117 @@
+---
+name: mastermind-context-monorepo
+description: Project-level CONTEXT.md template — polyglot monorepo variant. For repos with no single root stack and many per-package manifests across several languages. Pre-seeded with the convention that each package owns its stack and the agent reads the nearest manifest / per-service CLAUDE.md rather than assuming one toolchain.
+metadata:
+  version: 0.1.0
+  authors:
+    - mastermind
+  tags:
+    - claude-md
+    - context
+    - profile
+    - monorepo
+    - polyglot
+---
+
+<!--
+  Polyglot monorepo profile — CONTEXT.md template for repos with many stacks.
+  Copy everything below the COPY FROM HERE marker to <project-root>/CONTEXT.md.
+  Replace <PLACEHOLDERS>. List the actual top-level packages and their stacks.
+-->
+
+<!-- ─── COPY FROM HERE ─── -->
+
+# <PROJECT_NAME> — Context (Polyglot monorepo)
+
+## Identity
+
+**What it is:** a polyglot monorepo — multiple independent stacks live in subpackages; the repo root has no single toolchain.
+
+**What it is not:** <e.g. "not a single deployable service", "not one language">
+
+**Primary users:** <teams owning each package; CI; release tooling>
+
+---
+
+## Stack conventions
+
+**There is no one stack — each package owns its own.** Don't assume a root toolchain.
+
+- **Detected languages:** <e.g. Python (services), TypeScript (web), Go (infra) — fill in from the actual tree>
+- **Where stacks live:** manifests are per-package, not at the root — e.g.
+  - `<services/*/pyproject.toml>` — Python services
+  - `<apps/*/package.json>` — TS/JS apps
+  - `<cmd/*/go.mod>` — Go binaries
+- **Read the nearest context first:** before touching a package, read the closest `CLAUDE.md` and the package's own manifest — they define the test/lint/build commands for *that* package. The root commands (if any) only orchestrate.
+- **Run commands scoped to the package**, never the whole repo: `pytest services/billing`, `npm test -w apps/web`, `go test ./cmd/sync/...`. A whole-repo build/test is a CI concern, not a per-change one.
+- **Cross-package changes:** a change that crosses a package boundary touches two stacks — verify each side with its own toolchain.
+
+---
+
+## Active goals
+
+- <Goal 1 — concrete and measurable; name the package(s) it touches>
+
+---
+
+## Decision log
+
+### <YYYY-MM-DD> — Monorepo boundaries
+
+- **Decision:** <how packages are split — by service, by language, by domain>
+- **Why:** <shared CI, atomic cross-cutting changes, single review surface, etc.>
+- **Alternatives rejected:**
+  - <polyrepo / separate repos>: <reason>
+
+---
+
+## Known gotchas
+
+*Pre-seeded with monorepo-canonical surprises. Prune anything that doesn't apply.*
+
+- **No single "install" / "test" / "build"** — each package has its own. A command that works in one package fails in another. Always scope to the package.
+- **The nearest manifest wins** — a tool reading the root finds nothing (or the wrong thing). Resolve config (tsconfig, pyproject, lockfile) from the package dir up, not from the root down.
+- **Cross-language boundaries are contracts, not calls** — packages in different languages talk over HTTP/gRPC/queues/generated types, not direct imports. Changing one side without the other breaks the contract silently.
+- **Shared lockfiles / workspaces** — if a workspace tool (pnpm/yarn workspaces, uv, cargo workspace) hoists deps, a version bump in one package can move another's resolved version. Check the workspace root lockfile.
+- **Generated code mirrors across packages** — protobufs / OpenAPI / schema types are generated into multiple packages; edit the source, regenerate, don't hand-edit the copies.
+
+---
+
+## Domain glossary
+
+- <term> — <local meaning specific to this codebase>
+
+---
+
+## External dependencies
+
+*Services / APIs / vendors this monorepo relies on. Note which package owns each.*
+
+- **<service>** — owned by `<package>` — <what we use it for> — auth: <env var `X`>
+
+---
+
+## Don't-touch list
+
+- **`<package>/<generated dir>`** — generated from <source>; regenerate, don't edit
+- **Workspace lockfiles** (`pnpm-lock.yaml`, `uv.lock`, `Cargo.lock`) — let the workspace tool update them
+- **`<vendored / mirrored path>`** — synced by tooling (e.g. Copybara); edit upstream, not here
+- **`<path>`** — <project-specific area with hidden constraints>
+
+---
+
+## How this file gets updated
+
+The planner (`mastermind-task-planning` skill) appends to this file during post-flight semantic review when work surfaces something worth preserving across sessions:
+
+| Discovery type | Section to update |
+|---|---|
+| Non-trivial design decision the critic agreed with | Decision log |
+| Workflow surprised by something — "almost broke X" | Known gotchas |
+| New term that took explaining during brainstorming | Domain glossary |
+| New external dependency added | External dependencies |
+| Code area found to have hidden constraints | Don't-touch list |
+
+The planner does NOT update this file silently. Every change is logged in the spec's Notes section so the audit trail is preserved.
+
+<!-- ─── COPY TO HERE ─── -->

--- a/mcp/servers/mmcg/templates/profiles/rust.md
+++ b/mcp/servers/mmcg/templates/profiles/rust.md
@@ -1,6 +1,6 @@
 ---
-name: mastermind-context-rust-cli
-description: Project-level CONTEXT.md template — Rust command-line tool variant. Pre-seeded with stack conventions (src/main.rs + src/lib.rs split, clap-style CLI, cargo test/clippy/fmt commands) and Rust-CLI-canonical gotchas (MSRV drift, stdout vs stderr, signal handling, panic-to-exit-code mapping).
+name: mastermind-context-rust
+description: Project-level CONTEXT.md template — Rust project variant (CLI, service, or library). Pre-seeded with stack conventions (src/main.rs + src/lib.rs split, cargo test/clippy/fmt commands) and Rust-canonical gotchas (MSRV drift, stdout vs stderr, signal handling, panic-to-exit-code mapping). Prune the CLI-specific bits if you're shipping a library or service.
 metadata:
   version: 0.1.0
   authors:
@@ -10,18 +10,17 @@ metadata:
     - context
     - profile
     - rust
-    - cli
 ---
 
 <!--
-  Rust CLI profile — opinionated CONTEXT.md template for command-line tools.
+  Rust profile — opinionated CONTEXT.md template for Rust projects (CLI, service, library).
   Copy everything below the COPY FROM HERE marker to <project-root>/CONTEXT.md.
   Replace <PLACEHOLDERS>. Confirm whether you're shipping a binary, a library, or both.
 -->
 
 <!-- ─── COPY FROM HERE ─── -->
 
-# <PROJECT_NAME> — Context (Rust CLI)
+# <PROJECT_NAME> — Context (Rust)
 
 ## Identity
 


### PR DESCRIPTION
Reworks `mastermind init` stack detection from a handful of narrow profiles into **runtime + detected framework**, and adds first-class polyglot-monorepo detection.

## Why
- `rust-cli` mislabelled Rust services and libraries as CLIs.
- No React, Vue, Django, Go, or Desktop — they all fell back to `generic`.
- A polyglot monorepo (bare root, manifests in subpackages) reported `generic`, which reads as a detection failure rather than a finding.

## What
`detect_stack` now returns a rich label plus the lean template to scaffold:

| Repo | Label | Template |
|---|---|---|
| `Cargo.toml` | `rust` / `rust (tauri desktop)` | rust |
| `package.json` + react/vue/next/… | `node (react)` / `node (vue)` / `node (next.js)` | generic |
| `package.json` + express/fastify/nest | `node (api)` | typescript-api |
| react-native / expo | `react native` | react-native |
| pyproject / requirements | `python (fastapi)` / `(django)` / `(flask)` / `python` | fastapi or generic |
| `go.mod` | `go` | generic |
| bare root + ≥2 ecosystems | `monorepo (go, python, …)` | monorepo |

The label is the rich part (`detect_stack`); the template set stays lean — bespoke where one already fits (TypeScript-API, FastAPI, React Native, Rust), the generic scaffold otherwise. A new monorepo CONTEXT.md template says each package owns its stack and points the agent at the nearest manifest / per-service CLAUDE.md.

`rust-cli` → `rust` (template `rust-cli.md` → `rust.md`, generalized). `profile_label` removed — the rich label comes from detection.

## Testing
8 `detect_stack` tests cover rust/tauri/react/vue/next/api/fastapi/django/flask/go/monorepo/generic. `cargo test` + `clippy -D warnings` + `fmt --check` + `scripts/validate.py` clean. Live-verified: canary → `monorepo (go, java, javascript, php, python)`.

Independent of #fix/init-index-report (disjoint regions of `init.rs`); both add a CHANGELOG `[Unreleased]` entry.
