### PR TITLE
feat(workflow): mastermind-style-deep skill for in-session profile synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `mastermind-style-deep` skill — writes the LLM-interpreted "Design patterns & tendencies" section of `~/.mastermind/style.md`: the structural signature (error handling, control flow, decomposition, tests, commit voice) the deterministic miner can't measure. The agent gathers quantified evidence and writes the prose in-session — no `claude -p` subprocess or separate auth, sidestepping the `--deep` flag's nested-CLI auth wall for interactive use.
+
 ## [0.35.0] - 2026-06-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `mastermind-style-deep` skill — writes the LLM-interpreted "Design patterns & tendencies" section of `~/.mastermind/style.md`: the structural signature (error handling, control flow, decomposition, tests, commit voice) the deterministic miner can't measure. The agent gathers quantified evidence and writes the prose in-session — no `claude -p` subprocess or separate auth, sidestepping the `--deep` flag's nested-CLI auth wall for interactive use.
+- `mastermind-style-deep` skill — writes the LLM-interpreted "Design patterns & tendencies" section of `~/.mastermind/style.md`: the structural signature (error handling, control flow, decomposition, tests, commit voice) the deterministic miner can't measure. The agent gathers quantified evidence and writes the prose in-session — no `claude -p` subprocess or separate auth, sidestepping the `--deep` flag's nested-CLI auth wall for interactive use. Surfaced in `mastermind init`'s next-steps, and the planner flags it when `style.md` carries only formatter-level rules.
 
 ## [0.35.0] - 2026-06-27
 

--- a/mcp/servers/mmcg/src/commands/init.rs
+++ b/mcp/servers/mmcg/src/commands/init.rs
@@ -247,6 +247,9 @@ pub fn do_init(root: &Path, opts: InitOpts) -> Result<(), Box<dyn std::error::Er
     } else {
         println!("  4. Fill CLAUDE.md's <PLACEHOLDER> sections (--no-claude skipped auto-fill).");
     }
+    println!(
+        "  5. (Optional) richer \"write like me\" profile: run /mastermind-style-deep in Claude Code"
+    );
     if let Some(prompt) = context_fill_prompt {
         println!(
             "\nScaffold files were left as templates. To fill them, paste this into Claude Code:\n\n  {prompt}"

--- a/skills/workflow/mastermind-style-deep/SKILL.md
+++ b/skills/workflow/mastermind-style-deep/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: mastermind-style-deep
+description: Write the LLM-interpreted "Design patterns & tendencies" section of the author's ~/.mastermind/style.md — the structural signature (error handling, control flow, decomposition, tests, commit voice) that the deterministic miner can't measure. Use when the user wants a richer "write like me" profile, says "deep style", "design patterns", or notices `mastermind miner profile` only produced formatter-level rules.
+metadata:
+  version: 0.1.0
+  authors:
+    - mastermind
+  tags:
+    - workflow
+    - style
+    - miner
+---
+
+# Mastermind — deep style synthesis
+
+`mastermind miner profile` measures only lexical idioms (indentation, quotes, braces, line length) — exactly what a formatter already normalizes, so it's near-zero signal for "write like me". The valuable part — how the author *structures* code — is semantic and needs a model. That's this skill's job: the binary gathers evidence, **you** (the agent, with a working model already) write the prose. No `claude -p` subprocess, no separate auth.
+
+## When to use
+
+- The user wants a real "write like me" profile, not the formatter-config rules.
+- After `mastermind miner profile` — to add the section the deterministic core can't.
+- The user says "deep style", "design patterns", "make the profile richer".
+
+## Steps
+
+1. **Refresh the deterministic rules.** Run `mastermind miner profile` in the target repo (add `--force` only to reset the cross-repo store first). This writes the measured rules into `~/.mastermind/style.md`. Note the resolved author it reports (`enriched as <author>`).
+
+2. **Gather evidence — quantified, not eyeballed.** Sample the author's contribution and *count* structural signals with patterns appropriate to the repo's language(s). For a Rust repo that's `grep -c` over the tree for `?`, `Box<dyn …Error>`, `.unwrap()`/`.expect()`, `let … else`, early `return`, iterator chains, `#[test]`, `///`; for TS/JS it's `try/catch`, `?.`, `.then` vs `await`, `.map/.filter`, `describe/it`, JSDoc; adapt. Also pull commit subjects: `git log --author="$(git config user.name)" --no-merges --pretty=%s -100`. Every claim you make must point to a number.
+
+3. **Write the section** titled exactly `## Design patterns & tendencies (interpreted)`. Cover only what the evidence supports, across: error handling, control flow (early-return vs nesting), decomposition (function size, public surface, helper naming), comment/doc habits, test structure, and commit voice.
+
+4. **Inject it into `~/.mastermind/style.md`.** The section lives in the managed block (between `<!-- mastermind-style:managed:start -->` and `:managed:end`), right before the `\n---\nThe planner reads this …` footer. If a `## Design patterns & tendencies (interpreted)` section is already there, replace it; otherwise insert before the footer.
+
+## Hard rules for the section
+
+- **Ground every claim in a concrete tell with the count.** `Propagates errors with \`?\` (436 sites) …`, not `handles errors well`.
+- **Be falsifiable and specific.** No generic praise — `clean`, `readable`, `best practices`, `well-structured` are banned.
+- **At most 8 bullets.** Each: the tendency, then the concrete tell.
+- A tendency the repo's formatter/linter already enforces does **not** belong here — that's a measured rule, not a structural signature.
+
+## Caveat — managed block is regenerated
+
+This section sits in the managed block, so a plain `mastermind miner profile` re-mine overwrites it. This skill is how it gets regenerated — re-run it after a re-mine, or move the section into the manual block above if the author wants it pinned.
+
+## Example bullet
+
+```
+- **Guard-clause early returns over nested `if`.** 177 early `return`s and 43 `let … else {`
+  (`let Some(x) = … else { return }`) — the unhappy path exits at the top, the happy path
+  stays unindented.
+```

--- a/skills/workflow/mastermind-task-planning/SKILL.md
+++ b/skills/workflow/mastermind-task-planning/SKILL.md
@@ -108,6 +108,7 @@ If `~/.mastermind/style.md` exists, read it before drafting code. It's the user-
 - Write every `CHANGE TO` block in that style, and fold the load-bearing rules into the spec's **Rules (global)** so the executor (which applies blocks verbatim) and the auditor both see the same constraints.
 - Precedence: the repo's own tooling (formatter, linter) and surrounding-file convention win; an explicit task instruction wins over both. The profile only decides what the code and tooling leave open — never override a project convention to match it.
 - Absent file → skip this. Do not invent style rules.
+- The deep `## Design patterns & tendencies` section carries structural signal (error handling, decomposition, tests) the measured rules can't. If `style.md` exists but lacks it — or carries only formatter-level rules (braces, quotes, indentation) — surface that to the user: `/mastermind-style-deep` writes it from their git history. Suggest it; don't auto-run it mid-plan.
 
 ### Ambiguous requirements — verbalize, don't pick silently
 


### PR DESCRIPTION
## Why
`mastermind miner profile` measures only lexical idioms — indentation, quotes, braces, line length — which is exactly what a formatter already normalizes, so it's near-zero signal for "write like me". The valuable part — how the author *structures* code (error handling, early-return vs nesting, decomposition, tests, commit voice) — is semantic and needs a model.

The `--deep` flag tried to get that by spawning `claude -p` as a subprocess, which hits an auth wall (headless `claude -p` can't authenticate without an API key / a Pro-Max gate). Wrong layer: the binary duplicates auth the agent already has.

## What
`mastermind-style-deep` moves the synthesis to the agent layer. The binary gathers deterministic evidence; the agent (already running a model) writes the prose. No `claude -p`, no separate auth.

The skill instructs the agent to:
1. refresh the measured rules (`mastermind miner profile`),
2. quantify structural signals with patterns appropriate to the repo's language (`?`, `let … else`, iterator chains, `#[test]`, `///`, commit subjects — adapt per language),
3. write a `## Design patterns & tendencies (interpreted)` section under hard guardrails (ground every claim in a count, ≤8 bullets, falsifiable, no generic praise),
4. inject it into the managed block of `~/.mastermind/style.md`.

Discoverability — it's a main-agent, on-demand skill, so it's surfaced where the profile is created and used:
- `mastermind init` next-steps suggests `/mastermind-style-deep`;
- the planner flags it when `style.md` carries only formatter-level rules.

## Testing
`python scripts/validate.py` clean (20 artifacts); `cargo test` / `clippy` / `fmt --check` clean. Demonstrated live on the mmcg crate — the produced section is grounded in real counts (e.g. "Propagates errors with `?` (436 sites) and `Box<dyn std::error::Error>` (30)…"), not generic prose.
