### PR TITLE
feat(mmcg): add optional SCIP semantic overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `mastermind enrich --scip index.scip` adds an optional compiler-resolved
+  semantic layer without replacing the default Tree-sitter graph. SCIP
+  definitions, references, implementations, and type definitions are stored in
+  separate additive tables, exposed through CLI/MCP, and shown in Lens with
+  explicit high-confidence provenance and stale-file suppression. Import is
+  streamed and rejects semantic evidence that cannot be bound to the indexed
+  repository.
 - `mastermind ui --since <ref>` serves Mastermind Lens: an offline, loopback-only,
   read-only diff-first review UI backed by the existing bounded project-map and
   change-impact schemas. Checkpointed indexes open immutably; active WAL state is

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ mastermind doctor
 
 See [Getting started](docs/getting-started.md) for global vs per-repository state, project-local installation, and client-specific setup.
 
+The fast local Tree-sitter graph is always the default. Repositories that
+already produce a [SCIP](https://github.com/scip-code/scip) index can add
+compiler-resolved definitions, references, implementations, and type
+definitions without replacing that graph:
+
+```bash
+mastermind enrich --scip index.scip
+mastermind query semantic "scip-clang . my-package . PaymentService#charge()."
+```
+
+SCIP facts live in separate SQLite tables with `provenance=scip` and
+`confidence=high`. Lens prefers an exact SCIP symbol/file pair over matching
+Tree-sitter evidence, keeps runtime traces as `observed`, and falls back to the
+syntactic graph when the overlay is absent or stale. Imports are bound to the
+indexed repository through SCIP `project_root` or exact embedded document text.
+
 ## Core workflows
 
 ### Map a project
@@ -105,7 +121,8 @@ monorepo review.
 Lens evidence overlays correlate the returned static trace with SARIF findings,
 LCOV/Cobertura line coverage, JUnit results, explicit OpenTelemetry code paths,
 CODEOWNERS, bounded Git churn/contributors, and exact changed-file mentions in
-indexed specs, ADRs, audits, lessons, and context.
+indexed specs, ADRs, audits, lessons, and context. An imported SCIP overlay is
+loaded automatically and decorates only exact symbol/file endpoint matches.
 The graph topology stays unchanged: overlays add source-labelled marks and
 inspector facts rather than an opaque risk score. Lens auto-discovers
 `.github/CODEOWNERS`, `CODEOWNERS`, or `docs/CODEOWNERS`; use `--codeowners` to
@@ -182,7 +199,7 @@ re-mining preserves.
 
 ### Query the graph from an agent
 
-The MCP server exposes 24 bounded tools for symbol search, callers/callees,
+The MCP server exposes 25 bounded tools for symbol search, callers/callees,
 imports, architecture maps, change impact, test impact, cycles, API surface, and
 project history. The same engine is available through the CLI.
 

--- a/docs/integrations/generic-mcp.md
+++ b/docs/integrations/generic-mcp.md
@@ -9,7 +9,7 @@
 | transport | stdio |
 | command | `mastermind serve` |
 | protocol | MCP 2025-11-25; legacy 2024-11-05 |
-| tools | 24: 23 read-only, 1 additive local write (see below) |
+| tools | 25: 24 read-only, 1 additive local write (see below) |
 | resources | none |
 | prompts | none |
 
@@ -67,7 +67,7 @@ The `--index` flag is global and must come before `serve`.
   `mmcg_symbols_in_file`.
 - Relationships and architecture: `mmcg_callers`, `mmcg_callees`,
   `mmcg_imports`, `mmcg_imported_by`, `mmcg_impact`, `mmcg_api_surface`,
-  `mmcg_centrality`, `mmcg_dependency_cycles`, `mmcg_unreferenced`, `mmcg_map`.
+  `mmcg_centrality`, `mmcg_dependency_cycles`, `mmcg_unreferenced`, `mmcg_semantic`, `mmcg_map`.
 - Change analysis: `mmcg_symbols_changed_since`, `mmcg_change_class`,
   `mmcg_change_impact`, `mmcg_test_impact`, `mmcg_recent_changes`.
 - Workflow state: `mmcg_tasks`, `mmcg_history`, `mmcg_status`, `mmcg_scratchpad_read`, and the

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -2,7 +2,7 @@
 
 This is the exhaustive technical reference for the mmcg engine. For the shortest path to a working installation, start with [Getting started](../getting-started.md); for the product overview, return to the [Mastermind README](../../README.md).
 
-A small Rust binary that builds a structural index of a codebase (Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, C/C++). It serves the graph over **MCP** (23 read-only tools plus one additive local scratchpad write), but MCP is only one surface. The same binary provides spec gates (`verify-spec` / `audit-spec`), project setup (`init` / `doctor`), and the user-global style miner.
+A small Rust binary that builds a structural index of a codebase (Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, C/C++). It serves the graph over **MCP** (24 read-only tools plus one additive local scratchpad write), but MCP is only one surface. The same binary provides spec gates (`verify-spec` / `audit-spec`), project setup (`init` / `doctor`), and the user-global style miner.
 
 > Installed via npm (`@xcraftmind/mastermind`)? The command is **`mastermind`** — the same binary. The `mmcg` name used throughout this doc is the cargo-installed alias (`cargo install mmcg`).
 
@@ -69,7 +69,7 @@ The Mastermind workflow needs structural queries every few seconds (planner deci
 
 mmcg is intentionally narrow:
 - Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++ — extend by adding a parser, not by depending on multi-language toolchains
-- 24 MCP tools: 23 read-only structural tools plus `mmcg_scratchpad_append`, which makes an additive write to the gitignored local index
+- 25 MCP tools: 24 read-only structural/semantic tools plus `mmcg_scratchpad_append`, which makes an additive write to the gitignored local index
 
 ## Performance model
 
@@ -108,6 +108,10 @@ mmcg index ~/code/my-project
 
 # Force full re-index — re-parses everything regardless of mtime
 mmcg index --force
+
+# Optionally add compiler-resolved SCIP evidence without replacing the graph.
+mmcg enrich --scip index.scip
+mmcg query semantic "scip-clang . my-package . PaymentService#charge()." --top 100
 
 # Watch a directory and re-index on file changes (long-running, also incremental)
 mmcg watch
@@ -257,6 +261,46 @@ When to use `--force`:
 
 The index lives at `.mastermind/mmcg.db` in the current directory by default. Override with `--index <path>` or env var `MMCG_INDEX_PATH`.
 
+## Optional SCIP semantic overlay
+
+Tree-sitter remains the default graph: it is local, incremental, portable, and
+does not require every language toolchain. `mmcg enrich --scip index.scip`
+decodes the standard SCIP protobuf and atomically replaces only a separate set
+of `semantic_*` tables. It never rewrites `symbols`, `edges`, files, history,
+or scratchpad data. A failed import leaves the previous overlay intact.
+
+The importer accepts typed SCIP ranges and the deprecated packed range form,
+validates canonical repository-relative document paths, rejects paths and
+symlinks that escape the indexed root, and bounds the artifact at 512 MiB,
+documents at 500,000, occurrences at 10 million, definitions at 2 million,
+symbol-information records at 2 million, and semantic edges at 5 million. It
+streams top-level protobuf fields in bounded passes instead of retaining the
+full SCIP index and all embedded source text in memory. Source files are hashed at
+import. The reported `project_root` must resolve to the indexed repository; a
+portable or moved artifact is accepted only when every `Document.text` exactly
+matches its current file. Successful sources expose `repository_verified`.
+When some text is omitted, repository identity is still verified but the result
+carries `semantic_artifact_revision_unverified`. Later file changes suppress
+affected semantic facts as stale rather than silently mixing revisions.
+
+SCIP occurrence references become `reference` or `import` evidence; explicit
+SCIP relationships remain `implementation`, `type_definition`, `definition`,
+or `reference`. These are not relabelled as calls because SCIP occurrences do
+not prove that every reference is a call. The resolution contract is explicit:
+
+- Tree-sitter topology is the default and the no-SCIP fallback;
+- an exact matching SCIP symbol/file endpoint is the preferred static source,
+  with `provenance=scip` and `confidence=high`;
+- a Tree-sitter-only edge stays `syntactic` / medium confidence;
+- OpenTelemetry remains observed runtime corroboration and never creates
+  topology.
+
+Use `mmcg query semantic SYMBOL` or the read-only `mmcg_semantic` MCP tool to
+inspect definitions and relationships directly. Lens loads a valid imported
+overlay automatically, shows its producer and precision diagnostics, and only
+decorates exact returned endpoint and display-name pairs. `mmcg map`, callers,
+impact, and all existing tools continue to work unchanged without SCIP.
+
 ## Mastermind Lens (`mmcg ui`)
 
 Lens is a browser review surface for one baseline-to-working-tree change. It
@@ -300,6 +344,8 @@ evidence:
   `docs/CODEOWNERS` in that order, with `--codeowners PATH` as an override;
 - bounded Git churn and contributor names from the last 200 commits by default,
   configurable with `--git-commits 0..1000` (`0` disables Git history).
+- the repository's persisted SCIP overlay, when present and fresh. It is not a
+  UI flag or report path; import it first with `mmcg enrich --scip index.scip`.
 
 Evidence is matched only to files already returned by the bounded change,
 impact, and candidate-test trace. The versioned `evidence` response includes
@@ -327,7 +373,9 @@ uses the base-branch file. Git history is pinned to the impact snapshot's HEAD
 and does not follow renames.
 
 The UI renders redundant text and visual marks for SARIF, coverage, JUnit,
-runtime spans, project knowledge, ownership, and churn. Runtime parent-child
+SCIP, runtime spans, project knowledge, ownership, and churn. Exact SCIP
+symbol/file endpoint pairs supersede Tree-sitter as static provenance without
+changing the returned graph. Runtime parent-child
 file pairs may decorate an already returned static edge in either direction,
 but they never create a node or edge. Overlay switches change emphasis and
 inspector detail only; they do not add or remove codegraph topology. Imported
@@ -416,6 +464,7 @@ Run `mmcg watch` in a separate terminal so the index stays current while you wor
 | `mmcg_unreferenced` | optional `kind`, `language` | Symbols that no edge references. Dead-code candidates. **Review manually** — see Limitations for false-positive scenarios. |
 | `mmcg_api_surface` | `prefix`, optional `language` | Symbols under `prefix` referenced from at least one file OUTSIDE `prefix`. Empirical "who-uses-this-module" map; doesn't need declared visibility. |
 | `mmcg_centrality` | optional `prefix`, `language`, `kind`, `top` (default 20) | Rank symbols by in-degree (distinct callers). Pre-flight "where is the gravity" — top hits are the structural attractors of the codebase or a subdirectory. Use to learn what to read first on unfamiliar code. Excludes synthetic `<module>` rows and zero-degree symbols. |
+| `mmcg_semantic` | `symbol`, optional `top` (default 100, max 500) | Compiler-resolved SCIP definitions, references, implementations, type definitions, and explicit provenance. Returns `fallback_active: true` instead of an error when no overlay exists. Stale document facts are omitted with diagnostics. |
 | `mmcg_map` | optional `path` (default `.`), `depth` (1–6, default 2), `top` (1–100, default 20), `production_only` (default `false`) | Schema-v1 architecture briefing with lexical file/directory scope: `%` and `_` are literal bytes, selected-directory components are relative to that directory, root components remain repository-relative, and selected files retain their paths. `production_only` excludes conventional test/fixture/example/generated/vendor path segments and test filenames (`test_*`, `*_test.*`, `*.test.*`, `*.spec.*`, `*Test.*`, `*Tests.*`) before bounded queries run. Hotspots prefer unambiguous definitions before pooled same-name collisions. JSON, text, Mermaid, and CLI SARIF are projections of the same result; Mermaid includes component counts/languages, boundaries, hotspots, and cycle rings, while SARIF exports returned cycles as architecture findings. Caps are 50,000 aggregation paths, 20 languages, 20 components, 20 boundaries/component and 400 globally, 50 entry points, 100 hotspots, 50,000 scoped cycle edges, 50 cycles, and 500 cycle memberships. `path_work_limit` marks path-derived partial aggregates; `top_probe` marks a hotspot or per-component boundary cap+1 probe; `global_probe_limit` marks components whose certainty was prevented by the 401st global boundary row; cycle `work_limit` returns no cycles because SCC analysis was skipped before truncated edges could be analyzed. |
 | `mmcg_change_impact` | `since`, optional `root`, `depth` (1–5), `top` (1–500) | Stable schema-v1 analysis of the resolved baseline against staged, unstaged, and untracked content. Reports added/removed/signature/body-changed symbols, batched transitive callers, component crossings, ranked test candidates, a `disciplines` block routing the change to an evidence set, exact collection metadata, caps, and precision notes. Root, SHA-256 index freshness, Git snapshot, and SQLite snapshot checks fail closed with stable codes. |
 | `mmcg_test_impact` | `since`, optional `root`, `depth` (1–5), `top` (1–500) | Exact test-focused projection of `mmcg_change_impact`. Changed tests and depth-1 graph tests are direct, deeper graph tests are transitive, and scoped filename candidates are heuristic. Focused candidates never replace the repository's full required gate. |
@@ -534,7 +583,7 @@ subprocess never reaches it. The watchdog is what covers those paths.
 - **Ten language families.** Python (`.py`, `.pyi`), TS/TSX (`.ts`, `.tsx`), JS/JSX (`.js`, `.jsx`, `.mjs`, `.cjs`), Vue SFC (`.vue`), Rust (`.rs`), C# (`.cs`), Go (`.go`), Java (`.java`), PHP (`.php`, `.phtml`), C/C++ (`.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.hh`, `.hxx`, `.ipp`, `.tpp`). Extension matching is case-insensitive. Other extensions are skipped and appear in the bounded diagnostics sample.
 - **Call resolution is name-based, not type-based.** `obj.foo()` records a call to "foo" with literal path "obj.foo" — but `obj` isn't resolved to a type, so cross-file precision is best-effort.
 - **No cross-file symbol resolution.** Edges store `to_name` and `to_path` (strings), not `to_id`. Searching "callers of foo" finds *every* call to "foo" anywhere — even unrelated ones in different modules. The `to_path` column reduces ambiguity for imports specifically (use `mmcg_imported_by` with `match: path`).
-- **Path-based queries reflect literal source text, not semantic FQN.** When you index code with `use foo::bar::Baz` and `mmcg_imported_by --query "foo::bar::Baz" --match path` you'll get that file. But if another file imports the same type via `use crate::Baz` (re-exported), it stores `to_path = "crate::Baz"` and won't match the FQN query. Resolving paths to canonical FQNs would require parsing `Cargo.toml` / `package.json` / `pyproject.toml` and following re-exports — that's compiler-level work and out of scope. **Use `match: name` for "find all consumers"** (catches everything regardless of import phrasing); reserve `match: path` for "find this exact import spelling".
+- **Default path-based queries reflect literal source text, not semantic FQN.** When you index code with `use foo::bar::Baz` and `mmcg_imported_by --query "foo::bar::Baz" --match path` you'll get that file. But if another file imports the same type via `use crate::Baz` (re-exported), it stores `to_path = "crate::Baz"` and won't match the FQN query. **Use `match: name` for "find all syntactic consumers"**; reserve `match: path` for "find this exact import spelling". When the language's SCIP producer resolves the re-export, import its artifact and use `mmcg_semantic` for the compiler identity; this does not rewrite the literal Tree-sitter import edge.
 - **`to_type` for member-call detection uses a capital-letter heuristic in TS/JS/Python.** `Class.method()`, `JSON.parse()`, `Foo.bar.baz()` correctly emit `to_type = "Class"` / `"JSON"` / `"Foo"` (rightmost capitalized receiver). For Rust, `to_type` is unambiguous via the `scoped_identifier` AST node — no heuristic needed. The heuristic misses calls on uppercase-named variables (e.g. `const FOO = new Bar(); FOO.method()` won't emit `to_type=FOO`) but matches the common convention used in idiomatic JS/TS/Python code.
 - **JSX component usage is resolved by the uppercase-tag convention.** `<Button />` and `<Select.Option />` emit `calls` edges from the containing component; `<div>` and `<section>` do not, because a syntactic parser cannot otherwise tell a component from a host element. A component deliberately named in lowercase is invisible, and a capitalized host element in a custom renderer would be counted. `mmcg_callers` on a component therefore answers "who renders this", which is the frontend equivalent of "who calls this".
 - **Variable-declared functions are named after their binding.** `const Card = () => …`, `const Card = function () {…}`, and one level of wrapper call (`memo(…)`, `forwardRef(…)`, `styled(…)`) become `function` symbols named `Card`, with the inner parameters as the signature so a changed props contract still reports as `signature_changed`. Wrapper unwrapping stops at one level: `memo(forwardRef(() => …))` finds no inner function and produces no symbol. A non-function value that merely receives a callback (`const x = compute(() => 1)`) is captured as a function symbol — a known over-capture of the same heuristic.
@@ -547,7 +596,7 @@ subprocess never reaches it. The watchdog is what covers those paths.
 - **`mmcg_recent_changes` reflects index mtime, not git history.** If you re-index after rewriting history (rebase, amend, force-push) every touched file appears as "recent". Use `git log --since=...` for git truth; use this tool for "what has my watcher seen lately".
 - **C# partial classes** are stored as one symbol per file under an indexed namespace parent. `mmcg_search` collapses declarations only when name, kind, and namespace identity all match, returning a `locations` array; set `collapse_partials: false` to opt out. Legacy/malformed rows without namespace identity remain separate rather than risk merging unrelated types. `mmcg_callers` / `mmcg_callees` / `mmcg_impact` / `mmcg_outline` are unaffected: they resolve by name. Non-partial classes with colliding names across namespaces are *not* collapsed.
 - **Python module-level constants** (`MAX_RETRIES = 5`, `__all__ = [...]`, `HOST, PORT = ...`) are captured as `kind="constant"` since 0.14.0. Scoping is strict — only DIRECT children of the module node count; assignments inside `if` / `for` / `try` / class bodies / function bodies are not constants. `mmcg_unreferenced` **excludes constants by default** because the call/import graph doesn't track value-reads — every constant would otherwise appear as dead. Opt-in with `kind=constant` to surface unused constants explicitly. `mmcg_callers MAX_RETRIES` still works for the cases where a constant is referenced via `import` (`from foo import MAX_RETRIES` produces an `imports` edge) or attribute access (`foo.MAX_RETRIES` produces a `calls` edge to leaf `MAX_RETRIES`). Other languages: not extracted (TS/Rust/Go/etc. constants are typed declarations through different AST shapes — file a request if you need them).
-- **C/C++ is best-effort.** The C/C++ extractor uses tree-sitter alone — no preprocessor, no template instantiation, no semantic analysis. Concretely: (a) **macros are invisible** — `TEST(Suite, Name) { ... }` is seen as a call to `TEST`, not as a function definition, so gtest/Catch2 test bodies don't appear in `mmcg_search` and calls inside macro arguments may be lost; (b) **templates** record the template name but not instantiations (`vector<int>` doesn't create a `vector<int>` symbol); (c) **header/source split** produces two symbol rows (`void Foo::bar()` declared in `.h` and defined in `.cpp` = two `bar` hits); (d) **ADL/overload resolution** isn't performed (`swap(a, b)` records `swap` without knowing which namespace it resolves to); (e) **`#include` file resolution** tries exact repository-relative, source-relative, then deterministic suffix matches for map/cycle edges. It can over-approximate when several headers share a basename and it does not parse the included contents. For high-precision C++ structural analysis use `clangd` (semantic, slow, large) or `ctags` (similar tradeoffs to this extractor). mmcg uses one `tree-sitter-cpp` grammar for both `.c` and `.cpp` files — rare C-only code that uses C++ keywords as identifiers (e.g. a variable named `new`) may mis-parse.
+- **C/C++ Tree-sitter is best-effort.** The default C/C++ extractor has no preprocessor, template instantiation, or semantic analysis. Concretely: (a) **macros are invisible** — `TEST(Suite, Name) { ... }` is seen as a call to `TEST`, not as a function definition, so gtest/Catch2 test bodies don't appear in `mmcg_search` and calls inside macro arguments may be lost; (b) **templates** record the template name but not instantiations (`vector<int>` doesn't create a `vector<int>` symbol); (c) **header/source split** produces two symbol rows (`void Foo::bar()` declared in `.h` and defined in `.cpp` = two `bar` hits); (d) **ADL/overload resolution** isn't performed (`swap(a, b)` records `swap` without knowing which namespace it resolves to); (e) **`#include` file resolution** tries exact repository-relative, source-relative, then deterministic suffix matches for map/cycle edges. It can over-approximate when several headers share a basename and it does not parse the included contents. A `scip-clang` artifact imported through `mmcg enrich --scip` can add compiler-resolved identities and references, while the syntactic graph remains the fallback. mmcg uses one `tree-sitter-cpp` grammar for both `.c` and `.cpp` files — rare C-only code that uses C++ keywords as identifiers (e.g. a variable named `new`) may mis-parse.
 
 ## CI
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -7,4 +7,4 @@
 ### servers/
 | Server | Transport | Description |
 |---|---|---|
-| [`mmcg`](servers/mmcg/README.md) | stdio | Mastermind Codegraph — 24 MCP tools: 23 read-only structural tools plus one additive local scratchpad write, over a local SQLite index. Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Truth layer for the Mastermind workflow. |
+| [`mmcg`](servers/mmcg/README.md) | stdio | Mastermind Codegraph — 25 MCP tools: 24 read-only structural/semantic tools plus one additive local scratchpad write, over a local SQLite index. Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Truth layer for the Mastermind workflow. |

--- a/mcp/servers/mmcg/Cargo.lock
+++ b/mcp/servers/mmcg/Cargo.lock
@@ -606,9 +606,11 @@ dependencies = [
  "ignore",
  "libc",
  "notify",
+ "protobuf",
  "quick-xml",
  "rayon",
  "rusqlite",
+ "scip",
  "serde",
  "serde_json",
  "serde_norway",
@@ -692,6 +694,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,7 +771,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -788,7 +810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -847,6 +869,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scip"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26a72133c2d6fd45c9a3a343bcb3db2faa30f68f0919bfa3370ca85add5460c3"
+dependencies = [
+ "protobuf",
 ]
 
 [[package]]
@@ -1029,11 +1060,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/mcp/servers/mmcg/Cargo.toml
+++ b/mcp/servers/mmcg/Cargo.toml
@@ -58,6 +58,8 @@ notify = "8.2"
 # JSON for MCP protocol
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+scip = "=0.9.0"
+protobuf = "=3.7.2"
 quick-xml = "0.41"
 sha2 = "0.11"
 base64 = "0.23"

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -1,6 +1,6 @@
 ---
 name: mmcg
-description: Mastermind Codegraph — fast multi-language code indexer (Python + TypeScript/TSX + JavaScript/JSX + Vue SFC + Rust + C# + Go + Java + PHP + C/C++) exposed over MCP. Indexes symbols, calls, imports, and durable project history into a local SQLite database and exposes 24 bounded tools for AI coding agents.
+description: Mastermind Codegraph — fast multi-language code indexer (Python + TypeScript/TSX + JavaScript/JSX + Vue SFC + Rust + C# + Go + Java + PHP + C/C++) exposed over MCP. Indexes symbols, calls, imports, and durable project history into a local SQLite database and exposes 25 bounded tools for AI coding agents.
 metadata:
   version: 1.2.1
   authors:
@@ -59,6 +59,7 @@ SQLite and tree-sitter are bundled. No system SQLite or parser libraries are req
 ```bash
 cd your-project
 mmcg index .
+mmcg enrich --scip index.scip # optional compiler-resolved overlay
 mmcg status
 mmcg map .
 mmcg impact --since main
@@ -92,6 +93,7 @@ See the [client integration guides](https://github.com/xcrft/mastermind/tree/mai
 | Area | Examples |
 |---|---|
 | Symbol graph | Search, callers, callees, imports, outlines, API surface |
+| Semantic overlay | Optional SCIP definitions, references, implementations, and provenance |
 | Architecture | Project map, centrality, dependency cycles, unreferenced candidates |
 | Change analysis | Git-aware symbol changes, blast radius, component crossings |
 | Local review UI | Read-only diff-first Lens with bounded SARIF, coverage, JUnit, OTLP, project-knowledge, ownership, and churn overlays |
@@ -99,7 +101,7 @@ See the [client integration guides](https://github.com/xcrft/mastermind/tree/mai
 | Workflow gates | `verify-spec`, `audit-spec`, and `run-task` |
 | Local coordination | Bounded additive scratchpad and indexed project history |
 
-The MCP surface contains 23 read-only tools and one additive local scratchpad
+The MCP surface contains 24 read-only tools and one additive local scratchpad
 write. Results are bounded and return precision or truncation notes when the
 engine cannot prove completeness.
 
@@ -118,7 +120,7 @@ engine cannot prove completeness.
 
 ## Precision model
 
-mmcg is a syntactic graph, not a compiler or language server:
+The default mmcg graph is syntactic, not a compiler or language server:
 
 - Call resolution is primarily name-based rather than type-based.
 - Dynamic dispatch, reflection, generated code, and cross-language calls may be invisible.
@@ -128,6 +130,14 @@ mmcg is a syntactic graph, not a compiler or language server:
 - Dead-code and test-impact results are candidates to review, not deletion or test-skipping authorization.
 
 These trade-offs keep the index local, fast, portable, and easy for agents to query. The engine fails closed on stale index, root, Git snapshot, or work-limit conditions in change-impact workflows.
+
+`mmcg enrich --scip index.scip` is an optional second layer. It stores
+compiler-resolved facts separately, exposes them through `query semantic` and
+`mmcg_semantic`, and lets Lens prefer exact SCIP evidence while retaining the
+Tree-sitter topology and no-toolchain fallback. Embedded SCIP document text is
+verified when available; `project_root` must identify this repository unless
+every document embeds matching text. Later source changes suppress stale
+semantic facts.
 
 ## Reference
 

--- a/mcp/servers/mmcg/assets/lens/app.js
+++ b/mcp/servers/mmcg/assets/lens/app.js
@@ -10,7 +10,7 @@
   const CONNECTED_PER_LANE = 5;
   const MOBILE_CANDIDATES_PER_PAGE = 5;
   const MOBILE_CONNECTED_PER_LANE = 2;
-  const OVERLAY_KEYS = ["findings", "coverage", "ownership", "churn", "tests", "runtime", "knowledge"];
+  const OVERLAY_KEYS = ["findings", "coverage", "ownership", "churn", "tests", "semantic", "runtime", "knowledge"];
 
   const state = {
     raw: null,
@@ -109,6 +109,29 @@
 
   function symbolMatches(left, right) {
     return symbolIdentity(left) === symbolIdentity(right);
+  }
+
+  function semanticMatchesGraphEdge(value, edge) {
+    const semantic = record(value);
+    const fromFile = text(edge.from.symbol.file, "");
+    const toFile = text(edge.to.symbol.file, "");
+    const fromName = text(edge.from.symbol.name, "");
+    const toName = text(edge.to.symbol.name, "");
+    const semanticFromFile = text(semantic.from_file, "");
+    const semanticToFile = text(semantic.to_file, "");
+    const semanticFromName = text(semantic.from_display_name, "");
+    const semanticToName = text(semantic.to_display_name, "");
+    const semanticFromLine = finiteNumber(semantic.from_line);
+    const semanticToLine = finiteNumber(semantic.to_line);
+    const fromLine = finiteNumber(edge.from.symbol.line);
+    const toLine = finiteNumber(edge.to.symbol.line);
+    const direct = semanticFromFile === fromFile && semanticToFile === toFile
+      && semanticFromName === fromName && semanticToName === toName
+      && semanticFromLine === fromLine && semanticToLine === toLine;
+    const reverse = semanticFromFile === toFile && semanticToFile === fromFile
+      && semanticFromName === toName && semanticToName === fromName
+      && semanticFromLine === toLine && semanticToLine === fromLine;
+    return direct || reverse;
   }
 
   function shortOid(value) {
@@ -383,6 +406,7 @@
     const map = record(raw.map);
     const impact = record(raw.impact);
     const evidence = record(raw.evidence);
+    const semantic = record(raw.semantic);
     const changes = record(impact.changes);
 
     const files = collection(changes.files);
@@ -396,6 +420,7 @@
     const evidenceFiles = collection(evidence.files);
     const evidenceDiagnostics = collection(evidence.diagnostics);
     const runtimeEdges = collection(evidence.runtime_edges);
+    const semanticEdges = collection(semantic.edges);
     const evidenceByPath = new Map();
     evidenceFiles.items.map(normalizeFileEvidence).forEach(function (item) {
       if (item.path) {
@@ -516,6 +541,9 @@
         const child = text(runtimeEdge.child_file, "");
         return (parent === fromFile && child === toFile) || (parent === toFile && child === fromFile);
       });
+      edge.semanticEvidence = semanticEdges.items.map(record).filter(function (semanticEdge) {
+        return semanticMatchesGraphEdge(semanticEdge, edge);
+      });
     });
 
     const componentRows = buildComponentRows(
@@ -540,16 +568,18 @@
       apiCrossings: apiCrossings,
       mapComponents: mapComponents,
       evidence: evidence,
+      semantic: semantic,
       evidenceSources: evidenceSources,
       evidenceFiles: evidenceFiles,
       evidenceDiagnostics: evidenceDiagnostics,
       runtimeEdges: runtimeEdges,
+      semanticEdges: semanticEdges,
       evidenceByPath: evidenceByPath,
       nodes: nodes,
       edges: edges,
       components: componentRows,
-      precisionNotes: collectPrecisionNotes(map, impact, evidence),
-      truncations: collectTruncations(map, impact, evidence),
+      precisionNotes: collectPrecisionNotes(map, impact, evidence, semantic),
+      truncations: collectTruncations(map, impact, evidence, semantic),
       limits: collectLimits(raw, map, impact, evidence),
     };
   }
@@ -602,7 +632,7 @@
     });
   }
 
-  function collectPrecisionNotes(map, impact, evidence) {
+  function collectPrecisionNotes(map, impact, evidence, semantic) {
     const notes = [];
     array(map.precision_notes).forEach(function (value) {
       const note = record(value);
@@ -642,6 +672,14 @@
         source: "Evidence · " + text(diagnostic.source_id, "unknown source"),
       });
     });
+    array(semantic.diagnostics).forEach(function (value) {
+      const diagnostic = record(value);
+      notes.push({
+        code: text(diagnostic.code, "Semantic diagnostic"),
+        message: text(diagnostic.message, ""),
+        source: "Semantic · SCIP",
+      });
+    });
     const seen = new Set();
     return notes.filter(function (note) {
       const key = note.source + "|" + note.code + "|" + note.message;
@@ -653,7 +691,7 @@
     });
   }
 
-  function collectTruncations(map, impact, evidence) {
+  function collectTruncations(map, impact, evidence, semantic) {
     const results = [];
     const changes = record(impact.changes);
     const candidates = [
@@ -672,6 +710,8 @@
       ["Evidence files", evidence.files],
       ["Runtime evidence edges", evidence.runtime_edges],
       ["Evidence diagnostics", evidence.diagnostics],
+      ["SCIP semantic definitions", semantic.definitions],
+      ["SCIP semantic edges", semantic.edges],
     ];
     candidates.forEach(function (candidate) {
       const value = collection(candidate[1]);
@@ -1069,13 +1109,42 @@
   function renderEvidenceSources() {
     clearNode(elements.evidenceSourceList);
     const sources = state.model.evidenceSources.items.map(record);
-    const matchedFiles = returnedCount(state.model.evidenceFiles);
-    elements.evidenceSummary.textContent = sources.length === 0
+    const semantic = record(state.model.semantic);
+    const semanticSource = isRecord(semantic.source) ? record(semantic.source) : null;
+    const sourceCount = sources.length + (semanticSource ? 1 : 0);
+    const matchedPaths = new Set();
+    state.model.evidenceFiles.items.map(record).forEach(function (file) {
+      const path = text(file.path, "");
+      if (path) {
+        matchedPaths.add(path);
+      }
+    });
+    state.model.semanticEdges.items.map(record).forEach(function (edge) {
+      const from = text(edge.from_file, "");
+      const to = text(edge.to_file, "");
+      if (from) {
+        matchedPaths.add(from);
+      }
+      if (to) {
+        matchedPaths.add(to);
+      }
+    });
+    const matchedFiles = matchedPaths.size;
+    elements.evidenceSummary.textContent = sourceCount === 0
       ? "No external evidence sources loaded; the static graph remains available."
-      : sources.length + " source" + (sources.length === 1 ? "" : "s") + " · " + matchedFiles + " matched trace file" + (matchedFiles === 1 ? "" : "s") + (record(state.model.evidence).partial === true ? " · partial" : "");
-    if (sources.length === 0) {
-      elements.evidenceSourceList.appendChild(createElement("p", "evidence-source-list__empty", "Pass --sarif, --coverage, --junit, --otel, --codeowners, or --git-commits to add corroborating facts."));
+      : sourceCount + " source" + (sourceCount === 1 ? "" : "s") + " · " + matchedFiles + " matched trace file" + (matchedFiles === 1 ? "" : "s") + ((record(state.model.evidence).partial === true || semantic.partial === true) ? " · partial" : "");
+    if (sourceCount === 0) {
+      elements.evidenceSourceList.appendChild(createElement("p", "evidence-source-list__empty", "Use mastermind enrich --scip index.scip or pass external evidence flags to add corroborating facts."));
       return;
+    }
+    if (semanticSource) {
+      const status = semantic.partial === true ? "partial" : "loaded";
+      const card = createElement("article", "evidence-source evidence-source--" + status);
+      card.appendChild(createElement("span", "evidence-source__kind", "scip · " + status));
+      card.appendChild(createElement("span", "evidence-source__label", text(semanticSource.tool_name, "SCIP producer") + (text(semanticSource.tool_version, "") ? " " + text(semanticSource.tool_version, "") : "")));
+      const identity = semanticSource.repository_verified === true ? "repository verified" : "repository unverified";
+      card.appendChild(createElement("span", "evidence-source__facts", displayNumber(finiteNumber(semanticSource.edges)) + " compiler-resolved edges · " + displayNumber(finiteNumber(semanticSource.documents)) + " documents · " + identity));
+      elements.evidenceSourceList.appendChild(card);
     }
     sources.forEach(function (source) {
       const status = text(source.status, "unknown");
@@ -2118,8 +2187,9 @@
     const boundary = edge.crossing ? ", boundary crossing" : "";
     const ownership = overlayEnabled("ownership") && edge.ownershipBoundary ? ", ownership boundary" : "";
     const runtime = overlayEnabled("runtime") && edge.runtimeEvidence.length > 0 ? ", runtime trace corroborated" : "";
+    const semantic = overlayEnabled("semantic") && edge.semanticEvidence.length > 0 ? ", SCIP compiler-resolved, high confidence" : ", Tree-sitter syntactic, medium confidence";
     return relation + " from " + text(edge.from.symbol.name, "unnamed seed")
-      + " to " + text(edge.to.symbol.name, "unnamed claim") + boundary + ownership + runtime + ". Select for details.";
+      + " to " + text(edge.to.symbol.name, "unnamed claim") + boundary + ownership + semantic + runtime + ". Select for details.";
   }
 
   function drawEdge(layer, edge, from, to, mobile, width) {
@@ -2142,6 +2212,9 @@
     }
     if (overlayEnabled("runtime") && edge.runtimeEvidence.length > 0) {
       classes.push("graph-edge--runtime");
+    }
+    if (overlayEnabled("semantic") && edge.semanticEvidence.length > 0) {
+      classes.push("graph-edge--semantic");
     }
     if (state.selectedId === edge.id) {
       classes.push("is-selected");
@@ -2625,7 +2698,8 @@
     appendClaimGrid([
       ["Relation", isTest ? "Changed seed → candidate test" : "Changed seed → impacted symbol"],
       ["Minimum depth", displayNumber(edge.minimumDepth)],
-      ["Precision", edge.precision.join(", ") || "Not returned"],
+      ["Precision", overlayEnabled("semantic") && edge.semanticEvidence.length > 0 ? "high" : (edge.precision.join(", ") || "medium")],
+      ["Static provenance", overlayEnabled("semantic") && edge.semanticEvidence.length > 0 ? "SCIP (preferred)" : "Tree-sitter (fallback)"],
       ["Evidence kind", edge.evidence ? text(edge.evidence.kind, "Not classified") : "Impact seed"],
       ["Name collisions", displayNumber(edge.collisionCount)],
       ["Boundary crossing", edge.crossing ? "Observed" : "Not returned"],
@@ -2669,12 +2743,31 @@
         "No matching runtime evidence returned."
       );
     }
+    if (overlayEnabled("semantic") && edge.semanticEvidence.length > 0) {
+      appendClaimList(
+        "Compiler-resolved semantic evidence",
+        edge.semanticEvidence.map(function (value) {
+          const semantic = record(value);
+          return text(semantic.kind, "reference") + " · "
+            + text(semantic.from_display_name, "file scope") + " · "
+            + text(semantic.from_file, "file unavailable") + formatLine(semantic.from_line)
+            + " → " + text(semantic.to_display_name, "symbol unavailable") + " · "
+            + text(semantic.to_file, "external symbol") + formatLine(semantic.to_line)
+            + " · reference at " + text(semantic.from_file, "file unavailable") + formatLine(semantic.occurrence_line)
+            + " · SCIP / high";
+        }),
+        "semantic",
+        "No matching SCIP edge returned."
+      );
+    }
     elements.inspector.appendChild(createElement(
       "p",
       "claim-note",
       isTest
         ? "This line exists only because the test evidence explicitly names the changed symbol as its seed."
-        : "This line exists only because the impacted symbol explicitly names the changed symbol in its seeds array."
+        : (overlayEnabled("semantic") && edge.semanticEvidence.length > 0
+          ? "SCIP is the preferred static provenance for this exact endpoint and symbol pair; Tree-sitter remains the fallback topology."
+          : "This line exists only because the impacted symbol explicitly names the changed symbol in its seeds array.")
     ));
   }
 

--- a/mcp/servers/mmcg/assets/lens/app.test.cjs
+++ b/mcp/servers/mmcg/assets/lens/app.test.cjs
@@ -212,7 +212,7 @@ function createDocument() {
     button.setAttribute("data-scope", scope);
     return button;
   });
-  const overlayButtons = ["findings", "coverage", "ownership", "churn", "tests", "runtime", "knowledge"].map((overlay) => {
+  const overlayButtons = ["findings", "coverage", "ownership", "churn", "tests", "semantic", "runtime", "knowledge"].map((overlay) => {
     const button = new MockElement("button");
     button.dataset.overlay = overlay;
     button.setAttribute("data-overlay", overlay);
@@ -259,6 +259,35 @@ function fixture() {
     schema_version: 1,
     repository: { name: "example", root_label: "." },
     options: { since: "main", path: ".", depth: 3, top: 100, production_only: false },
+    semantic: {
+      schema_version: 1,
+      available: true,
+      partial: false,
+      fallback_active: false,
+      source: {
+        format: "scip", tool_name: "rust-analyzer", tool_version: "test",
+        documents: 2, definitions: 2, edges: 1, text_verified_documents: 2,
+        repository_verified: true, revision_verified: true,
+      },
+      definitions: { total: 0, returned: 0, truncated: false, items: [] },
+      edges: {
+        total: 1,
+        returned: 1,
+        truncated: false,
+        items: [{
+          from_symbol: "rust-analyzer . example . authorize_target().",
+          from_display_name: "authorize_target",
+          from_file: "src/target.rs", from_line: 7, from_character: 4,
+          occurrence_line: 9, occurrence_character: 6,
+          to_symbol: "rust-analyzer . example . authorize().",
+          to_display_name: "authorize",
+          to_file: "src/auth.rs", to_line: 42, to_character: 4,
+          kind: "reference", provenance: "scip", confidence: "high",
+        }],
+      },
+      diagnostics: [],
+      resolution: { default_graph: "tree-sitter", static_precedence: ["scip", "tree-sitter"], runtime_confidence: "observed", fallback_without_scip: "tree-sitter" },
+    },
     evidence: {
       schema_version: 1,
       partial: false,
@@ -452,8 +481,9 @@ async function main() {
   );
 
   const harness = await renderFixture();
-  assert.match(harness.nodes.get("evidence-summary").textContent, /7 sources · 3 matched trace files/i);
-  assert.equal(harness.nodes.get("evidence-source-list").querySelectorAll(".evidence-source").length, 7);
+  assert.match(harness.nodes.get("evidence-summary").textContent, /8 sources · 3 matched trace files/i);
+  assert.equal(harness.nodes.get("evidence-source-list").querySelectorAll(".evidence-source").length, 8);
+  assert.match(harness.nodes.get("evidence-source-list").textContent, /repository verified/i);
   const changedCandidate = harness.nodes.get("mobile-trace-list").querySelectorAll(".mobile-candidate")[0];
   assert.ok(changedCandidate, "Changed claim with overlays must remain selectable on mobile");
   assert.equal(
@@ -471,6 +501,11 @@ async function main() {
     harness.nodes.get("trace-graph").querySelectorAll(".graph-edge--ownership").length,
     1,
     "A named owner to explicit no-owner transition must remain visible as an ownership boundary"
+  );
+  assert.equal(
+    harness.nodes.get("trace-graph").querySelectorAll(".graph-edge--semantic").length,
+    1,
+    "An exact SCIP symbol, file, and definition-line pair must upgrade static provenance"
   );
   const changedInspector = harness.nodes.get("inspector-body").textContent;
   assert.match(changedInspector, /SARIF findings · file-level/i);
@@ -507,8 +542,19 @@ async function main() {
   runtime.dispatch("click");
   const runtimeEdge = harness.nodes.get("trace-graph").querySelectorAll("[data-edge-id]")[0];
   runtimeEdge.dispatch("click");
+  assert.match(harness.nodes.get("inspector-body").textContent, /Static provenanceSCIP \(preferred\)/i);
+  assert.match(harness.nodes.get("inspector-body").textContent, /Compiler-resolved semantic evidence/i);
+  assert.match(harness.nodes.get("inspector-body").textContent, /reference at src\/target\.rs:9/i);
   assert.match(harness.nodes.get("inspector-body").textContent, /Runtime trace corroboration/i);
   assert.match(harness.nodes.get("inspector-body").textContent, /src\/auth\.rs → src\/target\.rs/i);
+  const semantic = harness.overlayButtons.find((button) => button.dataset.overlay === "semantic");
+  const semanticEdgeCount = harness.nodes.get("trace-graph").querySelectorAll("[data-edge-id]").length;
+  semantic.dispatch("click");
+  assert.equal(semantic.getAttribute("aria-pressed"), "false");
+  assert.equal(harness.nodes.get("trace-graph").querySelectorAll(".graph-edge--semantic").length, 0);
+  assert.equal(harness.nodes.get("trace-graph").querySelectorAll("[data-edge-id]").length, semanticEdgeCount);
+  assert.match(harness.nodes.get("inspector-body").textContent, /Static provenanceTree-sitter \(fallback\)/i);
+  semantic.dispatch("click");
   harness.nodes.get("fit-button").dispatch("click");
   const testsScope = harness.scopeButtons.find((button) => button.dataset.scope === "test");
   testsScope.dispatch("click");

--- a/mcp/servers/mmcg/assets/lens/index.html
+++ b/mcp/servers/mmcg/assets/lens/index.html
@@ -162,6 +162,7 @@
           <button type="button" data-overlay="ownership" aria-pressed="true" disabled>Ownership</button>
           <button type="button" data-overlay="churn" aria-pressed="true" disabled>Churn</button>
           <button type="button" data-overlay="tests" aria-pressed="true" disabled>JUnit</button>
+          <button type="button" data-overlay="semantic" aria-pressed="true" disabled>SCIP</button>
           <button type="button" data-overlay="runtime" aria-pressed="true" disabled>Runtime</button>
           <button type="button" data-overlay="knowledge" aria-pressed="true" disabled>Knowledge</button>
         </div>

--- a/mcp/servers/mmcg/assets/lens/styles.css
+++ b/mcp/servers/mmcg/assets/lens/styles.css
@@ -1198,6 +1198,11 @@ body.is-refreshing .refresh-button__glyph {
   stroke-width: 3;
 }
 
+.graph-edge--semantic {
+  stroke: var(--plum-dark);
+  stroke-width: 3;
+}
+
 .graph-edge--runtime {
   filter: drop-shadow(0 0 2px rgba(36, 82, 209, 0.7));
   stroke-width: 3.5;

--- a/mcp/servers/mmcg/src/commands/query.rs
+++ b/mcp/servers/mmcg/src/commands/query.rs
@@ -462,6 +462,9 @@ fn execute(store: &Store, q: QueryCmd) -> Result<Value, Box<dyn std::error::Erro
         QueryCmd::Explain { name, language } => {
             serde_json::to_value(queries::explain(store, &name, language.as_deref())?)?
         }
+        QueryCmd::Semantic { symbol, top } => {
+            serde_json::to_value(mmcg::scip_overlay::query(store, &symbol, top)?)?
+        }
     })
 }
 

--- a/mcp/servers/mmcg/src/lens.rs
+++ b/mcp/servers/mmcg/src/lens.rs
@@ -52,6 +52,7 @@ pub struct LensSnapshot {
     pub options: LensOptions,
     pub map: ProjectMapResponse,
     pub impact: ChangeImpactResponse,
+    pub semantic: crate::scip_overlay::SemanticOverlaySnapshot,
     pub evidence: crate::evidence::EvidenceSnapshot,
 }
 
@@ -350,6 +351,36 @@ fn build_snapshot_until(
         options.production_only,
     )
     .map_err(LensError::MapUnavailable)?;
+    let semantic_paths = impact
+        .changes
+        .files
+        .items
+        .iter()
+        .map(|item| item.path.clone())
+        .chain(
+            impact
+                .changes
+                .symbols
+                .items
+                .iter()
+                .map(|item| item.file.clone()),
+        )
+        .chain(
+            impact
+                .impact
+                .items
+                .iter()
+                .map(|item| item.symbol.file.clone()),
+        )
+        .chain(
+            impact
+                .tests
+                .items
+                .iter()
+                .map(|item| item.symbol.file.clone()),
+        );
+    let semantic = crate::scip_overlay::for_lens(store, &root, semantic_paths)
+        .unwrap_or_else(|_| crate::scip_overlay::unavailable_with_diagnostic());
     let evidence = crate::evidence::collect_with_store(
         &root,
         evidence_options,
@@ -373,6 +404,7 @@ fn build_snapshot_until(
         options: options.clone(),
         map,
         impact,
+        semantic,
         evidence,
     })
 }

--- a/mcp/servers/mmcg/src/lib.rs
+++ b/mcp/servers/mmcg/src/lib.rs
@@ -25,6 +25,7 @@ pub mod miner;
 pub mod queries;
 pub mod run_task;
 pub mod sarif_export;
+pub mod scip_overlay;
 pub mod setup;
 pub mod spec;
 pub mod store;

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -4,6 +4,7 @@
 //!   mastermind init           — scaffold a project, build the index, draft CONTEXT.md
 //!   mastermind setup claude   — register the codegraph with Claude Code (MCP)
 //!   mastermind index [PATH]   — build or refresh the index
+//!   mastermind enrich --scip  — add optional compiler-resolved evidence
 //!   mastermind ui --since REF — open the local diff-first Lens UI
 //!   mastermind serve          — run as MCP stdio server
 //!   mastermind doctor         — health-check the setup
@@ -105,6 +106,13 @@ enum Cmd {
         /// Re-parse every file regardless of mtime. Use after schema changes or to recover from a stale index.
         #[arg(long)]
         force: bool,
+    },
+    /// Add an optional compiler-resolved semantic overlay to the existing
+    /// Tree-sitter codegraph. Replaces only the previous SCIP overlay.
+    Enrich {
+        /// SCIP protobuf index produced by a language-specific SCIP indexer.
+        #[arg(long, value_name = "PATH")]
+        scip: PathBuf,
     },
     /// Build a compact deterministic architecture briefing from the codegraph.
     Map {
@@ -699,6 +707,13 @@ enum QueryCmd {
         #[arg(long)]
         language: Option<String>,
     },
+    /// Inspect compiler-resolved SCIP definitions and references. An empty
+    /// result with fallback_active=true means the Tree-sitter-only mode is active.
+    Semantic {
+        symbol: String,
+        #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u32).range(1..=500))]
+        top: u32,
+    },
 }
 
 #[derive(Subcommand)]
@@ -863,6 +878,18 @@ fn run_cli_inner(
             if stats.extractor_contract_rebuilt {
                 eprintln!("extractor contract changed: rebuilt all structural data");
             }
+        }
+        Cmd::Enrich { scip } => {
+            if !index_path.is_file() {
+                return Err(format!(
+                    "codegraph index {} does not exist; run `mastermind index .` first",
+                    index_path.display()
+                )
+                .into());
+            }
+            let store = Store::open(&index_path)?;
+            let summary = mmcg::scip_overlay::import(&store, &scip)?;
+            println!("{}", serde_json::to_string_pretty(&summary)?);
         }
         Cmd::Map {
             path,
@@ -1329,6 +1356,37 @@ mod tests {
             index_path_for_root(Some(std::path::Path::new("custom/index.db")), root),
             PathBuf::from("custom/index.db")
         );
+    }
+
+    #[test]
+    fn enrich_and_semantic_query_cli_contracts_are_explicit() {
+        let enrich = Cli::try_parse_from([
+            "mastermind",
+            "--index",
+            "graph.db",
+            "enrich",
+            "--scip",
+            "index.scip",
+        ])
+        .unwrap();
+        assert!(
+            matches!(enrich.cmd, Cmd::Enrich { scip } if scip == std::path::Path::new("index.scip"))
+        );
+
+        let query = Cli::try_parse_from([
+            "mastermind",
+            "query",
+            "semantic",
+            "scip-clang . demo . target().",
+            "--top",
+            "25",
+        ])
+        .unwrap();
+        assert!(matches!(
+            query.cmd,
+            Cmd::Query(QueryCmd::Semantic { symbol, top })
+                if symbol == "scip-clang . demo . target()." && top == 25
+        ));
     }
 
     fn claude_setup_args(argv: &[&str]) -> SetupArgs {

--- a/mcp/servers/mmcg/src/mcp.rs
+++ b/mcp/servers/mmcg/src/mcp.rs
@@ -217,6 +217,7 @@ static TOOLS: &[ToolDef] = &[
     read_only_tool("mmcg_tasks", schema_tasks, handle_tasks),
     read_only_tool("mmcg_history", schema_history, handle_history),
     read_only_tool("mmcg_centrality", schema_centrality, handle_centrality),
+    read_only_tool("mmcg_semantic", schema_semantic, handle_semantic),
     read_only_tool("mmcg_map", schema_map, handle_map),
     read_only_tool(
         "mmcg_change_impact",
@@ -1376,6 +1377,21 @@ fn schema_map() -> Value {
     })
 }
 
+fn schema_semantic() -> Value {
+    json!({
+        "name": "mmcg_semantic",
+        "description": "Inspect optional compiler-resolved SCIP definitions, references, implementations, and type-definition relationships. Results carry provenance=scip and confidence=high. If no SCIP overlay was imported, fallback_active=true and the normal Tree-sitter graph remains available. Import or replace the overlay explicitly with `mastermind enrich --scip index.scip`.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "symbol": { "type": "string", "minLength": 1, "maxLength": 16384, "description": "SCIP symbol string or literal display-name fragment" },
+                "top": { "type": "integer", "minimum": 1, "maximum": 500, "default": 100 }
+            },
+            "required": ["symbol"]
+        }
+    })
+}
+
 fn impact_input_schema(name: &str, description: &str) -> Value {
     json!({
         "name": name,
@@ -1687,6 +1703,27 @@ fn handle_map(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
                 }
                 _ => HandlerError::internal("project_map_query", error),
             })?;
+    serde_json::to_value(result)
+        .map_err(|error| HandlerError::internal("serialize_response", error))
+}
+
+fn handle_semantic(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
+    let symbol = str_arg(args, "symbol")?;
+    if symbol.trim().is_empty() || symbol.len() > 16 * 1024 {
+        return Err(HandlerError::InvalidArguments(
+            "Invalid argument: symbol".into(),
+        ));
+    }
+    let top = match args.get("top") {
+        None => 100,
+        Some(value) => value
+            .as_u64()
+            .filter(|value| (1..=500).contains(value))
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or_else(|| HandlerError::InvalidArguments("Invalid argument: top".into()))?,
+    };
+    let result = crate::scip_overlay::query(store, symbol, top)
+        .map_err(|error| HandlerError::internal("semantic_query", error))?;
     serde_json::to_value(result)
         .map_err(|error| HandlerError::internal("serialize_response", error))
 }
@@ -2400,7 +2437,7 @@ mod tests {
     #[test]
     fn tool_annotations_match_behavior_table() {
         let legacy = tools_list(ProtocolVersion::Legacy);
-        assert_eq!(legacy["tools"].as_array().unwrap().len(), 24);
+        assert_eq!(legacy["tools"].as_array().unwrap().len(), 25);
         assert!(legacy["tools"]
             .as_array()
             .unwrap()
@@ -2409,7 +2446,7 @@ mod tests {
 
         let current = tools_list(ProtocolVersion::Current);
         let tools = current["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 24);
+        assert_eq!(tools.len(), 25);
         let mut readers = 0;
         for tool in tools {
             let annotations = &tool["annotations"];
@@ -2428,7 +2465,30 @@ mod tests {
                 readers += 1;
             }
         }
-        assert_eq!(readers, 23);
+        assert_eq!(readers, 24);
+    }
+
+    #[test]
+    fn semantic_tool_keeps_no_overlay_as_a_read_only_fallback() {
+        let path =
+            std::env::temp_dir().join(format!("mmcg-mcp-semantic-fallback-{}", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let mut store = Store::open(&path).unwrap();
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({
+                "name": "mmcg_semantic",
+                "arguments": { "symbol": "target", "top": 10 }
+            }),
+        )
+        .unwrap();
+        assert_eq!(result["isError"], false);
+        let payload = unwrap_content(&result);
+        assert_eq!(payload["available"], false);
+        assert_eq!(payload["fallback_active"], true);
+        assert_eq!(payload["resolution"]["default_graph"], "tree-sitter");
+        std::fs::remove_file(path).ok();
     }
 
     #[test]
@@ -2999,7 +3059,7 @@ mod tests {
     #[test]
     fn tools_list_covers_every_handler() {
         let listed: Vec<&str> = TOOLS.iter().map(|t| t.name).collect();
-        assert_eq!(listed.len(), 24, "expected 24 tools, got {}", listed.len());
+        assert_eq!(listed.len(), 25, "expected 25 tools, got {}", listed.len());
         for name in &listed {
             assert!(
                 TOOLS.iter().any(|t| &t.name == name),

--- a/mcp/servers/mmcg/src/scip_overlay.rs
+++ b/mcp/servers/mmcg/src/scip_overlay.rs
@@ -1621,6 +1621,15 @@ mod tests {
         info
     }
 
+    fn local_file_uri(path: &Path) -> String {
+        let normalized = path.to_string_lossy().replace('\\', "/");
+        if normalized.starts_with('/') {
+            format!("file://{normalized}")
+        } else {
+            format!("file:///{normalized}")
+        }
+    }
+
     fn fixture() -> (TempDir, Store, PathBuf) {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("repo");
@@ -1660,7 +1669,7 @@ mod tests {
 
         let mut index = Index::new();
         index.metadata = MessageField::some(Metadata {
-            project_root: format!("file://{}", root.display()),
+            project_root: local_file_uri(&root),
             tool_info: MessageField::some(ToolInfo {
                 name: "scip-clang".into(),
                 version: "test".into(),
@@ -1738,7 +1747,7 @@ mod tests {
         }
         let foreign = temp.path().join("foreign-repo");
         std::fs::create_dir(&foreign).unwrap();
-        index.metadata.as_mut().unwrap().project_root = format!("file://{}", foreign.display());
+        index.metadata.as_mut().unwrap().project_root = local_file_uri(&foreign);
         scip::write_message_to_file(&path, index).unwrap();
 
         let error = import(&store, &path).unwrap_err().to_string();

--- a/mcp/servers/mmcg/src/scip_overlay.rs
+++ b/mcp/servers/mmcg/src/scip_overlay.rs
@@ -1,0 +1,1849 @@
+//! Optional compiler-resolved semantic evidence imported from a SCIP index.
+//!
+//! The Tree-sitter graph remains the always-available topology. SCIP facts are
+//! stored in separate additive tables and surfaced with explicit provenance;
+//! they never rewrite syntactic symbols or edges.
+
+use crate::store::Store;
+use protobuf::CodedInputStream;
+use scip::types::{occurrence, Document, Metadata, Occurrence, SymbolInformation, TextEncoding};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::fmt;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_SCIP_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_DOCUMENT_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_SOURCE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+const MAX_DOCUMENTS: usize = 500_000;
+const MAX_OCCURRENCES: usize = 10_000_000;
+const MAX_SYMBOL_INFORMATION: usize = 2_000_000;
+const MAX_DEFINITIONS: usize = 2_000_000;
+const MAX_EDGES: usize = 5_000_000;
+const MAX_SYMBOL_BYTES: usize = 16 * 1024;
+const MAX_DISPLAY_BYTES: usize = 4 * 1024;
+const MAX_PATH_BYTES: usize = 4 * 1024;
+pub const MAX_LENS_SEMANTIC_EDGES: usize = 2_000;
+
+#[derive(Debug)]
+pub enum ScipOverlayError {
+    InvalidIndex(String),
+    InvalidQuery(String),
+    Io(String),
+    Store(String),
+}
+
+impl fmt::Display for ScipOverlayError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidIndex(message) => write!(formatter, "invalid SCIP index: {message}"),
+            Self::InvalidQuery(message) => write!(formatter, "invalid semantic query: {message}"),
+            Self::Io(message) => write!(formatter, "SCIP I/O error: {message}"),
+            Self::Store(message) => write!(formatter, "SCIP store error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ScipOverlayError {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SemanticSource {
+    pub format: &'static str,
+    pub tool_name: String,
+    pub tool_version: String,
+    pub project_root: String,
+    pub artifact_path: String,
+    pub artifact_sha256: String,
+    pub imported_at: i64,
+    pub documents: u32,
+    pub definitions: u32,
+    pub edges: u32,
+    pub text_verified_documents: u32,
+    pub repository_verified: bool,
+    pub revision_verified: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SemanticDefinition {
+    pub symbol: String,
+    pub display_name: String,
+    pub kind: String,
+    pub file: String,
+    pub line: u32,
+    pub character: u32,
+    pub end_line: u32,
+    pub end_character: u32,
+    pub provenance: &'static str,
+    pub confidence: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SemanticEdge {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_symbol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_display_name: Option<String>,
+    pub from_file: String,
+    pub from_line: u32,
+    pub from_character: u32,
+    pub occurrence_line: u32,
+    pub occurrence_character: u32,
+    pub to_symbol: String,
+    pub to_display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_character: Option<u32>,
+    pub kind: String,
+    pub provenance: &'static str,
+    pub confidence: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SemanticCollection<T> {
+    pub total: Option<u32>,
+    pub returned: u32,
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation_reason: Option<&'static str>,
+    pub items: Vec<T>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SemanticResolution {
+    pub default_graph: &'static str,
+    pub static_precedence: [&'static str; 2],
+    pub runtime_confidence: &'static str,
+    pub fallback_without_scip: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SemanticDiagnostic {
+    pub code: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SemanticOverlaySnapshot {
+    pub schema_version: u32,
+    pub available: bool,
+    pub partial: bool,
+    pub fallback_active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<SemanticSource>,
+    pub definitions: SemanticCollection<SemanticDefinition>,
+    pub edges: SemanticCollection<SemanticEdge>,
+    pub diagnostics: Vec<SemanticDiagnostic>,
+    pub resolution: SemanticResolution,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ImportSummary {
+    pub schema_version: u32,
+    pub replaced_previous_overlay: bool,
+    pub source: SemanticSource,
+    pub resolution: SemanticResolution,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SemanticSourceInput {
+    pub tool_name: String,
+    pub tool_version: String,
+    pub project_root: String,
+    pub artifact_path: String,
+    pub artifact_sha256: String,
+    pub imported_at: i64,
+    pub documents: u32,
+    pub definitions: u32,
+    pub edges: u32,
+    pub text_verified_documents: u32,
+    pub repository_verified: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SemanticDocumentInput {
+    pub path: String,
+    pub language: String,
+    pub position_encoding: String,
+    pub content_sha256: String,
+    pub source_text_verified: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SemanticDefinitionInput {
+    pub symbol: String,
+    pub display_name: String,
+    pub kind: String,
+    pub file: String,
+    pub line: u32,
+    pub character: u32,
+    pub end_line: u32,
+    pub end_character: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SemanticEdgeInput {
+    pub from_symbol: Option<String>,
+    pub from_display_name: Option<String>,
+    pub from_file: String,
+    pub from_line: u32,
+    pub from_character: u32,
+    pub occurrence_line: u32,
+    pub occurrence_character: u32,
+    pub to_symbol: String,
+    pub to_display_name: String,
+    pub to_file: Option<String>,
+    pub to_line: Option<u32>,
+    pub to_character: Option<u32>,
+    pub kind: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct SemanticImportBatch {
+    pub source: SemanticSourceInput,
+    pub documents: Vec<SemanticDocumentInput>,
+    pub definitions: Vec<SemanticDefinitionInput>,
+    pub edges: Vec<SemanticEdgeInput>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct SourceRange {
+    start_line: u32,
+    start_character: u32,
+    end_line: u32,
+    end_character: u32,
+}
+
+impl SourceRange {
+    fn contains(self, other: Self) -> bool {
+        (self.start_line, self.start_character) <= (other.start_line, other.start_character)
+            && (self.end_line, self.end_character) >= (other.end_line, other.end_character)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DefinitionLocator {
+    definition_index: usize,
+    body: SourceRange,
+}
+
+#[derive(Debug, Clone)]
+struct InfoRecord {
+    symbol: String,
+    display_name: String,
+    kind: String,
+}
+
+type SemanticEdgeKey = [u8; 32];
+
+fn resolution() -> SemanticResolution {
+    SemanticResolution {
+        default_graph: "tree-sitter",
+        static_precedence: ["scip", "tree-sitter"],
+        runtime_confidence: "observed",
+        fallback_without_scip: "tree-sitter",
+    }
+}
+
+fn checked_count(value: usize, maximum: usize, label: &str) -> Result<u32, ScipOverlayError> {
+    if value > maximum {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "{label} count {value} exceeds the {maximum} safety limit"
+        )));
+    }
+    u32::try_from(value)
+        .map_err(|_| ScipOverlayError::InvalidIndex(format!("{label} count is too large")))
+}
+
+fn validate_bounded(value: &str, maximum: usize, label: &str) -> Result<(), ScipOverlayError> {
+    if value.len() > maximum {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "{label} exceeds {maximum} bytes"
+        )));
+    }
+    if value.contains('\0') {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "{label} contains a NUL byte"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_document_path(path: &str) -> Result<String, ScipOverlayError> {
+    validate_bounded(path, MAX_PATH_BYTES, "document path")?;
+    if path.is_empty() || path.starts_with('/') || path.contains('\\') {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "document path must be a canonical repository-relative slash path: {path:?}"
+        )));
+    }
+    let mut normalized = Vec::new();
+    for component in path.split('/') {
+        if component.is_empty() || component == "." || component == ".." {
+            return Err(ScipOverlayError::InvalidIndex(format!(
+                "document path is not canonical: {path:?}"
+            )));
+        }
+        normalized.push(component);
+    }
+    Ok(normalized.join("/"))
+}
+
+fn qualify_symbol(document: Option<&str>, symbol: &str) -> Result<String, ScipOverlayError> {
+    validate_bounded(symbol, MAX_SYMBOL_BYTES, "symbol")?;
+    if symbol.is_empty() {
+        return Err(ScipOverlayError::InvalidIndex(
+            "an indexed semantic fact has an empty symbol".into(),
+        ));
+    }
+    if scip::symbol::is_local_symbol(symbol) {
+        let document = document.ok_or_else(|| {
+            ScipOverlayError::InvalidIndex("an external symbol cannot be local".into())
+        })?;
+        Ok(format!("local {document}::{}", &symbol[6..]))
+    } else {
+        Ok(symbol.to_string())
+    }
+}
+
+fn fallback_display_name(symbol: &str) -> String {
+    if let Some(local) = symbol.strip_prefix("local ") {
+        return local.rsplit("::").next().unwrap_or(local).to_string();
+    }
+    scip::symbol::parse_symbol(symbol)
+        .ok()
+        .and_then(|parsed| parsed.descriptors.last().map(|value| value.name.clone()))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| symbol.to_string())
+}
+
+fn info_record(
+    info: &SymbolInformation,
+    document: Option<&str>,
+) -> Result<InfoRecord, ScipOverlayError> {
+    let symbol = qualify_symbol(document, &info.symbol)?;
+    let display_name = if info.display_name.is_empty() {
+        fallback_display_name(&symbol)
+    } else {
+        validate_bounded(&info.display_name, MAX_DISPLAY_BYTES, "symbol display name")?;
+        info.display_name.clone()
+    };
+    let kind = info
+        .kind
+        .enum_value()
+        .map(|value| format!("{value:?}"))
+        .unwrap_or_else(|_| format!("Unknown({})", info.kind.value()));
+    Ok(InfoRecord {
+        symbol,
+        display_name,
+        kind,
+    })
+}
+
+fn insert_info(infos: &mut HashMap<String, InfoRecord>, record: InfoRecord) {
+    infos.entry(record.symbol.clone()).or_insert(record);
+}
+
+fn is_definition_occurrence(occurrence: &Occurrence) -> bool {
+    let roles = scip::types::SymbolRole::Definition as i32
+        | scip::types::SymbolRole::ForwardDefinition as i32;
+    occurrence.symbol_roles & roles != 0
+}
+
+fn range_from_values(values: &[i32], label: &str) -> Result<Option<SourceRange>, ScipOverlayError> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+    let (start_line, start_character, end_line, end_character) = match values {
+        [line, start, end] => (*line, *start, *line, *end),
+        [start_line, start, end_line, end] => (*start_line, *start, *end_line, *end),
+        _ => {
+            return Err(ScipOverlayError::InvalidIndex(format!(
+                "{label} must contain exactly three or four integers"
+            )))
+        }
+    };
+    range_from_i32(start_line, start_character, end_line, end_character, label).map(Some)
+}
+
+fn range_from_i32(
+    start_line: i32,
+    start_character: i32,
+    end_line: i32,
+    end_character: i32,
+    label: &str,
+) -> Result<SourceRange, ScipOverlayError> {
+    let values = [start_line, start_character, end_line, end_character];
+    if values.iter().any(|value| *value < 0) {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "{label} contains a negative position"
+        )));
+    }
+    let range = SourceRange {
+        start_line: start_line as u32,
+        start_character: start_character as u32,
+        end_line: end_line as u32,
+        end_character: end_character as u32,
+    };
+    if (range.end_line, range.end_character) < (range.start_line, range.start_character) {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "{label} ends before it starts"
+        )));
+    }
+    Ok(range)
+}
+
+fn occurrence_range(occurrence: &Occurrence) -> Result<SourceRange, ScipOverlayError> {
+    match &occurrence.typed_range {
+        Some(occurrence::Typed_range::SingleLineRange(value)) => range_from_i32(
+            value.line,
+            value.start_character,
+            value.line,
+            value.end_character,
+            "occurrence range",
+        ),
+        Some(occurrence::Typed_range::MultiLineRange(value)) => range_from_i32(
+            value.start_line,
+            value.start_character,
+            value.end_line,
+            value.end_character,
+            "occurrence range",
+        ),
+        None => range_from_values(&occurrence.range, "occurrence range")?.ok_or_else(|| {
+            ScipOverlayError::InvalidIndex("a symbol occurrence has no source range".into())
+        }),
+        Some(_) => Err(ScipOverlayError::InvalidIndex(
+            "occurrence uses an unsupported typed range variant".into(),
+        )),
+    }
+}
+
+fn enclosing_range(occurrence: &Occurrence) -> Result<Option<SourceRange>, ScipOverlayError> {
+    match &occurrence.typed_enclosing_range {
+        Some(occurrence::Typed_enclosing_range::SingleLineEnclosingRange(value)) => range_from_i32(
+            value.line,
+            value.start_character,
+            value.line,
+            value.end_character,
+            "enclosing range",
+        )
+        .map(Some),
+        Some(occurrence::Typed_enclosing_range::MultiLineEnclosingRange(value)) => range_from_i32(
+            value.start_line,
+            value.start_character,
+            value.end_line,
+            value.end_character,
+            "enclosing range",
+        )
+        .map(Some),
+        None => range_from_values(&occurrence.enclosing_range, "enclosing range"),
+        Some(_) => Err(ScipOverlayError::InvalidIndex(
+            "occurrence uses an unsupported typed enclosing-range variant".into(),
+        )),
+    }
+}
+
+fn hash_file(path: &Path) -> Result<(String, u64), ScipOverlayError> {
+    let metadata = path.metadata().map_err(|error| {
+        ScipOverlayError::Io(format!("read {} metadata: {error}", path.display()))
+    })?;
+    if !metadata.is_file() {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "document is not a regular file: {}",
+            path.display()
+        )));
+    }
+    if metadata.len() > MAX_DOCUMENT_BYTES {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "document {} exceeds the {} MiB safety limit",
+            path.display(),
+            MAX_DOCUMENT_BYTES / 1024 / 1024
+        )));
+    }
+    let file = File::open(path)
+        .map_err(|error| ScipOverlayError::Io(format!("open {}: {error}", path.display())))?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut total = 0_u64;
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| ScipOverlayError::Io(format!("read {}: {error}", path.display())))?;
+        if read == 0 {
+            break;
+        }
+        total = total.saturating_add(read as u64);
+        if total > MAX_DOCUMENT_BYTES {
+            return Err(ScipOverlayError::InvalidIndex(format!(
+                "document {} grew beyond the {} MiB safety limit while being read",
+                path.display(),
+                MAX_DOCUMENT_BYTES / 1024 / 1024
+            )));
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok((crate::hex::encode(&hasher.finalize()), total))
+}
+
+fn embedded_text_matches_file(
+    path: &Path,
+    embedded: &str,
+    encoding: TextEncoding,
+) -> Result<bool, ScipOverlayError> {
+    let metadata = path.metadata().map_err(|error| {
+        ScipOverlayError::Io(format!("read {} metadata: {error}", path.display()))
+    })?;
+    if metadata.len() > MAX_DOCUMENT_BYTES {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "document {} exceeds the {} MiB safety limit",
+            path.display(),
+            MAX_DOCUMENT_BYTES / 1024 / 1024
+        )));
+    }
+    let mut bytes = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
+    File::open(path)
+        .and_then(|file| {
+            file.take(MAX_DOCUMENT_BYTES.saturating_add(1))
+                .read_to_end(&mut bytes)
+        })
+        .map_err(|error| ScipOverlayError::Io(format!("read {}: {error}", path.display())))?;
+    if bytes.len() as u64 > MAX_DOCUMENT_BYTES {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "document {} grew beyond the {} MiB safety limit while being read",
+            path.display(),
+            MAX_DOCUMENT_BYTES / 1024 / 1024
+        )));
+    }
+    let decoded = match encoding {
+        TextEncoding::UTF16 => {
+            let (little_endian, body) = match bytes.as_slice() {
+                [0xff, 0xfe, rest @ ..] => (true, rest),
+                [0xfe, 0xff, rest @ ..] => (false, rest),
+                _ => {
+                    return Err(ScipOverlayError::InvalidIndex(format!(
+                        "UTF-16 SCIP document {} has no byte-order mark",
+                        path.display()
+                    )))
+                }
+            };
+            if body.len() % 2 != 0 {
+                return Err(ScipOverlayError::InvalidIndex(format!(
+                    "UTF-16 SCIP document {} has an odd byte length",
+                    path.display()
+                )));
+            }
+            let units = body
+                .chunks_exact(2)
+                .map(|pair| {
+                    if little_endian {
+                        u16::from_le_bytes([pair[0], pair[1]])
+                    } else {
+                        u16::from_be_bytes([pair[0], pair[1]])
+                    }
+                })
+                .collect::<Vec<_>>();
+            String::from_utf16(&units).map_err(|_| {
+                ScipOverlayError::InvalidIndex(format!(
+                    "UTF-16 SCIP document {} is malformed",
+                    path.display()
+                ))
+            })?
+        }
+        TextEncoding::UTF8 | TextEncoding::UnspecifiedTextEncoding => {
+            let decoded = std::str::from_utf8(&bytes).map_err(|_| {
+                ScipOverlayError::InvalidIndex(format!(
+                    "SCIP document {} is not valid UTF-8",
+                    path.display()
+                ))
+            })?;
+            decoded
+                .strip_prefix('\u{feff}')
+                .unwrap_or(decoded)
+                .to_string()
+        }
+    };
+    Ok(decoded == embedded)
+}
+
+fn source_for_store(source: &SemanticSourceInput) -> SemanticSource {
+    SemanticSource {
+        format: "scip",
+        tool_name: source.tool_name.clone(),
+        tool_version: source.tool_version.clone(),
+        project_root: source.project_root.clone(),
+        artifact_path: source.artifact_path.clone(),
+        artifact_sha256: source.artifact_sha256.clone(),
+        imported_at: source.imported_at,
+        documents: source.documents,
+        definitions: source.definitions,
+        edges: source.edges,
+        text_verified_documents: source.text_verified_documents,
+        repository_verified: source.repository_verified,
+        revision_verified: source.documents > 0
+            && source.text_verified_documents == source.documents,
+    }
+}
+
+fn artifact_metadata(path: &Path) -> Result<std::fs::Metadata, ScipOverlayError> {
+    let metadata = path.metadata().map_err(|error| {
+        ScipOverlayError::Io(format!("read {} metadata: {error}", path.display()))
+    })?;
+    if !metadata.is_file() {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "artifact is not a regular file: {}",
+            path.display()
+        )));
+    }
+    if metadata.len() > MAX_SCIP_BYTES {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "artifact exceeds the {} MiB safety limit",
+            MAX_SCIP_BYTES / 1024 / 1024
+        )));
+    }
+    Ok(metadata)
+}
+
+fn hash_artifact(path: &Path) -> Result<String, ScipOverlayError> {
+    artifact_metadata(path)?;
+    let file = File::open(path)
+        .map_err(|error| ScipOverlayError::Io(format!("open {}: {error}", path.display())))?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut total = 0_u64;
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| ScipOverlayError::Io(format!("read {}: {error}", path.display())))?;
+        if read == 0 {
+            break;
+        }
+        total = total.saturating_add(read as u64);
+        if total > MAX_SCIP_BYTES {
+            return Err(ScipOverlayError::InvalidIndex(format!(
+                "artifact grew beyond the {} MiB safety limit while being read",
+                MAX_SCIP_BYTES / 1024 / 1024
+            )));
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(crate::hex::encode(&hasher.finalize()))
+}
+
+enum ScipRecord {
+    Metadata(Metadata),
+    Document(Document),
+    ExternalSymbol(SymbolInformation),
+}
+
+/// Decode one top-level protobuf field at a time. SCIP indexes are commonly
+/// produced for monorepos and the schema explicitly permits streaming; keeping
+/// the full `Index` plus every document body in memory would multiply the
+/// artifact's peak footprint before any useful evidence reached SQLite.
+fn stream_scip(
+    path: &Path,
+    mut visit: impl FnMut(ScipRecord) -> Result<(), ScipOverlayError>,
+) -> Result<(), ScipOverlayError> {
+    artifact_metadata(path)?;
+    let file = File::open(path)
+        .map_err(|error| ScipOverlayError::Io(format!("open {}: {error}", path.display())))?;
+    let mut reader = BufReader::new(file.take(MAX_SCIP_BYTES.saturating_add(1)));
+    let mut input = CodedInputStream::from_buf_read(&mut reader);
+    let mut metadata_seen = false;
+    loop {
+        let tag = input.read_raw_tag_or_eof().map_err(|error| {
+            ScipOverlayError::InvalidIndex(format!("protobuf decode failed: {error}"))
+        })?;
+        let Some(tag) = tag else {
+            break;
+        };
+        let record = match tag {
+            10 => {
+                if metadata_seen {
+                    return Err(ScipOverlayError::InvalidIndex(
+                        "the SCIP index contains duplicate metadata".into(),
+                    ));
+                }
+                metadata_seen = true;
+                Some(ScipRecord::Metadata(input.read_message().map_err(
+                    |error| {
+                        ScipOverlayError::InvalidIndex(format!(
+                            "decode SCIP metadata failed: {error}"
+                        ))
+                    },
+                )?))
+            }
+            18 if !metadata_seen => {
+                return Err(ScipOverlayError::InvalidIndex(
+                    "SCIP metadata must appear before documents for streaming consumption".into(),
+                ))
+            }
+            18 => Some(ScipRecord::Document(input.read_message().map_err(
+                |error| {
+                    ScipOverlayError::InvalidIndex(format!("decode SCIP document failed: {error}"))
+                },
+            )?)),
+            26 if !metadata_seen => {
+                return Err(ScipOverlayError::InvalidIndex(
+                    "SCIP metadata must appear before external symbols for streaming consumption"
+                        .into(),
+                ))
+            }
+            26 => Some(ScipRecord::ExternalSymbol(input.read_message().map_err(
+                |error| {
+                    ScipOverlayError::InvalidIndex(format!(
+                        "decode external SCIP symbol failed: {error}"
+                    ))
+                },
+            )?)),
+            _ => {
+                protobuf::rt::skip_field_for_tag(tag, &mut input).map_err(|error| {
+                    ScipOverlayError::InvalidIndex(format!(
+                        "skip unknown SCIP field failed: {error}"
+                    ))
+                })?;
+                None
+            }
+        };
+        if let Some(record) = record {
+            visit(record)?;
+        }
+    }
+    if input.pos() > MAX_SCIP_BYTES {
+        return Err(ScipOverlayError::InvalidIndex(format!(
+            "artifact grew beyond the {} MiB safety limit while being decoded",
+            MAX_SCIP_BYTES / 1024 / 1024
+        )));
+    }
+    Ok(())
+}
+
+fn decode_percent_encoded(value: &str) -> Result<String, ScipOverlayError> {
+    fn nibble(value: u8) -> Option<u8> {
+        match value {
+            b'0'..=b'9' => Some(value - b'0'),
+            b'a'..=b'f' => Some(value - b'a' + 10),
+            b'A'..=b'F' => Some(value - b'A' + 10),
+            _ => None,
+        }
+    }
+
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            decoded.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+        let high = bytes.get(index + 1).and_then(|value| nibble(*value));
+        let low = bytes.get(index + 2).and_then(|value| nibble(*value));
+        let (Some(high), Some(low)) = (high, low) else {
+            return Err(ScipOverlayError::InvalidIndex(
+                "SCIP project_root contains malformed percent encoding".into(),
+            ));
+        };
+        decoded.push((high << 4) | low);
+        index += 3;
+    }
+    let decoded = String::from_utf8(decoded).map_err(|_| {
+        ScipOverlayError::InvalidIndex("SCIP project_root is not valid UTF-8".into())
+    })?;
+    if decoded.contains('\0') {
+        return Err(ScipOverlayError::InvalidIndex(
+            "SCIP project_root contains a NUL byte".into(),
+        ));
+    }
+    Ok(decoded)
+}
+
+fn project_root_path(value: &str) -> Result<Option<PathBuf>, ScipOverlayError> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+    if value.contains(['?', '#']) {
+        return Err(ScipOverlayError::InvalidIndex(
+            "SCIP project_root must not contain a query or fragment".into(),
+        ));
+    }
+    let decoded = if let Some(rest) = value.strip_prefix("file://") {
+        let local = if let Some(path) = rest.strip_prefix("localhost/") {
+            format!("/{path}")
+        } else if rest.starts_with('/') {
+            rest.to_string()
+        } else {
+            return Err(ScipOverlayError::InvalidIndex(
+                "SCIP project_root must be a local file URI".into(),
+            ));
+        };
+        decode_percent_encoded(&local)?
+    } else if let Some(rest) = value.strip_prefix("file:") {
+        decode_percent_encoded(rest)?
+    } else {
+        decode_percent_encoded(value)?
+    };
+
+    #[cfg(windows)]
+    let decoded = decoded
+        .strip_prefix('/')
+        .filter(|path| path.as_bytes().get(1) == Some(&b':'))
+        .unwrap_or(&decoded)
+        .to_string();
+
+    let path = PathBuf::from(decoded);
+    if path.is_absolute() {
+        Ok(Some(path))
+    } else {
+        Err(ScipOverlayError::InvalidIndex(
+            "SCIP project_root must be an absolute local path".into(),
+        ))
+    }
+}
+
+fn verify_repository_identity(
+    project_root: &str,
+    indexed_root: &Path,
+    all_documents_text_verified: bool,
+) -> Result<bool, ScipOverlayError> {
+    let reported = project_root_path(project_root)?;
+    if let Some(reported) = reported {
+        match reported.canonicalize() {
+            Ok(reported) if reported == indexed_root => return Ok(true),
+            Ok(reported) if !all_documents_text_verified => {
+                return Err(ScipOverlayError::InvalidIndex(format!(
+                    "SCIP project_root {} does not match the indexed repository {}; regenerate the artifact here or embed every Document.text",
+                    reported.display(),
+                    indexed_root.display()
+                )));
+            }
+            Err(error) if !all_documents_text_verified => {
+                return Err(ScipOverlayError::InvalidIndex(format!(
+                    "SCIP project_root cannot be verified ({error}); regenerate the artifact here or embed every Document.text"
+                )));
+            }
+            _ => {}
+        }
+    } else if !all_documents_text_verified {
+        return Err(ScipOverlayError::InvalidIndex(
+            "SCIP metadata has no project_root and not every document embeds matching text".into(),
+        ));
+    }
+    // Exact embedded text binds a portable artifact to this repository even
+    // when its producer used a container-only or since-moved project root.
+    Ok(all_documents_text_verified)
+}
+
+fn artifact_label(artifact: &Path, root: &Path) -> String {
+    artifact
+        .strip_prefix(root)
+        .ok()
+        .and_then(|relative| relative.to_str())
+        .filter(|relative| !relative.is_empty())
+        .map(|relative| relative.replace('\\', "/"))
+        .or_else(|| {
+            artifact
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "index.scip".into())
+}
+
+fn definition_for_symbol<'a>(
+    definitions: &'a HashMap<String, Vec<DefinitionLocator>>,
+    symbol: &str,
+) -> Option<&'a DefinitionLocator> {
+    definitions.get(symbol).and_then(|values| values.first())
+}
+
+fn owner_for_reference(
+    definitions: &[DefinitionLocator],
+    range: SourceRange,
+) -> Option<&DefinitionLocator> {
+    definitions
+        .iter()
+        .filter(|definition| definition.body.contains(range))
+        .max_by(|left, right| {
+            (left.body.start_line, left.body.start_character)
+                .cmp(&(right.body.start_line, right.body.start_character))
+                .then_with(|| {
+                    (right.body.end_line, right.body.end_character)
+                        .cmp(&(left.body.end_line, left.body.end_character))
+                })
+        })
+}
+
+fn edge_key(edge: &SemanticEdgeInput) -> SemanticEdgeKey {
+    fn string(hasher: &mut Sha256, value: Option<&str>) {
+        match value {
+            Some(value) => {
+                hasher.update([1]);
+                hasher.update((value.len() as u64).to_le_bytes());
+                hasher.update(value.as_bytes());
+            }
+            None => hasher.update([0]),
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    string(&mut hasher, edge.from_symbol.as_deref());
+    string(&mut hasher, Some(&edge.from_file));
+    for value in [
+        edge.from_line,
+        edge.from_character,
+        edge.occurrence_line,
+        edge.occurrence_character,
+    ] {
+        hasher.update(value.to_le_bytes());
+    }
+    string(&mut hasher, Some(&edge.to_symbol));
+    string(&mut hasher, edge.to_file.as_deref());
+    string(&mut hasher, Some(&edge.kind));
+    hasher.finalize().into()
+}
+
+fn push_edge(
+    edges: &mut Vec<SemanticEdgeInput>,
+    seen_edges: &mut HashSet<SemanticEdgeKey>,
+    edge: SemanticEdgeInput,
+) -> Result<(), ScipOverlayError> {
+    if seen_edges.insert(edge_key(&edge)) {
+        edges.push(edge);
+        checked_count(edges.len(), MAX_EDGES, "semantic edge")?;
+    }
+    Ok(())
+}
+
+fn append_relationship_edges(
+    info: &SymbolInformation,
+    document: Option<&str>,
+    definitions: &[SemanticDefinitionInput],
+    locators_by_symbol: &HashMap<String, Vec<DefinitionLocator>>,
+    infos: &HashMap<String, InfoRecord>,
+    edges: &mut Vec<SemanticEdgeInput>,
+    seen_edges: &mut HashSet<SemanticEdgeKey>,
+) -> Result<(), ScipOverlayError> {
+    let source_symbol = qualify_symbol(document, &info.symbol)?;
+    let Some(source_locator) = definition_for_symbol(locators_by_symbol, &source_symbol) else {
+        return Ok(());
+    };
+    let source = &definitions[source_locator.definition_index];
+    for relationship in &info.relationships {
+        let target_symbol = qualify_symbol(document, &relationship.symbol)?;
+        let target = definition_for_symbol(locators_by_symbol, &target_symbol)
+            .map(|locator| &definitions[locator.definition_index]);
+        let target_display = infos
+            .get(&target_symbol)
+            .map(|value| value.display_name.clone())
+            .unwrap_or_else(|| fallback_display_name(&target_symbol));
+        for (enabled, kind) in [
+            (relationship.is_reference, "reference"),
+            (relationship.is_implementation, "implementation"),
+            (relationship.is_type_definition, "type_definition"),
+            (relationship.is_definition, "definition"),
+        ] {
+            if !enabled {
+                continue;
+            }
+            push_edge(
+                edges,
+                seen_edges,
+                SemanticEdgeInput {
+                    from_symbol: Some(source.symbol.clone()),
+                    from_display_name: Some(source.display_name.clone()),
+                    from_file: source.file.clone(),
+                    from_line: source.line,
+                    from_character: source.character,
+                    occurrence_line: source.line,
+                    occurrence_character: source.character,
+                    to_symbol: target_symbol.clone(),
+                    to_display_name: target_display.clone(),
+                    to_file: target.map(|value| value.file.clone()),
+                    to_line: target.map(|value| value.line),
+                    to_character: target.map(|value| value.character),
+                    kind: kind.into(),
+                },
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn build_batch(store: &Store, scip_path: &Path) -> Result<SemanticImportBatch, ScipOverlayError> {
+    if !store
+        .schema_current()
+        .map_err(|error| ScipOverlayError::Store(error.to_string()))?
+    {
+        return Err(ScipOverlayError::Store(
+            "the codegraph schema is stale; run `mastermind index .` first".into(),
+        ));
+    }
+    let root = store
+        .meta_value("index_root")
+        .map_err(|error| ScipOverlayError::Store(error.to_string()))?
+        .ok_or_else(|| {
+            ScipOverlayError::Store(
+                "the index has no repository identity; run `mastermind index .` first".into(),
+            )
+        })?;
+    let root = PathBuf::from(root)
+        .canonicalize()
+        .map_err(|error| ScipOverlayError::Store(format!("resolve index root: {error}")))?;
+    crate::indexer::validate_index_root(store, &root).map_err(ScipOverlayError::Store)?;
+
+    let artifact = scip_path.canonicalize().map_err(|error| {
+        ScipOverlayError::Io(format!("resolve {}: {error}", scip_path.display()))
+    })?;
+    let artifact_sha256 = hash_artifact(&artifact)?;
+
+    let mut scip_metadata = None::<Metadata>;
+    let mut documents = Vec::new();
+    let mut document_paths = HashSet::new();
+    let mut total_source_bytes = 0_u64;
+    let mut text_verified_documents = 0_usize;
+    let mut occurrence_count = 0_usize;
+    let mut symbol_information_count = 0_usize;
+    let mut infos = HashMap::<String, InfoRecord>::new();
+    let mut locators_by_document = HashMap::<String, Vec<DefinitionLocator>>::new();
+    let mut locators_by_symbol = HashMap::<String, Vec<DefinitionLocator>>::new();
+    let mut definitions = Vec::new();
+
+    // Pass one validates source identity and retains only compact definition
+    // and relationship records. Each potentially large Document is released
+    // before the next top-level protobuf field is decoded.
+    stream_scip(&artifact, |record| {
+        match record {
+            ScipRecord::Metadata(value) => scip_metadata = Some(value),
+            ScipRecord::ExternalSymbol(info) => {
+                symbol_information_count = symbol_information_count.saturating_add(1);
+                checked_count(
+                    symbol_information_count,
+                    MAX_SYMBOL_INFORMATION,
+                    "symbol information",
+                )?;
+                let record = info_record(&info, None)?;
+                insert_info(&mut infos, record);
+            }
+            ScipRecord::Document(document) => {
+                checked_count(documents.len().saturating_add(1), MAX_DOCUMENTS, "document")?;
+                occurrence_count = occurrence_count.saturating_add(document.occurrences.len());
+                checked_count(occurrence_count, MAX_OCCURRENCES, "occurrence")?;
+                symbol_information_count =
+                    symbol_information_count.saturating_add(document.symbols.len());
+                checked_count(
+                    symbol_information_count,
+                    MAX_SYMBOL_INFORMATION,
+                    "symbol information",
+                )?;
+
+                let relative = normalize_document_path(&document.relative_path)?;
+                if !document_paths.insert(relative.clone()) {
+                    return Err(ScipOverlayError::InvalidIndex(format!(
+                        "duplicate document path: {relative}"
+                    )));
+                }
+                validate_bounded(&document.language, 256, "document language")?;
+                let resolved = root.join(&relative).canonicalize().map_err(|error| {
+                    ScipOverlayError::InvalidIndex(format!(
+                        "document {relative:?} is unavailable under the indexed repository: {error}"
+                    ))
+                })?;
+                if !resolved.starts_with(&root) {
+                    return Err(ScipOverlayError::InvalidIndex(format!(
+                        "document escapes the indexed repository through a symlink: {relative:?}"
+                    )));
+                }
+                let (content_sha256, bytes) = hash_file(&resolved)?;
+                total_source_bytes = total_source_bytes.saturating_add(bytes);
+                if total_source_bytes > MAX_SOURCE_BYTES {
+                    return Err(ScipOverlayError::InvalidIndex(format!(
+                        "documents exceed the {} GiB source verification limit",
+                        MAX_SOURCE_BYTES / 1024 / 1024 / 1024
+                    )));
+                }
+                let source_text_verified = if document.text.is_empty() {
+                    false
+                } else {
+                    let encoding = scip_metadata
+                        .as_ref()
+                        .expect("stream_scip guarantees metadata before documents")
+                        .text_document_encoding
+                        .enum_value()
+                        .map_err(|_| {
+                            ScipOverlayError::InvalidIndex(
+                                "SCIP metadata uses an unknown document text encoding".into(),
+                            )
+                        })?;
+                    if !embedded_text_matches_file(&resolved, &document.text, encoding)? {
+                        return Err(ScipOverlayError::InvalidIndex(format!(
+                            "embedded SCIP text does not match the current repository file {relative:?}"
+                        )));
+                    }
+                    if hash_file(&resolved)?.0 != content_sha256 {
+                        return Err(ScipOverlayError::InvalidIndex(format!(
+                            "repository file changed while SCIP evidence was being verified: {relative:?}"
+                        )));
+                    }
+                    text_verified_documents += 1;
+                    true
+                };
+                let position_encoding = document
+                    .position_encoding
+                    .enum_value()
+                    .map(|value| format!("{value:?}"))
+                    .unwrap_or_else(|_| format!("Unknown({})", document.position_encoding.value()));
+                documents.push(SemanticDocumentInput {
+                    path: relative.clone(),
+                    language: document.language.clone(),
+                    position_encoding,
+                    content_sha256,
+                    source_text_verified,
+                });
+
+                for info in &document.symbols {
+                    let record = info_record(info, Some(&relative))?;
+                    insert_info(&mut infos, record);
+                }
+                for occurrence in &document.occurrences {
+                    if occurrence.symbol.is_empty() || !is_definition_occurrence(occurrence) {
+                        continue;
+                    }
+                    let symbol = qualify_symbol(Some(&relative), &occurrence.symbol)?;
+                    let range = occurrence_range(occurrence)?;
+                    let body = enclosing_range(occurrence)?.unwrap_or(range);
+                    if !body.contains(range) {
+                        return Err(ScipOverlayError::InvalidIndex(format!(
+                            "definition enclosing range does not enclose its occurrence in {relative:?}"
+                        )));
+                    }
+                    let info = infos.get(&symbol);
+                    let definition = SemanticDefinitionInput {
+                        symbol: symbol.clone(),
+                        display_name: info
+                            .map(|value| value.display_name.clone())
+                            .unwrap_or_else(|| fallback_display_name(&symbol)),
+                        kind: info
+                            .map(|value| value.kind.clone())
+                            .unwrap_or_else(|| "UnspecifiedKind".into()),
+                        file: relative.clone(),
+                        line: range.start_line.saturating_add(1),
+                        character: range.start_character.saturating_add(1),
+                        end_line: range.end_line.saturating_add(1),
+                        end_character: range.end_character.saturating_add(1),
+                    };
+                    let definition_index = definitions.len();
+                    let locator = DefinitionLocator {
+                        definition_index,
+                        body,
+                    };
+                    definitions.push(definition);
+                    locators_by_document
+                        .entry(relative.clone())
+                        .or_default()
+                        .push(locator.clone());
+                    locators_by_symbol.entry(symbol).or_default().push(locator);
+                    checked_count(definitions.len(), MAX_DEFINITIONS, "definition")?;
+                }
+            }
+        }
+        Ok(())
+    })?;
+
+    let metadata = scip_metadata
+        .as_ref()
+        .ok_or_else(|| ScipOverlayError::InvalidIndex("the SCIP index has no metadata".into()))?;
+    let tool = metadata.tool_info.as_ref();
+    let tool_name = tool.map(|value| value.name.clone()).unwrap_or_default();
+    let tool_version = tool.map(|value| value.version.clone()).unwrap_or_default();
+    let project_root = metadata.project_root.clone();
+    validate_bounded(&tool_name, 256, "tool name")?;
+    validate_bounded(&tool_version, 256, "tool version")?;
+    validate_bounded(&project_root, MAX_PATH_BYTES * 2, "project root")?;
+    let all_documents_text_verified =
+        !documents.is_empty() && text_verified_documents == documents.len();
+    let repository_verified =
+        verify_repository_identity(&project_root, &root, all_documents_text_verified)?;
+
+    for values in locators_by_symbol.values_mut() {
+        values.sort_by(|left, right| {
+            definitions[left.definition_index]
+                .file
+                .cmp(&definitions[right.definition_index].file)
+                .then_with(|| {
+                    definitions[left.definition_index]
+                        .line
+                        .cmp(&definitions[right.definition_index].line)
+                })
+                .then_with(|| {
+                    definitions[left.definition_index]
+                        .character
+                        .cmp(&definitions[right.definition_index].character)
+                })
+        });
+    }
+
+    let mut edges = Vec::new();
+    let mut seen_edges = HashSet::new();
+    let mut second_pass_paths = HashSet::with_capacity(document_paths.len());
+    let mut second_pass_occurrences = 0_usize;
+    // Pass two resolves references now that every global definition and symbol
+    // relationship is known. It still holds only one Document at a time.
+    stream_scip(&artifact, |record| {
+        let ScipRecord::Document(document) = record else {
+            return Ok(());
+        };
+        let relative = normalize_document_path(&document.relative_path)?;
+        if !document_paths.contains(&relative) || !second_pass_paths.insert(relative.clone()) {
+            return Err(ScipOverlayError::InvalidIndex(
+                "SCIP artifact changed while it was being imported".into(),
+            ));
+        }
+        second_pass_occurrences =
+            second_pass_occurrences.saturating_add(document.occurrences.len());
+        checked_count(second_pass_occurrences, MAX_OCCURRENCES, "occurrence")?;
+        let document_definitions = locators_by_document
+            .get(&relative)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        for occurrence in &document.occurrences {
+            if occurrence.symbol.is_empty() || is_definition_occurrence(occurrence) {
+                continue;
+            }
+            let symbol = qualify_symbol(Some(&relative), &occurrence.symbol)?;
+            let range = occurrence_range(occurrence)?;
+            let owner = owner_for_reference(document_definitions, range)
+                .map(|locator| &definitions[locator.definition_index]);
+            let target = definition_for_symbol(&locators_by_symbol, &symbol)
+                .map(|locator| &definitions[locator.definition_index]);
+            let display = infos
+                .get(&symbol)
+                .map(|value| value.display_name.clone())
+                .unwrap_or_else(|| fallback_display_name(&symbol));
+            let kind = if occurrence.symbol_roles & scip::types::SymbolRole::Import as i32 != 0 {
+                "import"
+            } else {
+                "reference"
+            };
+            let edge = SemanticEdgeInput {
+                from_symbol: owner.map(|value| value.symbol.clone()),
+                from_display_name: owner.map(|value| value.display_name.clone()),
+                from_file: relative.clone(),
+                from_line: owner
+                    .map(|value| value.line)
+                    .unwrap_or_else(|| range.start_line.saturating_add(1)),
+                from_character: owner
+                    .map(|value| value.character)
+                    .unwrap_or_else(|| range.start_character.saturating_add(1)),
+                occurrence_line: range.start_line.saturating_add(1),
+                occurrence_character: range.start_character.saturating_add(1),
+                to_symbol: symbol,
+                to_display_name: display,
+                to_file: target.map(|value| value.file.clone()),
+                to_line: target.map(|value| value.line),
+                to_character: target.map(|value| value.character),
+                kind: kind.into(),
+            };
+            push_edge(&mut edges, &mut seen_edges, edge)?;
+        }
+        for info in &document.symbols {
+            append_relationship_edges(
+                info,
+                Some(&relative),
+                &definitions,
+                &locators_by_symbol,
+                &infos,
+                &mut edges,
+                &mut seen_edges,
+            )?;
+        }
+        Ok(())
+    })?;
+    if second_pass_paths != document_paths || second_pass_occurrences != occurrence_count {
+        return Err(ScipOverlayError::InvalidIndex(
+            "SCIP artifact changed while it was being imported".into(),
+        ));
+    }
+
+    // External symbol information can also carry relationships. A third
+    // streaming pass avoids retaining those relationship vectors in memory.
+    stream_scip(&artifact, |record| {
+        let ScipRecord::ExternalSymbol(info) = record else {
+            return Ok(());
+        };
+        append_relationship_edges(
+            &info,
+            None,
+            &definitions,
+            &locators_by_symbol,
+            &infos,
+            &mut edges,
+            &mut seen_edges,
+        )
+    })?;
+
+    if hash_artifact(&artifact)? != artifact_sha256 {
+        return Err(ScipOverlayError::InvalidIndex(
+            "SCIP artifact changed while it was being imported".into(),
+        ));
+    }
+
+    let source = SemanticSourceInput {
+        tool_name,
+        tool_version,
+        project_root: ".".into(),
+        artifact_path: artifact_label(&artifact, &root),
+        artifact_sha256,
+        imported_at: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .try_into()
+            .unwrap_or(i64::MAX),
+        documents: checked_count(documents.len(), MAX_DOCUMENTS, "document")?,
+        definitions: checked_count(definitions.len(), MAX_DEFINITIONS, "definition")?,
+        edges: checked_count(edges.len(), MAX_EDGES, "semantic edge")?,
+        text_verified_documents: checked_count(
+            text_verified_documents,
+            MAX_DOCUMENTS,
+            "text-verified document",
+        )?,
+        repository_verified,
+    };
+    Ok(SemanticImportBatch {
+        source,
+        documents,
+        definitions,
+        edges,
+    })
+}
+
+pub fn import(store: &Store, scip_path: &Path) -> Result<ImportSummary, ScipOverlayError> {
+    let batch = build_batch(store, scip_path)?;
+    let previous = store
+        .semantic_source()
+        .map_err(|error| ScipOverlayError::Store(error.to_string()))?
+        .is_some();
+    let source = source_for_store(&batch.source);
+    store
+        .replace_semantic_overlay(&batch)
+        .map_err(|error| ScipOverlayError::Store(error.to_string()))?;
+    Ok(ImportSummary {
+        schema_version: 1,
+        replaced_previous_overlay: previous,
+        source,
+        resolution: resolution(),
+    })
+}
+
+fn empty_snapshot() -> SemanticOverlaySnapshot {
+    SemanticOverlaySnapshot {
+        schema_version: 1,
+        available: false,
+        partial: false,
+        fallback_active: true,
+        source: None,
+        definitions: SemanticCollection {
+            total: Some(0),
+            returned: 0,
+            truncated: false,
+            truncation_reason: None,
+            items: Vec::new(),
+        },
+        edges: SemanticCollection {
+            total: Some(0),
+            returned: 0,
+            truncated: false,
+            truncation_reason: None,
+            items: Vec::new(),
+        },
+        diagnostics: Vec::new(),
+        resolution: resolution(),
+    }
+}
+
+pub fn unavailable_with_diagnostic() -> SemanticOverlaySnapshot {
+    let mut snapshot = empty_snapshot();
+    snapshot.partial = true;
+    snapshot.diagnostics.push(SemanticDiagnostic {
+        code: "semantic_overlay_unavailable",
+        message: "The SCIP overlay could not be read safely. Tree-sitter remains available; re-run `mastermind enrich --scip <index.scip>` to replace it.".into(),
+    });
+    snapshot
+}
+
+pub fn query(
+    store: &Store,
+    symbol: &str,
+    top: u32,
+) -> Result<SemanticOverlaySnapshot, ScipOverlayError> {
+    if symbol.len() > MAX_SYMBOL_BYTES || symbol.contains('\0') {
+        return Err(ScipOverlayError::InvalidQuery(format!(
+            "query exceeds {MAX_SYMBOL_BYTES} bytes or contains a NUL byte"
+        )));
+    }
+    if symbol.trim().is_empty() {
+        return Err(ScipOverlayError::InvalidQuery(
+            "query must not be empty".into(),
+        ));
+    }
+    let source = store
+        .semantic_source()
+        .map_err(|error| ScipOverlayError::Store(error.to_string()))?;
+    let Some(source) = source else {
+        return Ok(empty_snapshot());
+    };
+    if !source.repository_verified {
+        return Ok(unverified_repository_snapshot(source));
+    }
+    let limit = usize::try_from(top.clamp(1, 500)).unwrap_or(500);
+    let (mut definitions, definitions_truncated) = store
+        .semantic_definitions(Some(symbol), limit)
+        .map_err(|error| ScipOverlayError::Store(error.to_string()))?;
+    let (mut edges, edges_truncated) = store
+        .semantic_edges(Some(symbol), &[], limit)
+        .map_err(|error| ScipOverlayError::Store(error.to_string()))?;
+    let root = store
+        .meta_value("index_root")
+        .map_err(|error| ScipOverlayError::Store(error.to_string()))?
+        .ok_or_else(|| ScipOverlayError::Store("the index has no repository identity".into()))?;
+    let root = PathBuf::from(root)
+        .canonicalize()
+        .map_err(|error| ScipOverlayError::Store(format!("resolve index root: {error}")))?;
+    let semantic_paths =
+        definitions
+            .iter()
+            .map(|definition| definition.file.clone())
+            .chain(edges.iter().flat_map(|edge| {
+                std::iter::once(edge.from_file.clone()).chain(edge.to_file.clone())
+            }))
+            .collect::<Vec<_>>();
+    let stale = stale_semantic_paths(store, &root, semantic_paths)?;
+    definitions.retain(|definition| !stale.contains(&definition.file));
+    edges.retain(|edge| {
+        !stale.contains(&edge.from_file)
+            && edge
+                .to_file
+                .as_ref()
+                .is_none_or(|path| !stale.contains(path))
+    });
+    let mut diagnostics = revision_diagnostic(&source).into_iter().collect::<Vec<_>>();
+    diagnostics.extend(stale_diagnostic(&stale));
+    Ok(SemanticOverlaySnapshot {
+        schema_version: 1,
+        available: true,
+        partial: definitions_truncated || edges_truncated || !stale.is_empty(),
+        fallback_active: false,
+        source: Some(source),
+        definitions: collection(definitions, definitions_truncated, "definition_limit"),
+        edges: collection(edges, edges_truncated, "semantic_edge_limit"),
+        diagnostics,
+        resolution: resolution(),
+    })
+}
+
+fn unverified_repository_snapshot(source: SemanticSource) -> SemanticOverlaySnapshot {
+    let mut snapshot = empty_snapshot();
+    snapshot.available = true;
+    snapshot.partial = true;
+    snapshot.source = Some(source);
+    snapshot.diagnostics.push(SemanticDiagnostic {
+        code: "semantic_repository_unverified",
+        message: "SCIP evidence was omitted because its repository identity is not verified. Re-import it with `mastermind enrich --scip <index.scip>`.".into(),
+    });
+    snapshot
+}
+
+fn collection<T>(items: Vec<T>, truncated: bool, reason: &'static str) -> SemanticCollection<T> {
+    let returned = u32::try_from(items.len()).unwrap_or(u32::MAX);
+    SemanticCollection {
+        total: (!truncated).then_some(returned),
+        returned,
+        truncated,
+        truncation_reason: truncated.then_some(reason),
+        items,
+    }
+}
+
+fn stale_semantic_paths(
+    store: &Store,
+    root: &Path,
+    paths: impl IntoIterator<Item = String>,
+) -> Result<BTreeSet<String>, ScipOverlayError> {
+    let paths = paths.into_iter().collect::<BTreeSet<_>>();
+    let path_vec = paths.iter().cloned().collect::<Vec<_>>();
+    let hashes = store
+        .semantic_document_hashes(&path_vec)
+        .map_err(|error| ScipOverlayError::Store(error.to_string()))?;
+    let mut stale = paths;
+    for (path, expected) in hashes {
+        stale.remove(&path);
+        let actual = root.join(&path).canonicalize().ok().and_then(|resolved| {
+            resolved
+                .starts_with(root)
+                .then(|| hash_file(&resolved).ok().map(|value| value.0))
+                .flatten()
+        });
+        if actual.as_deref() != Some(expected.as_str()) {
+            stale.insert(path);
+        }
+    }
+    Ok(stale)
+}
+
+fn revision_diagnostic(source: &SemanticSource) -> Option<SemanticDiagnostic> {
+    (!source.revision_verified).then(|| SemanticDiagnostic {
+        code: "semantic_artifact_revision_unverified",
+        message: "The SCIP producer omitted embedded text for at least one document. Mastermind can detect changes after import, but cannot prove that every imported semantic fact was generated from the current revision.".into(),
+    })
+}
+
+fn stale_diagnostic(stale: &BTreeSet<String>) -> Option<SemanticDiagnostic> {
+    if stale.is_empty() {
+        return None;
+    }
+    let sample = stale.iter().take(5).cloned().collect::<Vec<_>>().join(", ");
+    Some(SemanticDiagnostic {
+        code: "semantic_overlay_stale",
+        message: format!(
+            "SCIP evidence was omitted for {} changed or unavailable document(s): {sample}. Re-run the language indexer and `mastermind enrich --scip <index.scip>`.",
+            stale.len()
+        ),
+    })
+}
+
+pub fn for_lens(
+    store: &Store,
+    root: &Path,
+    relevant_paths: impl IntoIterator<Item = String>,
+) -> Result<SemanticOverlaySnapshot, ScipOverlayError> {
+    let source = store
+        .semantic_source()
+        .map_err(|error| ScipOverlayError::Store(error.to_string()))?;
+    let Some(source) = source else {
+        return Ok(empty_snapshot());
+    };
+    if !source.repository_verified {
+        return Ok(unverified_repository_snapshot(source));
+    }
+    let paths = relevant_paths.into_iter().collect::<BTreeSet<_>>();
+    let path_vec = paths.into_iter().collect::<Vec<_>>();
+    let (mut edges, edges_truncated) = if path_vec.is_empty() {
+        (Vec::new(), false)
+    } else {
+        store
+            .semantic_edges(None, &path_vec, MAX_LENS_SEMANTIC_EDGES)
+            .map_err(|error| ScipOverlayError::Store(error.to_string()))?
+    };
+    let edge_paths = edges
+        .iter()
+        .flat_map(|edge| std::iter::once(edge.from_file.clone()).chain(edge.to_file.clone()))
+        .collect::<Vec<_>>();
+    let stale = stale_semantic_paths(store, root, edge_paths)?;
+    edges.retain(|edge| {
+        !stale.contains(&edge.from_file)
+            && edge
+                .to_file
+                .as_ref()
+                .is_none_or(|path| !stale.contains(path))
+    });
+    let mut diagnostics = revision_diagnostic(&source).into_iter().collect::<Vec<_>>();
+    diagnostics.extend(stale_diagnostic(&stale));
+    let partial = edges_truncated || !stale.is_empty();
+    Ok(SemanticOverlaySnapshot {
+        schema_version: 1,
+        available: true,
+        partial,
+        fallback_active: false,
+        source: Some(source),
+        definitions: collection(Vec::new(), false, "definition_limit"),
+        edges: collection(edges, edges_truncated, "semantic_edge_limit"),
+        diagnostics,
+        resolution: resolution(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use protobuf::{EnumOrUnknown, Message, MessageField};
+    use scip::types::{
+        occurrence, Document, Index, Metadata, MultiLineRange, Occurrence, Relationship,
+        SingleLineRange, SymbolInformation, SymbolRole, ToolInfo,
+    };
+    use tempfile::TempDir;
+
+    fn definition(symbol: &str, line: i32, body_start: i32, body_end: i32) -> Occurrence {
+        let mut occurrence = Occurrence::new();
+        occurrence.symbol = symbol.into();
+        occurrence.symbol_roles = SymbolRole::Definition as i32;
+        occurrence.typed_range = Some(occurrence::Typed_range::SingleLineRange(SingleLineRange {
+            line,
+            start_character: 3,
+            end_character: 8,
+            ..Default::default()
+        }));
+        occurrence.typed_enclosing_range = Some(
+            occurrence::Typed_enclosing_range::MultiLineEnclosingRange(MultiLineRange {
+                start_line: body_start,
+                start_character: 0,
+                end_line: body_end,
+                end_character: 100,
+                ..Default::default()
+            }),
+        );
+        occurrence
+    }
+
+    fn reference(symbol: &str, line: i32) -> Occurrence {
+        let mut occurrence = Occurrence::new();
+        occurrence.symbol = symbol.into();
+        occurrence.typed_range = Some(occurrence::Typed_range::SingleLineRange(SingleLineRange {
+            line,
+            start_character: 4,
+            end_character: 9,
+            ..Default::default()
+        }));
+        occurrence
+    }
+
+    fn symbol(symbol: &str, display: &str) -> SymbolInformation {
+        let mut info = SymbolInformation::new();
+        info.symbol = symbol.into();
+        info.display_name = display.into();
+        info.kind = EnumOrUnknown::from_i32(17);
+        info
+    }
+
+    fn fixture() -> (TempDir, Store, PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("repo");
+        std::fs::create_dir(&root).unwrap();
+        let a_text = "int target() { return 1; }\n";
+        let b_text = "int caller() {\n  return target();\n}\n";
+        std::fs::write(root.join("a.cpp"), a_text).unwrap();
+        std::fs::write(root.join("b.cpp"), b_text).unwrap();
+        let db = temp.path().join("index.db");
+        let store = Store::open(&db).unwrap();
+        store
+            .set_meta("index_root", root.canonicalize().unwrap().to_str().unwrap())
+            .unwrap();
+
+        let target = "scip-clang . demo . target().";
+        let caller = "scip-clang . demo . caller().";
+        let mut target_info = symbol(target, "target");
+        target_info.relationships.push(Relationship {
+            symbol: caller.into(),
+            is_definition: true,
+            ..Default::default()
+        });
+        let mut a = Document::new();
+        a.relative_path = "a.cpp".into();
+        a.language = "cpp".into();
+        a.text = a_text.into();
+        a.occurrences.push(definition(target, 0, 0, 0));
+        a.symbols.push(target_info);
+
+        let mut b = Document::new();
+        b.relative_path = "b.cpp".into();
+        b.language = "cpp".into();
+        b.text = b_text.into();
+        b.occurrences.push(definition(caller, 0, 0, 2));
+        b.occurrences.push(reference(target, 1));
+        b.symbols.push(symbol(caller, "caller"));
+
+        let mut index = Index::new();
+        index.metadata = MessageField::some(Metadata {
+            project_root: format!("file://{}", root.display()),
+            tool_info: MessageField::some(ToolInfo {
+                name: "scip-clang".into(),
+                version: "test".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        index.documents = vec![a, b];
+        let scip_path = temp.path().join("index.scip");
+        scip::write_message_to_file(&scip_path, index).unwrap();
+        (temp, store, scip_path)
+    }
+
+    #[test]
+    fn import_keeps_semantic_facts_separate_and_resolves_reference_owner() {
+        let (_temp, store, path) = fixture();
+        let summary = import(&store, &path).unwrap();
+        assert_eq!(summary.source.documents, 2);
+        assert_eq!(summary.source.text_verified_documents, 2);
+        assert!(summary.source.repository_verified);
+        assert!(summary.source.revision_verified);
+
+        let snapshot = query(&store, "target", 20).unwrap();
+        assert!(snapshot.available);
+        assert_eq!(
+            snapshot.resolution.static_precedence,
+            ["scip", "tree-sitter"]
+        );
+        let reference = snapshot
+            .edges
+            .items
+            .iter()
+            .find(|edge| edge.kind == "reference")
+            .unwrap();
+        assert_eq!(reference.from_display_name.as_deref(), Some("caller"));
+        assert_eq!(reference.from_file, "b.cpp");
+        assert_eq!(reference.from_line, 1);
+        assert_eq!(reference.occurrence_line, 2);
+        assert_eq!(reference.to_file.as_deref(), Some("a.cpp"));
+        assert_eq!(reference.to_line, Some(1));
+        assert_eq!(reference.provenance, "scip");
+        assert_eq!(reference.confidence, "high");
+
+        assert_eq!(store.callers_of("target", None, None).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn malformed_path_does_not_replace_previous_overlay() {
+        let (_temp, store, path) = fixture();
+        import(&store, &path).unwrap();
+        let previous = store.semantic_source().unwrap().unwrap().artifact_sha256;
+
+        let mut bad = Index::new();
+        let mut document = Document::new();
+        document.relative_path = "../outside.cpp".into();
+        bad.documents.push(document);
+        scip::write_message_to_file(&path, bad).unwrap();
+        assert!(import(&store, &path).is_err());
+        assert_eq!(
+            store.semantic_source().unwrap().unwrap().artifact_sha256,
+            previous
+        );
+    }
+
+    #[test]
+    fn foreign_project_root_without_embedded_text_is_rejected_atomically() {
+        let (temp, store, path) = fixture();
+        import(&store, &path).unwrap();
+        let previous = store.semantic_source().unwrap().unwrap().artifact_sha256;
+
+        let bytes = std::fs::read(&path).unwrap();
+        let mut index = Index::parse_from_bytes(&bytes).unwrap();
+        for document in &mut index.documents {
+            document.text.clear();
+        }
+        let foreign = temp.path().join("foreign-repo");
+        std::fs::create_dir(&foreign).unwrap();
+        index.metadata.as_mut().unwrap().project_root = format!("file://{}", foreign.display());
+        scip::write_message_to_file(&path, index).unwrap();
+
+        let error = import(&store, &path).unwrap_err().to_string();
+        assert!(error.contains("does not match the indexed repository"));
+        assert_eq!(
+            store.semantic_source().unwrap().unwrap().artifact_sha256,
+            previous
+        );
+    }
+
+    #[test]
+    fn lens_omits_stale_semantic_edges_without_breaking_tree_sitter_fallback() {
+        let (temp, store, path) = fixture();
+        import(&store, &path).unwrap();
+        let root = temp.path().join("repo").canonicalize().unwrap();
+        std::fs::write(root.join("b.cpp"), "int caller() { return 2; }\n").unwrap();
+        let snapshot = for_lens(&store, &root, ["a.cpp".into(), "b.cpp".into()]).unwrap();
+        assert!(snapshot.available);
+        assert!(snapshot.partial);
+        assert!(snapshot.edges.items.is_empty());
+        assert_eq!(snapshot.diagnostics[0].code, "semantic_overlay_stale");
+        assert_eq!(snapshot.resolution.default_graph, "tree-sitter");
+
+        let queried = query(&store, "target", 20).unwrap();
+        assert!(queried.edges.items.is_empty());
+        assert!(queried
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "semantic_overlay_stale"));
+    }
+
+    #[test]
+    fn no_overlay_is_an_explicit_non_error_fallback() {
+        let temp = TempDir::new().unwrap();
+        let store = Store::open(temp.path().join("index.db")).unwrap();
+        let snapshot = query(&store, "anything", 10).unwrap();
+        assert!(!snapshot.available);
+        assert!(snapshot.fallback_active);
+        assert_eq!(snapshot.edges.returned, 0);
+    }
+
+    #[test]
+    fn lens_does_not_leak_the_whole_overlay_without_relevant_paths() {
+        let (temp, store, path) = fixture();
+        import(&store, &path).unwrap();
+        let root = temp.path().join("repo").canonicalize().unwrap();
+        let snapshot = for_lens(&store, &root, Vec::<String>::new()).unwrap();
+        assert!(snapshot.available);
+        assert!(snapshot.edges.items.is_empty());
+    }
+
+    #[test]
+    fn typed_ranges_and_forward_definitions_follow_the_modern_scip_fields() {
+        let mut occurrence = definition("local 0", 4, 4, 4);
+        occurrence.range = vec![99, 1, 2];
+        occurrence.symbol_roles = SymbolRole::ForwardDefinition as i32;
+        assert!(is_definition_occurrence(&occurrence));
+        assert_eq!(occurrence_range(&occurrence).unwrap().start_line, 4);
+    }
+
+    #[test]
+    fn nested_reference_owner_prefers_the_innermost_multiline_definition() {
+        let outer = DefinitionLocator {
+            definition_index: 0,
+            body: SourceRange {
+                start_line: 1,
+                start_character: 20,
+                end_line: 8,
+                end_character: 10,
+            },
+        };
+        let inner = DefinitionLocator {
+            definition_index: 1,
+            body: SourceRange {
+                start_line: 1,
+                start_character: 30,
+                end_line: 8,
+                end_character: 5,
+            },
+        };
+        let reference = SourceRange {
+            start_line: 4,
+            start_character: 1,
+            end_line: 4,
+            end_character: 2,
+        };
+        assert_eq!(
+            owner_for_reference(&[outer, inner], reference)
+                .unwrap()
+                .definition_index,
+            1
+        );
+    }
+
+    #[test]
+    fn embedded_text_verification_honors_scip_utf16_metadata() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("utf16.cpp");
+        let source = "int target() { return 1; }\n";
+        let mut bytes = vec![0xff, 0xfe];
+        for unit in source.encode_utf16() {
+            bytes.extend_from_slice(&unit.to_le_bytes());
+        }
+        std::fs::write(&path, bytes).unwrap();
+        assert!(embedded_text_matches_file(&path, source, TextEncoding::UTF16).unwrap());
+        assert!(!embedded_text_matches_file(&path, "different", TextEncoding::UTF16).unwrap());
+    }
+}

--- a/mcp/servers/mmcg/src/store.rs
+++ b/mcp/servers/mmcg/src/store.rs
@@ -4,13 +4,16 @@
 //!   symbols(id, name, kind, file_path, line_start, line_end, signature, parent_id)
 //!   edges(id, from_id, to_id?, to_name, kind, line)
 //!   files(path, indexed_at, symbol_count)
+//!   semantic_* (optional compiler-resolved overlay; never rewrites the graph)
 //!   meta(key, value)
 
+use crate::scip_overlay::{SemanticDefinition, SemanticEdge, SemanticImportBatch, SemanticSource};
 use rusqlite::{
     params, types::Value as SqlValue, Connection, OpenFlags, OptionalExtension, Result as SqlResult,
 };
 use serde::{Deserialize, Serialize};
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
@@ -1069,6 +1072,83 @@ impl Store {
             );
             CREATE INDEX IF NOT EXISTS idx_scratchpad_ts ON scratchpad(ts);
             CREATE INDEX IF NOT EXISTS idx_scratchpad_agent ON scratchpad(agent);
+
+            -- Optional SCIP semantic overlay. These tables are additive and
+            -- deliberately separate from `symbols` / `edges`: Tree-sitter is
+            -- still the default graph and remains usable when no overlay exists.
+            CREATE TABLE IF NOT EXISTS semantic_sources (
+                id                       INTEGER PRIMARY KEY CHECK (id = 1),
+                tool_name                TEXT NOT NULL,
+                tool_version             TEXT NOT NULL,
+                project_root             TEXT NOT NULL,
+                artifact_path            TEXT NOT NULL,
+                artifact_sha256          TEXT NOT NULL,
+                imported_at              INTEGER NOT NULL,
+                document_count           INTEGER NOT NULL,
+                definition_count         INTEGER NOT NULL,
+                edge_count               INTEGER NOT NULL,
+                text_verified_documents  INTEGER NOT NULL,
+                repository_verified      INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE IF NOT EXISTS semantic_documents (
+                path                  TEXT PRIMARY KEY,
+                source_id             INTEGER NOT NULL REFERENCES semantic_sources(id) ON DELETE CASCADE,
+                language              TEXT NOT NULL,
+                position_encoding     TEXT NOT NULL,
+                content_sha256        TEXT NOT NULL,
+                source_text_verified  INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_semantic_documents_source
+                ON semantic_documents(source_id);
+            CREATE TABLE IF NOT EXISTS semantic_definitions (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_id      INTEGER NOT NULL REFERENCES semantic_sources(id) ON DELETE CASCADE,
+                symbol         TEXT NOT NULL,
+                display_name   TEXT NOT NULL,
+                kind           TEXT NOT NULL,
+                file_path      TEXT NOT NULL REFERENCES semantic_documents(path) ON DELETE CASCADE,
+                line           INTEGER NOT NULL,
+                character      INTEGER NOT NULL,
+                end_line       INTEGER NOT NULL,
+                end_character  INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_semantic_definitions_symbol
+                ON semantic_definitions(symbol);
+            CREATE INDEX IF NOT EXISTS idx_semantic_definitions_display
+                ON semantic_definitions(display_name);
+            CREATE INDEX IF NOT EXISTS idx_semantic_definitions_file
+                ON semantic_definitions(file_path);
+            CREATE TABLE IF NOT EXISTS semantic_edges (
+                id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_id          INTEGER NOT NULL REFERENCES semantic_sources(id) ON DELETE CASCADE,
+                from_symbol        TEXT,
+                from_display_name  TEXT,
+                from_file          TEXT NOT NULL REFERENCES semantic_documents(path) ON DELETE CASCADE,
+                from_line          INTEGER NOT NULL,
+                from_character     INTEGER NOT NULL,
+                occurrence_line    INTEGER NOT NULL,
+                occurrence_character INTEGER NOT NULL,
+                to_symbol          TEXT NOT NULL,
+                to_display_name    TEXT NOT NULL,
+                to_file            TEXT REFERENCES semantic_documents(path) ON DELETE CASCADE,
+                to_line            INTEGER,
+                to_character       INTEGER,
+                kind               TEXT NOT NULL,
+                UNIQUE (
+                    source_id, from_symbol, from_file, from_line, from_character,
+                    occurrence_line, occurrence_character, to_symbol, to_file, kind
+                )
+            );
+            CREATE INDEX IF NOT EXISTS idx_semantic_edges_from_symbol
+                ON semantic_edges(from_symbol);
+            CREATE INDEX IF NOT EXISTS idx_semantic_edges_to_symbol
+                ON semantic_edges(to_symbol);
+            CREATE INDEX IF NOT EXISTS idx_semantic_edges_from_file
+                ON semantic_edges(from_file);
+            CREATE INDEX IF NOT EXISTS idx_semantic_edges_to_file
+                ON semantic_edges(to_file);
+            CREATE INDEX IF NOT EXISTS idx_semantic_edges_kind
+                ON semantic_edges(kind);
             "#,
         )?;
 
@@ -1083,6 +1163,10 @@ impl Store {
             "ALTER TABLE files ADD COLUMN content_sha256 TEXT NOT NULL DEFAULT ''",
             [],
         );
+        let _ = self.conn.execute(
+            "ALTER TABLE semantic_sources ADD COLUMN repository_verified INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
 
         // Stamp the active version on first init and after a derived-schema
         // rebuild. Other metadata — especially index_root — remains intact.
@@ -1092,6 +1176,329 @@ impl Store {
             params![SCHEMA_VERSION],
         )?;
         Ok(())
+    }
+
+    fn semantic_tables_exist(&self) -> SqlResult<bool> {
+        self.conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master
+                 WHERE type = 'table' AND name = 'semantic_sources'",
+                [],
+                |_| Ok(true),
+            )
+            .optional()
+            .map(|value| value.unwrap_or(false))
+    }
+
+    fn semantic_repository_verified_column_exists(&self) -> SqlResult<bool> {
+        self.conn
+            .query_row(
+                "SELECT 1 FROM pragma_table_info('semantic_sources')
+                 WHERE name = 'repository_verified'",
+                [],
+                |_| Ok(true),
+            )
+            .optional()
+            .map(|value| value.unwrap_or(false))
+    }
+
+    /// Metadata for the currently imported compiler-resolved overlay.
+    /// `None` is the normal Tree-sitter-only state, including a v7 database
+    /// created by an older binary before the additive semantic tables existed.
+    pub fn semantic_source(&self) -> SqlResult<Option<SemanticSource>> {
+        if !self.semantic_tables_exist()? {
+            return Ok(None);
+        }
+        let repository_verified = if self.semantic_repository_verified_column_exists()? {
+            "repository_verified"
+        } else {
+            "0 AS repository_verified"
+        };
+        self.conn
+            .query_row(
+                &format!(
+                    "SELECT tool_name, tool_version, project_root, artifact_path,
+                        artifact_sha256, imported_at, document_count,
+                        definition_count, edge_count, text_verified_documents,
+                        {repository_verified}
+                     FROM semantic_sources WHERE id = 1"
+                ),
+                [],
+                |row| {
+                    let documents = row.get::<_, u32>(6)?;
+                    let text_verified_documents = row.get::<_, u32>(9)?;
+                    Ok(SemanticSource {
+                        format: "scip",
+                        tool_name: row.get(0)?,
+                        tool_version: row.get(1)?,
+                        project_root: row.get(2)?,
+                        artifact_path: row.get(3)?,
+                        artifact_sha256: row.get(4)?,
+                        imported_at: row.get(5)?,
+                        documents,
+                        definitions: row.get(7)?,
+                        edges: row.get(8)?,
+                        text_verified_documents,
+                        repository_verified: row.get(10)?,
+                        revision_verified: documents > 0 && documents == text_verified_documents,
+                    })
+                },
+            )
+            .optional()
+    }
+
+    /// Atomically replace the entire SCIP snapshot after it has been decoded
+    /// and validated in memory. Any parse/path/range error therefore leaves the
+    /// previous known-good overlay intact.
+    pub(crate) fn replace_semantic_overlay(&self, batch: &SemanticImportBatch) -> SqlResult<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute("DELETE FROM semantic_sources", [])?;
+        tx.execute(
+            "INSERT INTO semantic_sources(
+                id, tool_name, tool_version, project_root, artifact_path,
+                artifact_sha256, imported_at, document_count, definition_count,
+                edge_count, text_verified_documents, repository_verified
+             ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            params![
+                batch.source.tool_name,
+                batch.source.tool_version,
+                batch.source.project_root,
+                batch.source.artifact_path,
+                batch.source.artifact_sha256,
+                batch.source.imported_at,
+                batch.source.documents,
+                batch.source.definitions,
+                batch.source.edges,
+                batch.source.text_verified_documents,
+                batch.source.repository_verified,
+            ],
+        )?;
+        {
+            let mut statement = tx.prepare(
+                "INSERT INTO semantic_documents(
+                    path, source_id, language, position_encoding,
+                    content_sha256, source_text_verified
+                 ) VALUES (?1, 1, ?2, ?3, ?4, ?5)",
+            )?;
+            for document in &batch.documents {
+                statement.execute(params![
+                    document.path,
+                    document.language,
+                    document.position_encoding,
+                    document.content_sha256,
+                    document.source_text_verified,
+                ])?;
+            }
+        }
+        {
+            let mut statement = tx.prepare(
+                "INSERT INTO semantic_definitions(
+                    source_id, symbol, display_name, kind, file_path, line,
+                    character, end_line, end_character
+                 ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            )?;
+            for definition in &batch.definitions {
+                statement.execute(params![
+                    definition.symbol,
+                    definition.display_name,
+                    definition.kind,
+                    definition.file,
+                    definition.line,
+                    definition.character,
+                    definition.end_line,
+                    definition.end_character,
+                ])?;
+            }
+        }
+        {
+            let mut statement = tx.prepare(
+                "INSERT OR IGNORE INTO semantic_edges(
+                    source_id, from_symbol, from_display_name, from_file,
+                    from_line, from_character, occurrence_line,
+                    occurrence_character, to_symbol, to_display_name,
+                    to_file, to_line, to_character, kind
+                 ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            )?;
+            for edge in &batch.edges {
+                statement.execute(params![
+                    edge.from_symbol,
+                    edge.from_display_name,
+                    edge.from_file,
+                    edge.from_line,
+                    edge.from_character,
+                    edge.occurrence_line,
+                    edge.occurrence_character,
+                    edge.to_symbol,
+                    edge.to_display_name,
+                    edge.to_file,
+                    edge.to_line,
+                    edge.to_character,
+                    edge.kind,
+                ])?;
+            }
+        }
+        tx.commit()
+    }
+
+    pub(crate) fn semantic_definitions(
+        &self,
+        query: Option<&str>,
+        limit: usize,
+    ) -> SqlResult<(Vec<SemanticDefinition>, bool)> {
+        if !self.semantic_tables_exist()? {
+            return Ok((Vec::new(), false));
+        }
+        let limit = limit.clamp(1, 5_000);
+        let mut sql = String::from(
+            "SELECT symbol, display_name, kind, file_path, line, character,
+                    end_line, end_character
+             FROM semantic_definitions",
+        );
+        let mut values = Vec::<SqlValue>::new();
+        if let Some(query) = query {
+            sql.push_str(" WHERE instr(lower(symbol || ' ' || display_name), lower(?)) > 0");
+            values.push(query.to_string().into());
+        }
+        sql.push_str(" ORDER BY file_path, line, character, symbol LIMIT ?");
+        values.push(
+            i64::try_from(limit.saturating_add(1))
+                .unwrap_or(i64::MAX)
+                .into(),
+        );
+        let mut statement = self.conn.prepare(&sql)?;
+        let rows = statement.query_map(rusqlite::params_from_iter(values.iter()), |row| {
+            Ok(SemanticDefinition {
+                symbol: row.get(0)?,
+                display_name: row.get(1)?,
+                kind: row.get(2)?,
+                file: row.get(3)?,
+                line: row.get(4)?,
+                character: row.get(5)?,
+                end_line: row.get(6)?,
+                end_character: row.get(7)?,
+                provenance: "scip",
+                confidence: "high",
+            })
+        })?;
+        let mut items = rows.collect::<SqlResult<Vec<_>>>()?;
+        let truncated = items.len() > limit;
+        items.truncate(limit);
+        Ok((items, truncated))
+    }
+
+    pub(crate) fn semantic_edges(
+        &self,
+        query: Option<&str>,
+        relevant_paths: &[String],
+        limit: usize,
+    ) -> SqlResult<(Vec<SemanticEdge>, bool)> {
+        if !self.semantic_tables_exist()? {
+            return Ok((Vec::new(), false));
+        }
+        let limit = limit.clamp(1, 10_000);
+        let relevant_paths = relevant_paths.iter().take(2_000).collect::<Vec<_>>();
+        let mut values = Vec::<SqlValue>::new();
+        let mut sql = String::new();
+        if !relevant_paths.is_empty() {
+            sql.push_str("WITH relevant(path) AS (VALUES ");
+            for (index, path) in relevant_paths.iter().enumerate() {
+                if index > 0 {
+                    sql.push(',');
+                }
+                sql.push_str("(?)");
+                values.push((*path).clone().into());
+            }
+            sql.push_str(") ");
+        }
+        sql.push_str(
+            "SELECT from_symbol, from_display_name, from_file, from_line,
+                    from_character, occurrence_line, occurrence_character,
+                    to_symbol, to_display_name, to_file, to_line, to_character, kind
+             FROM semantic_edges",
+        );
+        let mut predicates = Vec::new();
+        if !relevant_paths.is_empty() {
+            predicates.push(
+                "(from_file IN (SELECT path FROM relevant)
+                  AND to_file IN (SELECT path FROM relevant))",
+            );
+        }
+        if let Some(query) = query {
+            predicates.push(
+                "instr(lower(
+                    coalesce(from_symbol, '') || ' ' ||
+                    coalesce(from_display_name, '') || ' ' ||
+                    to_symbol || ' ' || to_display_name
+                 ), lower(?)) > 0",
+            );
+            values.push(query.to_string().into());
+        }
+        if !predicates.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&predicates.join(" AND "));
+        }
+        sql.push_str(" ORDER BY from_file, from_line, from_character, to_symbol, kind LIMIT ?");
+        values.push(
+            i64::try_from(limit.saturating_add(1))
+                .unwrap_or(i64::MAX)
+                .into(),
+        );
+        let mut statement = self.conn.prepare(&sql)?;
+        let rows = statement.query_map(rusqlite::params_from_iter(values.iter()), |row| {
+            Ok(SemanticEdge {
+                from_symbol: row.get(0)?,
+                from_display_name: row.get(1)?,
+                from_file: row.get(2)?,
+                from_line: row.get(3)?,
+                from_character: row.get(4)?,
+                occurrence_line: row.get(5)?,
+                occurrence_character: row.get(6)?,
+                to_symbol: row.get(7)?,
+                to_display_name: row.get(8)?,
+                to_file: row.get(9)?,
+                to_line: row.get(10)?,
+                to_character: row.get(11)?,
+                kind: row.get(12)?,
+                provenance: "scip",
+                confidence: "high",
+            })
+        })?;
+        let mut items = rows.collect::<SqlResult<Vec<_>>>()?;
+        let truncated = items.len() > limit;
+        items.truncate(limit);
+        Ok((items, truncated))
+    }
+
+    pub(crate) fn semantic_document_hashes(
+        &self,
+        paths: &[String],
+    ) -> SqlResult<HashMap<String, String>> {
+        if !self.semantic_tables_exist()? || paths.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut hashes = HashMap::new();
+        for chunk in paths.chunks(500) {
+            let placeholders = std::iter::repeat_n("?", chunk.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let sql = format!(
+                "SELECT path, content_sha256 FROM semantic_documents
+                 WHERE path IN ({placeholders})"
+            );
+            let values = chunk
+                .iter()
+                .map(|path| SqlValue::from((*path).clone()))
+                .collect::<Vec<_>>();
+            let mut statement = self.conn.prepare(&sql)?;
+            let rows = statement.query_map(rusqlite::params_from_iter(values.iter()), |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
+            for row in rows {
+                let (path, digest) = row?;
+                hashes.insert(path, digest);
+            }
+        }
+        Ok(hashes)
     }
 
     /// Wipe everything related to a single file before re-indexing it.
@@ -3158,6 +3565,37 @@ mod tests {
         let store = Store::open(&path).unwrap();
         assert_eq!(store.symbol_count().unwrap(), 0);
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn read_only_legacy_semantic_source_fails_closed_without_identity_column() {
+        let path = tmp_db("legacy_semantic_source");
+        {
+            let connection = rusqlite::Connection::open(&path).unwrap();
+            connection
+                .execute_batch(
+                    "CREATE TABLE semantic_sources (
+                        id INTEGER PRIMARY KEY,
+                        tool_name TEXT NOT NULL,
+                        tool_version TEXT NOT NULL,
+                        project_root TEXT NOT NULL,
+                        artifact_path TEXT NOT NULL,
+                        artifact_sha256 TEXT NOT NULL,
+                        imported_at INTEGER NOT NULL,
+                        document_count INTEGER NOT NULL,
+                        definition_count INTEGER NOT NULL,
+                        edge_count INTEGER NOT NULL,
+                        text_verified_documents INTEGER NOT NULL
+                    );
+                    INSERT INTO semantic_sources VALUES
+                        (1, 'legacy', '1', '/repo', '/tmp/index.scip', 'sha', 1, 1, 1, 1, 1);",
+                )
+                .unwrap();
+        }
+        let store = Store::open_read_only(&path).unwrap();
+        let source = store.semantic_source().unwrap().unwrap();
+        assert!(!source.repository_verified);
+        std::fs::remove_file(path).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add optional SCIP semantic enrichment without replacing the default Tree-sitter graph
- persist semantic definitions and edges separately, with provenance exposed through CLI, MCP, and Lens
- validate repository identity and revision, and import protobuf data with bounded streaming

## Validation

- `just check`
  - Rust: 470 library + 48 binary + 20 golden tests
  - validator: 39 artifacts, 0 errors, 0 warnings
  - npm: 17 tests
  - security fixtures: 36 tests
  - eval harness: 16 tests
  - Lens DOM: 1 test
  - cargo-deny: advisories, bans, licenses, and sources passed
- `cargo package --locked --allow-dirty`

## Behavior

- Tree-sitter remains the default and fallback
- SCIP evidence is optional and reported as `confidence=high`
- runtime evidence remains `confidence=observed`
- failed, stale, or foreign SCIP imports fail closed and preserve the last good overlay

## Review

Draft pending independent review of the public CLI, MCP, and SQLite contracts.
