### PR TITLE
feat(workflow): mastermind-style-deep writes a developer portrait, not count-bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `mastermind-style-deep` now writes a grounded developer *portrait* — design approach, code shape, comments, tests, optimization habits, what the author pays attention to, and commit voice — organized by dimension, instead of a flat list of grepped counts. It gathers qualitative evidence (reads real files, checks enforcing lint/fmt config to drop tool-forced traits, counts each preference against its alternative), so the section reads like a description of how the person works rather than a lint report.
+
 ## [0.36.1] - 2026-06-27
 
 ### Fixed

--- a/skills/workflow/mastermind-style-deep/SKILL.md
+++ b/skills/workflow/mastermind-style-deep/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: mastermind-style-deep
-description: Write the LLM-interpreted "Design patterns & tendencies" section of the author's ~/.mastermind/style.md — the structural signature (error handling, control flow, decomposition, tests, commit voice) that the deterministic miner can't measure. Use when the user wants a richer "write like me" profile, says "deep style", "design patterns", or notices `mastermind miner profile` only produced formatter-level rules.
+description: Write a grounded portrait of how the author actually develops — design approach, code shape, comments, tests, optimization habits, what they pay attention to, and commit voice — into the "Design patterns & tendencies" section of ~/.mastermind/style.md. The structural signature the deterministic miner can't measure. Use when the user wants a real "write like me" profile, says "deep style", "design patterns", "qualitative profile", or notices `mastermind miner profile` only produced formatter-level rules.
 metadata:
-  version: 0.1.0
+  version: 0.2.0
   authors:
     - mastermind
   tags:
@@ -11,41 +11,54 @@ metadata:
     - miner
 ---
 
-# Mastermind — deep style synthesis
+# Mastermind — deep style portrait
 
-`mastermind miner profile` measures only lexical idioms (indentation, quotes, braces, line length) — exactly what a formatter already normalizes, so it's near-zero signal for "write like me". The valuable part — how the author *structures* code — is semantic and needs a model. That's this skill's job: the binary gathers evidence, **you** (the agent, with a working model already) write the prose. No `claude -p` subprocess, no separate auth.
+`mastermind miner profile` measures only lexical idioms (indentation, quotes, braces, line length) — what a formatter already normalizes, so it's near-zero signal for "write like me". This skill writes the part that matters: a grounded **portrait of how the author develops**. The binary gathers evidence; you (the agent, already running a model) read code and write the portrait. No `claude -p`, no separate auth.
 
 ## When to use
 
-- The user wants a real "write like me" profile, not the formatter-config rules.
-- After `mastermind miner profile` — to add the section the deterministic core can't.
-- The user says "deep style", "design patterns", "make the profile richer".
+- The user wants a real "write like me" profile, not formatter-config rules.
+- The user says "deep style", "design patterns", "qualitative profile", "make it richer".
+- After `mastermind miner profile`, to add the section the deterministic core can't.
 
-## Steps
+## What you're producing
 
-1. **Refresh the deterministic rules.** Run `mastermind miner profile` in the target repo (add `--force` only to reset the cross-repo store first). This writes the measured rules into `~/.mastermind/style.md`. Note the resolved author it reports (`enriched as <author>`).
+A portrait of **how this person works** — the kind a senior writes after reading someone's PRs for a month. Organized by the dimensions below, every claim tied to a concrete tell. Prose per dimension, not a list of isolated counts — the measured static rules already live in the section above this one.
 
-2. **Gather evidence — quantified, not eyeballed.** Sample the author's contribution and *count* structural signals with patterns appropriate to the repo's language(s). For a Rust repo that's `grep -c` over the tree for `?`, `Box<dyn …Error>`, `.unwrap()`/`.expect()`, `let … else`, early `return`, iterator chains, `#[test]`, `///`; for TS/JS it's `try/catch`, `?.`, `.then` vs `await`, `.map/.filter`, `describe/it`, JSDoc; adapt. Also pull commit subjects: `git log --author="$(git config user.name)" --no-merges --pretty=%s -100`. Every claim you make must point to a number.
+## Gather evidence — quantitative AND qualitative
 
-3. **Write the section** titled exactly `## Design patterns & tendencies (interpreted)`. Cover only what the evidence supports, across: error handling, control flow (early-return vs nesting), decomposition (function size, public surface, helper naming), comment/doc habits, test structure, and commit voice.
+Don't just grep. A portrait needs both numbers and read code:
 
-4. **Inject it into `~/.mastermind/style.md`.** The section lives in the managed block (between `<!-- mastermind-style:managed:start -->` and `:managed:end`), right before the `\n---\nThe planner reads this …` footer. If a `## Design patterns & tendencies (interpreted)` section is already there, replace it; otherwise insert before the footer.
+1. **Counts with their contrast.** Any "prefers X over Y" needs BOTH counted — early-`return`/`let-else` vs nesting depth; iterator chains vs `for` loops; typed errors vs `Box<dyn Error>`; table-driven tests vs one-assertion-per-fn. A bare count of X is not evidence of a preference.
+2. **Read 4–6 real files.** A core module (design), a hot path (optimization), a public API (ergonomics), a test file (test style), a recent diff. Greps can't see *why* or *what they watch for* — reading can.
+3. **Commits.** `git log --author="$(git config user.name)" --no-merges --pretty=%s -100` for voice and granularity; open a few bodies.
+4. **Enforcing config FIRST.** `rustfmt.toml` / `.eslintrc` / `pyproject` lint config, `#![deny(...)]` / `#![warn(...)]`, `clippy.toml`, CI lint steps. Anything a formatter or linter *forces* is not personal style — exclude it, or mark it "enforced". Do not credit a `///` on every fn as a habit if `#![deny(missing_docs)]` mandates it.
+5. **Optimization signals.** Benchmarks (`criterion` / `#[bench]` / `*.bench.*`), `#[inline]`, `with_capacity`, caching/memoization, `tracing`/profiling spans, comments mentioning perf. Their presence — or absence — tells you whether they optimize and whether it's measured or by feel.
+6. **Observability & safety signals.** Logging/tracing/metrics density, assertions, input validation, `#[must_use]`, where error boundaries sit.
 
-## Hard rules for the section
+## Dimensions (cover only where evidence supports; omit the rest)
 
-- **Ground every claim in a concrete tell with the count.** `Propagates errors with \`?\` (436 sites) …`, not `handles errors well`.
-- **Be falsifiable and specific.** No generic praise — `clean`, `readable`, `best practices`, `well-structured` are banned.
-- **At most 8 bullets.** Each: the tendency, then the concrete tell.
-- A tendency the repo's formatter/linter already enforces does **not** belong here — that's a measured rule, not a structural signature.
+- **Design & problem-solving** — what they reach for: error-handling philosophy, how they decompose, concurrency/ownership model, abstraction level, state management.
+- **Code shape & organization** — module/file/function layout, granularity, naming tendencies. Exclude anything the formatter enforces.
+- **Comments** — do they write them *at all*? Where, and what kind — why-comments, doc contracts, or none? Is the density lint-forced?
+- **Tests** — parametrized/table-driven or one-off per case? Unit vs integration? Assert-heavy vs property-based? What do they actually cover — happy path, edges, error paths?
+- **Optimization & performance** — do they optimize? Premature, or measured (benchmarks/profiling present)? What — allocations, hot paths, caching? Or do they trade perf for clarity?
+- **What they pay attention to** — the throughline. Where the care and ceremony cluster: correctness, type-safety, error boundaries, observability, API ergonomics, backward-compat, security. Infer it; name it.
+- **Commits** — voice (terse/verbose, imperative, conventional/ticket/bare), granularity (one concern or bundled), subject vs body.
+
+## Hard rules
+
+- **Ground every claim in a tell** — a count or a named example. `Optimizes only after measuring (3 criterion benches; no #[inline] in the hot loop)`, not `cares about performance`.
+- **Count the contrast.** "X over Y" needs both numbers.
+- **Exclude tool-enforced traits.** Check fmt/lint config first; a forced trait is a measured rule, not a signature.
+- **Negative space is signal.** What they *don't* do — no property tests, no premature optimization, sparse comments — belongs in the portrait.
+- **No generic praise.** `clean`, `readable`, `idiomatic`, `well-structured`, `best practices` — banned. If you can't tie it to a tell, cut it.
+- **Write it as a portrait** — a short grounded paragraph per dimension, not isolated bullets. It should read like a description of a person, not a lint report.
+
+## Inject into `~/.mastermind/style.md`
+
+The portrait is the `## Design patterns & tendencies (interpreted)` section in the managed block, right before the `\n---\nThe planner reads this …` footer. Replace it if present; otherwise insert before the footer.
 
 ## Caveat — managed block is regenerated
 
-This section sits in the managed block, so a plain `mastermind miner profile` re-mine overwrites it. This skill is how it gets regenerated — re-run it after a re-mine, or move the section into the manual block above if the author wants it pinned.
-
-## Example bullet
-
-```
-- **Guard-clause early returns over nested `if`.** 177 early `return`s and 43 `let … else {`
-  (`let Some(x) = … else { return }`) — the unhappy path exits at the top, the happy path
-  stays unindented.
-```
+This section lives in the managed block, so a plain `mastermind miner profile` re-mine overwrites it. This skill is how it gets rewritten — re-run it after a re-mine, or move the section into the manual block above to pin it.


### PR DESCRIPTION
Rewrites the `mastermind-style-deep` skill from a flat list of grepped counts into a grounded **developer portrait**.

## Why
The first version produced 8 isolated count-bullets — useful, but it (a) asserted preferences like "iterators over loops" without counting the alternative, and (b) credited things a linter forces (e.g. `///` on every fn under `#![deny(missing_docs)]`) as personal signature. It read like a lint report, not a description of a person.

## What
The skill now instructs the agent to write a portrait organized by the dimensions of how someone actually develops: **design & problem-solving, code shape, comments (do they write them at all?), tests (parametrized or one-off?), optimization (measured or not?), what they pay attention to, and commit voice.** Prose per dimension, every claim tied to a tell.

New guards, all addressing real gaps:
- **Count the contrast** — "X over Y" needs both numbers (e.g. `904 iterator calls vs 185 for-loops`).
- **Check enforcing config first** — `rustfmt.toml` / `#![deny(missing_docs)]` / `clippy.toml` / CI lint steps; a tool-forced trait is a measured rule, not a signature, and is excluded.
- **Read 4–6 real files**, not just grep — design/optimization/ergonomics intent isn't visible in counts.
- **Negative space is signal** — "no property tests", "doesn't micro-optimize" belong in the portrait.

## Testing
`python scripts/validate.py` clean (20 artifacts). Demonstrated on the mmcg crate — the portrait correctly distinguished personal habits (heavy doc-comments, no `missing_docs` lint) from enforced ones (clippy `-D warnings` in CI), and grounded every dimension in counts.
