### PR TITLE
fix(npm): bundle auto-discovers skills (ships style-deep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- 0.36.0 shipped without the `mastermind-style-deep` skill in the default install — it was missing from the `stage-npm-share.sh` bundle allowlist, so `mastermind install` never copied it to `~/.claude/skills/`. The bundle now auto-discovers every skill under `skills/` instead of a hand-maintained allowlist (`extras/` stays excluded as a separate tree), so the skill ships and future skills can't be forgotten.
+
 ## [0.36.0] - 2026-06-27
 
 ### Added

--- a/scripts/stage-npm-share.sh
+++ b/scripts/stage-npm-share.sh
@@ -19,30 +19,18 @@ mkdir -p "$SHARE/agents" "$SHARE/skills"
 # Subagents — flat `.md` files.
 cp "$REPO_ROOT"/agents/subagents/*.md "$SHARE/agents/"
 
-# Core skills — explicit allowlist. Add here only skills that belong in the
-# default install (intake → plan → execute → audit loop).
-CORE_SKILLS=(
-  skills/workflow/mastermind-task-planning
-  skills/workflow/mastermind-task-executor
-  skills/workflow/mastermind-codegraph-research
-  skills/workflow/mastermind-structured-report-contract
-  skills/workflow/mastermind-critical-review
-  skills/prompt-engineering/mastermind-prompt-refiner
-  skills/debugging/mastermind-investigation-ledger
-  skills/security/mastermind-agent-security-review
-  skills/coding/no-ai-slop-comments
-)
-
-for skill_dir in "${CORE_SKILLS[@]}"; do
-  src="$REPO_ROOT/$skill_dir"
-  name="$(basename "$skill_dir")"
-  if [ ! -d "$src" ]; then
-    echo "ERROR: core skill not found: $src" >&2
-    exit 1
-  fi
-  cp -R "$src" "$SHARE/skills/$name"
-done
+# Core skills — every skill under `skills/` ships in the default install. Non-core
+# artifacts live in `extras/` (a separate tree), which this never scans, so adding
+# a skill under `skills/` ships it automatically — no allowlist to forget.
+while IFS= read -r skill_md; do
+  src="$(dirname "$skill_md")"
+  cp -R "$src" "$SHARE/skills/$(basename "$src")"
+done < <(find "$REPO_ROOT/skills" -name SKILL.md | sort)
 
 agents_n=$(find "$SHARE/agents" -name '*.md' | wc -l | tr -d ' ')
 skills_n=$(find "$SHARE/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+if [ "$agents_n" -eq 0 ] || [ "$skills_n" -eq 0 ]; then
+  echo "ERROR: staged $agents_n subagents + $skills_n skills — discovery found nothing" >&2
+  exit 1
+fi
 echo "staged $agents_n subagents + $skills_n skills → npm/mastermind/share/"


### PR DESCRIPTION
0.36.0 shipped the `mastermind-style-deep` skill in the repo but **not** in the default install: `stage-npm-share.sh` staged the bundle from a hand-maintained `CORE_SKILLS` allowlist, and the new skill was never added to it — so `mastermind install` never copied it to `~/.claude/skills/`, and `/mastermind-style-deep` was "Unknown command".

## Fix
Replace the allowlist with auto-discovery: stage every skill under `skills/` (each `*/SKILL.md`). `extras/` is a separate tree and is never scanned, so the core/non-core split is preserved — but adding a skill under `skills/` now ships it automatically, with no list to forget. A zero-found guard fails the stage if discovery turns up nothing.

## Testing
`bash scripts/stage-npm-share.sh` → `staged 7 subagents + 10 skills` (the previous 9 + `mastermind-style-deep`), identical set to the old allowlist plus the new skill. No behavior change for the existing skills.
