### PR TITLE
feat(mmcg): add architecture policy as code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `mastermind policy check --since <ref>` evaluates a strict v1
+  `mastermind-policy.yml` DSL over normalized codegraph, Git, CODEOWNERS, test,
+  and workflow evidence. It covers forbidden dependency directions, new-cycle
+  and blast-radius budgets, observed API-owner requirements, related tests,
+  ownership crossings, and held strict-workflow evidence. Text, JSON, and SARIF
+  outputs fail closed when relevant evidence is truncated or unavailable.
+  Strict evidence is bound to the audited touch-file snapshot, related tests
+  must be graph-linked or in scope, and report cardinality is bounded.
 - `mastermind enrich --scip index.scip` adds an optional compiler-resolved
   semantic layer without replacing the default Tree-sitter graph. SCIP
   definitions, references, implementations, and type definitions are stored in

--- a/Dockerfile.audit-action
+++ b/Dockerfile.audit-action
@@ -1,6 +1,7 @@
 FROM rust:1.96-bookworm@sha256:a339861ae23e9abb272cea45dfafde21760d2ce6577a70f8a926153677902663 AS builder
 WORKDIR /source
 COPY mcp/servers/mmcg/Cargo.toml mcp/servers/mmcg/Cargo.lock ./mcp/servers/mmcg/
+COPY mcp/servers/mmcg/build.rs ./mcp/servers/mmcg/build.rs
 COPY mcp/servers/mmcg/src ./mcp/servers/mmcg/src
 COPY mcp/servers/mmcg/assets ./mcp/servers/mmcg/assets
 COPY mcp/servers/mmcg/templates ./mcp/servers/mmcg/templates

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ cd your-project
 mastermind index .
 mastermind map .
 mastermind impact --since main
+mastermind policy check --since main
 mastermind ui --since main
 ```
 
@@ -152,6 +153,37 @@ artifact URIs so dependency cycles and cross-component change risks can be
 uploaded through GitHub's standard SARIF workflow. They export only returned
 bounded findings and preserve partial-result metadata; an empty partial export
 is not a clean verdict.
+
+### Enforce architecture policy as code
+
+Keep a small, reviewable `mastermind-policy.yml` in the repository and evaluate
+it against the same bounded change graph used by impact and Lens:
+
+```yaml
+version: 1
+rules:
+  - id: domain-must-not-import-infrastructure
+    from: src/domain/**
+    deny_imports: src/infrastructure/**
+  - id: no-new-payment-cycles
+    scope: services/payment/**
+    max_new_cycles: 0
+  - id: public-api-review
+    when: api_surface_changed
+    require_owner: platform
+```
+
+```bash
+mastermind policy check --since main
+mastermind policy check --since main --format sarif > mastermind-policy.sarif
+```
+
+The v1 DSL also supports blast-radius budgets, related-test requirements,
+CODEOWNERS boundary checks, and held strict-workflow evidence for critical
+paths. A check exits non-zero for either a violation or incomplete evidence; a
+work limit can never become a clean result. See the complete
+[example policy](docs/examples/mastermind-policy.yml) and
+[CLI contract](docs/reference/mmcg.md#architecture-policy-as-code-mmcg-policy-check).
 
 ### Review architecture invariants
 

--- a/docs/examples/mastermind-policy.yml
+++ b/docs/examples/mastermind-policy.yml
@@ -1,0 +1,29 @@
+version: 1
+rules:
+  - id: domain-must-not-import-infrastructure
+    from: src/domain/**
+    deny_imports: src/infrastructure/**
+
+  - id: no-new-payment-cycles
+    scope: services/payment/**
+    max_new_cycles: 0
+
+  - id: public-api-review
+    when: api_surface_changed
+    require_owner: platform
+
+  - id: payment-blast-budget
+    scope: services/payment/**
+    max_blast_radius: 25
+
+  - id: payment-needs-tests
+    scope: services/payment/**
+    require_tests: true
+
+  - id: payment-ownership-boundary
+    scope: services/payment/**
+    deny_ownership_crossings: true
+
+  - id: critical-payment-workflow
+    critical: services/payment/**
+    require_workflow: strict

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -136,6 +136,11 @@ mmcg impact --since main --format text --depth 3 --top 100
 mmcg impact --since HEAD~1 --format json
 mmcg impact --since main --format sarif > mastermind-impact.sarif
 
+# Evaluate repository-owned architecture rules. Violations and incomplete
+# evidence both exit non-zero.
+mmcg policy check --since main
+mmcg policy check --since main --format sarif > mastermind-policy.sarif
+
 # Serve the local, read-only diff-first Lens UI on an ephemeral loopback port.
 mmcg ui --since main
 mmcg ui --since origin/main --path src --depth 2 --top 50 --production-only
@@ -401,6 +406,105 @@ files so GitHub can populate missing fingerprints. Stable `ruleId` values and
 consistent relative paths are retained across runs for alert identity.
 See [GitHub's SARIF support contract](https://docs.github.com/en/code-security/reference/code-scanning/sarif-files/sarif-support)
 for ingestion limits and PR annotation behavior.
+
+## Architecture policy as code (`mmcg policy check`)
+
+`mmcg policy check --since REF` evaluates a repository-owned
+`mastermind-policy.yml` over one normalized evidence input. Git/SQLite,
+CODEOWNERS, and strict workflow artifacts are collected first; the policy
+evaluator itself is deterministic and has no Rego, OPA daemon, network access,
+or embedded general-purpose runtime.
+
+```yaml
+version: 1
+rules:
+  - id: domain-must-not-import-infrastructure
+    from: src/domain/**
+    deny_imports: src/infrastructure/**
+
+  - id: no-new-payment-cycles
+    scope: services/payment/**
+    max_new_cycles: 0
+
+  - id: public-api-review
+    when: api_surface_changed
+    require_owner: platform
+
+  - id: payment-blast-budget
+    scope: services/payment/**
+    max_blast_radius: 25
+
+  - id: payment-needs-tests
+    scope: services/payment/**
+    require_tests: true
+
+  - id: payment-ownership-boundary
+    scope: services/payment/**
+    deny_ownership_crossings: true
+
+  - id: critical-payment-workflow
+    critical: services/payment/**
+    require_workflow: strict
+```
+
+The schema is intentionally closed: unknown keys, duplicate IDs, invalid globs,
+more than one action in a rule, no-op booleans, and configurations above 100
+rules are errors.
+The default file is `mastermind-policy.yml`; use `--config PATH` to select a
+different file inside the repository. A symlink that resolves outside the
+repository is rejected. Paths are repository-relative glob patterns with `/`
+separators.
+
+Evaluation is diff-first:
+
+- `deny_imports` reports current forbidden import edges only when the source
+  file is part of the baseline-to-working-tree change;
+- `max_new_cycles` compares current SCC membership with the exact baseline Git
+  blobs, without checking out or mutating the baseline worktree;
+- `api_surface_changed` means an observed changed symbol reaches another
+  inferred top-level component. It is empirical cross-component usage, not a
+  language-level `public`/`export` declaration claim;
+- `max_blast_radius` counts unique returned impacted symbols whose changed seed
+  matches the rule scope;
+- `require_tests` accepts bounded graph-linked candidates or test files inside
+  the configured scope. A test elsewhere under the same top-level directory is
+  not treated as related. The rule does not claim that those tests ran or
+  passed;
+- `deny_ownership_crossings` compares CODEOWNER sets on the changed and
+  impacted sides of an observed component crossing. Missing ownership makes
+  the rule incomplete rather than silently clean;
+- `require_workflow: strict` requires a canonical strict `spec.md`, matching
+  baseline `state.json`, held `audit.md`, and an exact touched-file entry. The
+  held state carries a SHA-256 snapshot of every declared touch, so editing a
+  critical file after the audit invalidates the evidence.
+
+The default workflow evidence directory is `.mastermind/tasks`; CI must restore
+the canonical task artifacts or point `--workflow-evidence PATH` at the
+downloaded evidence directory. CODEOWNERS is discovered in GitHub priority
+order, or overridden with `--codeowners PATH`.
+
+Policy topology stays on the fast default syntactic graph in v1. Imported SCIP
+and runtime overlays retain their provenance for Lens but do not add or remove
+policy edges. Strict workflow evidence validates canonical local artifact
+consistency; it does not prove an audit signature, GitHub approval, or remote CI
+execution.
+
+Impact defaults are depth 3 and top 500 for policy checks. Override them with
+`--depth 1..5` and `--top 1..500`. Import/cycle work is capped at 50,000 file
+edges; baseline cycle comparison is capped at 500 files and 32 MiB; workflow
+evidence is capped at 1,000 tasks and 1 MiB per artifact. A strict snapshot can
+bind at most 1,000 touch files, 16 MiB each and 32 MiB total. Reports stop at
+1,000 total results (reserving one result for the fail-closed diagnostic) and
+become incomplete rather than allocating unbounded SARIF. Any relevant cap, stale index, concurrent snapshot
+change, or unreadable required evidence exits non-zero. JSON and SARIF preserve
+`complete`, diagnostics, baseline/head OIDs, config path, and config SHA-256.
+SARIF uses each configured rule ID as its stable `ruleId`; incomplete evaluation emits
+`mastermind/policy-evaluation-incomplete` at the config location.
+Policy results also include deterministic `partialFingerprints` so repeated
+uploads can retain alert identity when source line numbers move.
+
+See [`docs/examples/mastermind-policy.yml`](../examples/mastermind-policy.yml)
+for all v1 rule forms.
 
 ## MCP server usage
 

--- a/mcp/servers/mmcg/Cargo.toml
+++ b/mcp/servers/mmcg/Cargo.toml
@@ -3,6 +3,7 @@ name = "mmcg"
 version = "1.2.1"
 edition = "2021"
 rust-version = "1.96"
+build = "build.rs"
 description = "Mastermind Codegraph — fast multi-language code indexer (Python, TypeScript, JavaScript, Vue SFC, Rust, C#, Go, Java, PHP, C/C++) with MCP interface. Truth layer for AI coding agents."
 authors = ["mastermind"]
 license = "MIT"

--- a/mcp/servers/mmcg/build.rs
+++ b/mcp/servers/mmcg/build.rs
@@ -1,0 +1,16 @@
+use std::ffi::OsStr;
+
+const WINDOWS_STACK_RESERVE_BYTES: usize = 8 * 1024 * 1024;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ENV");
+
+    let target_os = std::env::var_os("CARGO_CFG_TARGET_OS");
+    let target_env = std::env::var_os("CARGO_CFG_TARGET_ENV");
+    if target_os.as_deref() == Some(OsStr::new("windows"))
+        && target_env.as_deref() == Some(OsStr::new("msvc"))
+    {
+        println!("cargo:rustc-link-arg-bin=mmcg=/STACK:{WINDOWS_STACK_RESERVE_BYTES}");
+    }
+}

--- a/mcp/servers/mmcg/src/lens.rs
+++ b/mcp/servers/mmcg/src/lens.rs
@@ -219,7 +219,11 @@ fn remaining_work_budget(deadline: Option<Instant>) -> WorkBudget {
     }
 }
 
-fn validate_index_snapshot(
+/// Fail-closed freshness proof shared by read-only architecture consumers.
+/// It checks indexed rows against source files and tracked source files against
+/// indexed rows, so deletions and newly tracked files cannot hide in one
+/// direction of the comparison.
+pub(crate) fn validate_index_snapshot(
     store: &Store,
     root: &Path,
     deadline: Option<Instant>,

--- a/mcp/servers/mmcg/src/lib.rs
+++ b/mcp/servers/mmcg/src/lib.rs
@@ -7,6 +7,7 @@
 //!
 //! Supported languages: Python, TypeScript/TSX, JavaScript/JSX, Rust, C#, Go,
 //! Java, PHP, C/C++. C/C++ is best-effort syntactic — see README Limitations.
+//! Repository-owned architecture policies consume the same bounded graph.
 
 pub mod audit_bundle;
 pub mod audit_spec;
@@ -22,6 +23,7 @@ pub mod lens;
 pub mod lessons;
 pub mod mcp;
 pub mod miner;
+pub mod policy;
 pub mod queries;
 pub mod run_task;
 pub mod sarif_export;

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -60,6 +60,14 @@ pub enum ImpactFormat {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[clap(rename_all = "kebab-case")]
+pub enum PolicyFormat {
+    Text,
+    Json,
+    Sarif,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
 pub enum UninstallScope {
     /// This project only: remove `.mastermind/` and the project `.mcp.json` mmcg entry.
     Project,
@@ -142,6 +150,9 @@ enum Cmd {
         #[arg(long, default_value = ".")]
         root: PathBuf,
     },
+    /// Evaluate repository-owned architecture rules over bounded change evidence.
+    #[command(subcommand)]
+    Policy(PolicyCmd),
     /// Serve Mastermind Lens: a local, read-only, diff-first change review UI.
     Ui {
         /// Git ref used as the change-impact baseline.
@@ -478,6 +489,36 @@ enum Cmd {
     /// code-shape style). Output lives under `~/.mastermind/`, not the project.
     #[command(subcommand)]
     Miner(MinerCmd),
+}
+
+#[derive(Subcommand)]
+enum PolicyCmd {
+    /// Check architecture policy against a baseline and exit non-zero on violations or incomplete evidence.
+    Check {
+        /// Git ref used as the diff and cycle-comparison baseline.
+        #[arg(long)]
+        since: String,
+        /// Project root. Defaults to cwd.
+        #[arg(long, default_value = ".")]
+        root: PathBuf,
+        /// Repository-owned v1 policy file.
+        #[arg(long, default_value = "mastermind-policy.yml")]
+        config: PathBuf,
+        #[arg(long, value_enum, default_value_t = PolicyFormat::Text)]
+        format: PolicyFormat,
+        /// Override the repository CODEOWNERS file.
+        #[arg(long, value_name = "PATH")]
+        codeowners: Option<PathBuf>,
+        /// Directory containing canonical strict task evidence.
+        #[arg(long, default_value = ".mastermind/tasks", value_name = "PATH")]
+        workflow_evidence: PathBuf,
+        /// Static caller depth used for blast-radius and boundary evidence.
+        #[arg(long, default_value_t = 3, value_parser = clap::value_parser!(u32).range(1..=5))]
+        depth: u32,
+        /// Maximum returned impacted symbols. Incomplete evidence fails closed.
+        #[arg(long, default_value_t = 500, value_parser = clap::value_parser!(u32).range(1..=500))]
+        top: u32,
+    },
 }
 
 #[derive(Subcommand)]
@@ -921,6 +962,54 @@ fn run_cli_inner(
                 commands::query::render_change_impact(&response, format)?
             );
         }
+        Cmd::Policy(PolicyCmd::Check {
+            since,
+            root,
+            config,
+            format,
+            codeowners,
+            workflow_evidence,
+            depth,
+            top,
+        }) => {
+            let root = root
+                .canonicalize()
+                .map_err(|_| mmcg::policy::PolicyError::new_for_cli("policy_root_unavailable"))?;
+            let index_path = index_path_for_root(index_override.as_deref(), &root);
+            let store = Store::open_read_only(&index_path)
+                .map_err(|_| mmcg::policy::PolicyError::new_for_cli("policy_index_unavailable"))?;
+            let report = mmcg::policy::check(
+                &store,
+                &root,
+                &mmcg::policy::CheckOptions {
+                    since,
+                    config_path: config,
+                    codeowners,
+                    workflow_evidence_path: workflow_evidence,
+                    depth,
+                    top: usize::try_from(top).map_err(|_| {
+                        mmcg::policy::PolicyError::new_for_cli("invalid_policy_limit")
+                    })?,
+                },
+            )?;
+            match format {
+                PolicyFormat::Text => print!("{}", mmcg::policy::render_text(&report)),
+                PolicyFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&report)?);
+                }
+                PolicyFormat::Sarif => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&mmcg::sarif_export::architecture_policy(
+                            &report
+                        ))?
+                    );
+                }
+            }
+            if !report.passed {
+                std::process::exit(1);
+            }
+        }
         Cmd::Ui {
             since,
             root,
@@ -1318,6 +1407,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 fn cli_error_line(error: &(dyn std::error::Error + 'static)) -> String {
     if let Some(error) = error.downcast_ref::<mmcg::queries::ChangeImpactError>() {
         error.code().to_string()
+    } else if let Some(error) = error.downcast_ref::<mmcg::policy::PolicyError>() {
+        error.to_string()
     } else {
         format!("mmcg error: {error}")
     }
@@ -1386,6 +1477,38 @@ mod tests {
             query.cmd,
             Cmd::Query(QueryCmd::Semantic { symbol, top })
                 if symbol == "scip-clang . demo . target()." && top == 25
+        ));
+    }
+
+    #[test]
+    fn architecture_policy_cli_contract_is_explicit() {
+        let cli = Cli::try_parse_from([
+            "mastermind",
+            "policy",
+            "check",
+            "--since",
+            "main",
+            "--format",
+            "sarif",
+            "--config",
+            "architecture.yml",
+            "--workflow-evidence",
+            "policy-evidence",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.cmd,
+            Cmd::Policy(PolicyCmd::Check {
+                since,
+                config,
+                format: PolicyFormat::Sarif,
+                workflow_evidence,
+                depth: 3,
+                top: 500,
+                ..
+            }) if since == "main"
+                && config == std::path::Path::new("architecture.yml")
+                && workflow_evidence == std::path::Path::new("policy-evidence")
         ));
     }
 

--- a/mcp/servers/mmcg/src/policy.rs
+++ b/mcp/servers/mmcg/src/policy.rs
@@ -1,0 +1,1540 @@
+//! Declarative architecture policy checks over bounded codegraph evidence.
+//!
+//! The evaluator is intentionally separate from evidence collection: Git,
+//! SQLite, CODEOWNERS, and workflow artifacts are normalized into
+//! [`PolicyInput`], then a small repository-owned YAML DSL is evaluated as a
+//! pure deterministic function. This keeps the first release understandable
+//! without embedding Rego or another policy runtime.
+
+mod evidence;
+
+use globset::{GlobBuilder, GlobMatcher};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use crate::queries::{ImpactBaseline, ImpactEngine};
+use crate::store::Store;
+
+pub const DEFAULT_CONFIG_PATH: &str = "mastermind-policy.yml";
+pub const DEFAULT_WORKFLOW_EVIDENCE_PATH: &str = ".mastermind/tasks";
+const CONFIG_BYTE_LIMIT: u64 = 1024 * 1024;
+const RULE_LIMIT: usize = 100;
+const RULE_ID_LIMIT: usize = 128;
+const PATTERN_LIMIT: usize = 512;
+const POLICY_RESULT_LIMIT: usize = 1_000;
+
+const FAMILY_IMPORT_GRAPH: &str = "import_graph";
+const FAMILY_CYCLES: &str = "cycles";
+const FAMILY_API: &str = "api_surface";
+const FAMILY_IMPACT: &str = "impact";
+const FAMILY_TESTS: &str = "tests";
+const FAMILY_OWNERSHIP: &str = "ownership";
+const FAMILY_WORKFLOW: &str = "workflow";
+
+#[derive(Debug)]
+pub struct PolicyError {
+    code: &'static str,
+    detail: String,
+}
+
+impl PolicyError {
+    fn new(code: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            code,
+            detail: detail.into(),
+        }
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+
+    pub fn new_for_cli(code: &'static str) -> Self {
+        let detail = match code {
+            "policy_root_unavailable" => "project root cannot be resolved",
+            "policy_index_unavailable" => {
+                "read-only codegraph index is unavailable; run `mastermind index .`"
+            }
+            "invalid_policy_limit" => "policy work limit is invalid",
+            _ => "architecture policy check cannot continue",
+        };
+        Self::new(code, detail)
+    }
+}
+
+impl std::fmt::Display for PolicyError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.detail)
+    }
+}
+
+impl std::error::Error for PolicyError {}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+    #[serde(default = "policy_version")]
+    version: u32,
+    rules: Vec<RawRule>,
+}
+
+fn policy_version() -> u32 {
+    1
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRule {
+    id: String,
+    #[serde(default)]
+    from: Option<String>,
+    #[serde(default)]
+    deny_imports: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    max_new_cycles: Option<u32>,
+    #[serde(default)]
+    when: Option<String>,
+    #[serde(default)]
+    require_owner: Option<String>,
+    #[serde(default)]
+    max_blast_radius: Option<u32>,
+    #[serde(default)]
+    require_tests: Option<bool>,
+    #[serde(default)]
+    deny_ownership_crossings: Option<bool>,
+    #[serde(default)]
+    critical: Option<String>,
+    #[serde(default)]
+    require_workflow: Option<String>,
+}
+
+impl RawRule {
+    fn present_fields(&self) -> Vec<&'static str> {
+        let mut fields = Vec::new();
+        if self.from.is_some() {
+            fields.push("from");
+        }
+        if self.deny_imports.is_some() {
+            fields.push("deny_imports");
+        }
+        if self.scope.is_some() {
+            fields.push("scope");
+        }
+        if self.max_new_cycles.is_some() {
+            fields.push("max_new_cycles");
+        }
+        if self.when.is_some() {
+            fields.push("when");
+        }
+        if self.require_owner.is_some() {
+            fields.push("require_owner");
+        }
+        if self.max_blast_radius.is_some() {
+            fields.push("max_blast_radius");
+        }
+        if self.require_tests.is_some() {
+            fields.push("require_tests");
+        }
+        if self.deny_ownership_crossings.is_some() {
+            fields.push("deny_ownership_crossings");
+        }
+        if self.critical.is_some() {
+            fields.push("critical");
+        }
+        if self.require_workflow.is_some() {
+            fields.push("require_workflow");
+        }
+        fields
+    }
+
+    fn action_count(&self) -> usize {
+        [
+            self.deny_imports.is_some(),
+            self.max_new_cycles.is_some(),
+            self.require_owner.is_some(),
+            self.max_blast_radius.is_some(),
+            self.require_tests.is_some(),
+            self.deny_ownership_crossings.is_some(),
+            self.require_workflow.is_some(),
+        ]
+        .into_iter()
+        .filter(|value| *value)
+        .count()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PathPattern {
+    raw: String,
+    matcher: GlobMatcher,
+}
+
+impl PathPattern {
+    fn compile(raw: String, rule_id: &str, field: &str) -> Result<Self, PolicyError> {
+        let normalized = raw.trim().replace('\\', "/");
+        if normalized.is_empty()
+            || normalized.len() > PATTERN_LIMIT
+            || normalized.starts_with('/')
+            || normalized.starts_with("//")
+            || normalized.as_bytes().get(1) == Some(&b':')
+            || normalized
+                .split('/')
+                .any(|part| part == ".." || part.chars().any(char::is_control))
+        {
+            return Err(config_error(
+                rule_id,
+                format!("`{field}` must be a bounded repository-relative glob"),
+            ));
+        }
+        let glob = GlobBuilder::new(&normalized)
+            .literal_separator(true)
+            .backslash_escape(false)
+            .build()
+            .map_err(|_| config_error(rule_id, format!("`{field}` is not a valid glob")))?;
+        Ok(Self {
+            raw: normalized,
+            matcher: glob.compile_matcher(),
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    fn matches(&self, path: &str) -> bool {
+        self.matcher.is_match(path)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum PolicyRuleKind {
+    DependencyDirection {
+        from: PathPattern,
+        deny_imports: PathPattern,
+    },
+    NewCycles {
+        scope: PathPattern,
+        maximum: u32,
+    },
+    ApiOwner {
+        scope: Option<PathPattern>,
+        owner: String,
+    },
+    BlastRadius {
+        scope: PathPattern,
+        maximum: u32,
+    },
+    RelatedTests {
+        scope: PathPattern,
+    },
+    OwnershipBoundary {
+        scope: PathPattern,
+    },
+    StrictWorkflow {
+        critical: PathPattern,
+    },
+}
+
+impl PolicyRuleKind {
+    fn family(&self) -> &'static str {
+        match self {
+            Self::DependencyDirection { .. } => FAMILY_IMPORT_GRAPH,
+            Self::NewCycles { .. } => FAMILY_CYCLES,
+            Self::ApiOwner { .. } => FAMILY_API,
+            Self::BlastRadius { .. } => FAMILY_IMPACT,
+            Self::RelatedTests { .. } => FAMILY_TESTS,
+            Self::OwnershipBoundary { .. } => FAMILY_OWNERSHIP,
+            Self::StrictWorkflow { .. } => FAMILY_WORKFLOW,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::DependencyDirection { .. } => "forbidden-dependency-direction",
+            Self::NewCycles { .. } => "new-dependency-cycle-budget",
+            Self::ApiOwner { .. } => "public-api-owner-review",
+            Self::BlastRadius { .. } => "blast-radius-budget",
+            Self::RelatedTests { .. } => "related-test-evidence",
+            Self::OwnershipBoundary { .. } => "ownership-boundary-crossing",
+            Self::StrictWorkflow { .. } => "strict-workflow-evidence",
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        match self {
+            Self::DependencyDirection { .. } => {
+                "A changed source file imports a path forbidden by the architecture policy."
+            }
+            Self::NewCycles { .. } => {
+                "The change adds more import dependency cycles than the configured budget."
+            }
+            Self::ApiOwner { .. } => {
+                "An observed cross-component API change lacks the required CODEOWNER."
+            }
+            Self::BlastRadius { .. } => {
+                "The bounded static impact of changed symbols exceeds the configured budget."
+            }
+            Self::RelatedTests { .. } => {
+                "A changed policy scope has no related test candidate in change-impact evidence."
+            }
+            Self::OwnershipBoundary { .. } => {
+                "A changed symbol crosses between disjoint CODEOWNER sets."
+            }
+            Self::StrictWorkflow { .. } => {
+                "A critical changed file lacks matching held strict-workflow evidence."
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PolicyRule {
+    pub id: String,
+    pub kind: PolicyRuleKind,
+}
+
+#[derive(Debug, Clone)]
+pub struct PolicyConfig {
+    pub version: u32,
+    pub rules: Vec<PolicyRule>,
+}
+
+pub fn parse_config(source: &[u8]) -> Result<PolicyConfig, PolicyError> {
+    if source.is_empty() || source.len() as u64 > CONFIG_BYTE_LIMIT {
+        return Err(PolicyError::new(
+            "invalid_policy_config",
+            "policy config must be non-empty and no larger than 1 MiB",
+        ));
+    }
+    let raw: RawConfig = serde_norway::from_slice(source).map_err(|error| {
+        PolicyError::new(
+            "invalid_policy_config",
+            format!("YAML does not match the v1 policy schema: {error}"),
+        )
+    })?;
+    if raw.version != 1 {
+        return Err(PolicyError::new(
+            "unsupported_policy_version",
+            format!("expected version 1, found {}", raw.version),
+        ));
+    }
+    if raw.rules.is_empty() || raw.rules.len() > RULE_LIMIT {
+        return Err(PolicyError::new(
+            "invalid_policy_config",
+            format!("`rules` must contain between 1 and {RULE_LIMIT} entries"),
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    let mut rules = Vec::with_capacity(raw.rules.len());
+    for rule in raw.rules {
+        validate_rule_id(&rule.id)?;
+        if !ids.insert(rule.id.clone()) {
+            return Err(config_error(&rule.id, "rule id is duplicated"));
+        }
+        if rule.action_count() != 1 {
+            return Err(config_error(
+                &rule.id,
+                "exactly one policy action must be configured",
+            ));
+        }
+        let kind = compile_rule(&rule)?;
+        rules.push(PolicyRule { id: rule.id, kind });
+    }
+    rules.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(PolicyConfig { version: 1, rules })
+}
+
+fn validate_rule_id(id: &str) -> Result<(), PolicyError> {
+    let valid = !id.is_empty()
+        && id.len() <= RULE_ID_LIMIT
+        && id.bytes().enumerate().all(|(index, byte)| {
+            byte.is_ascii_alphanumeric() || (index > 0 && b"._-".contains(&byte))
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(PolicyError::new(
+            "invalid_policy_config",
+            "rule ids must start with an alphanumeric byte and contain only alphanumerics, `.`, `_`, or `-`",
+        ))
+    }
+}
+
+fn compile_rule(rule: &RawRule) -> Result<PolicyRuleKind, PolicyError> {
+    if let Some(target) = &rule.deny_imports {
+        ensure_fields(rule, &["from", "deny_imports"])?;
+        return Ok(PolicyRuleKind::DependencyDirection {
+            from: PathPattern::compile(required(&rule.from, rule, "from")?, &rule.id, "from")?,
+            deny_imports: PathPattern::compile(target.clone(), &rule.id, "deny_imports")?,
+        });
+    }
+    if let Some(maximum) = rule.max_new_cycles {
+        ensure_fields(rule, &["scope", "max_new_cycles"])?;
+        return Ok(PolicyRuleKind::NewCycles {
+            scope: PathPattern::compile(required(&rule.scope, rule, "scope")?, &rule.id, "scope")?,
+            maximum,
+        });
+    }
+    if let Some(owner) = &rule.require_owner {
+        ensure_fields(rule, &["scope", "when", "require_owner"])?;
+        if rule.when.as_deref() != Some("api_surface_changed") {
+            return Err(config_error(
+                &rule.id,
+                "`require_owner` requires `when: api_surface_changed`",
+            ));
+        }
+        let owner = normalize_required_owner(owner)
+            .ok_or_else(|| config_error(&rule.id, "`require_owner` is empty or invalid"))?;
+        return Ok(PolicyRuleKind::ApiOwner {
+            scope: rule
+                .scope
+                .clone()
+                .map(|scope| PathPattern::compile(scope, &rule.id, "scope"))
+                .transpose()?,
+            owner,
+        });
+    }
+    if let Some(maximum) = rule.max_blast_radius {
+        ensure_fields(rule, &["scope", "max_blast_radius"])?;
+        return Ok(PolicyRuleKind::BlastRadius {
+            scope: PathPattern::compile(required(&rule.scope, rule, "scope")?, &rule.id, "scope")?,
+            maximum,
+        });
+    }
+    if let Some(required_tests) = rule.require_tests {
+        ensure_fields(rule, &["scope", "require_tests"])?;
+        if !required_tests {
+            return Err(config_error(
+                &rule.id,
+                "`require_tests` must be true; remove the rule to disable it",
+            ));
+        }
+        return Ok(PolicyRuleKind::RelatedTests {
+            scope: PathPattern::compile(required(&rule.scope, rule, "scope")?, &rule.id, "scope")?,
+        });
+    }
+    if let Some(denied) = rule.deny_ownership_crossings {
+        ensure_fields(rule, &["scope", "deny_ownership_crossings"])?;
+        if !denied {
+            return Err(config_error(
+                &rule.id,
+                "`deny_ownership_crossings` must be true; remove the rule to disable it",
+            ));
+        }
+        return Ok(PolicyRuleKind::OwnershipBoundary {
+            scope: PathPattern::compile(required(&rule.scope, rule, "scope")?, &rule.id, "scope")?,
+        });
+    }
+    if let Some(workflow) = &rule.require_workflow {
+        ensure_fields(rule, &["critical", "require_workflow"])?;
+        if workflow != "strict" {
+            return Err(config_error(
+                &rule.id,
+                "the v1 workflow evidence mode is exactly `strict`",
+            ));
+        }
+        return Ok(PolicyRuleKind::StrictWorkflow {
+            critical: PathPattern::compile(
+                required(&rule.critical, rule, "critical")?,
+                &rule.id,
+                "critical",
+            )?,
+        });
+    }
+    Err(config_error(&rule.id, "policy action is missing"))
+}
+
+fn required(value: &Option<String>, rule: &RawRule, field: &str) -> Result<String, PolicyError> {
+    value
+        .clone()
+        .ok_or_else(|| config_error(&rule.id, format!("`{field}` is required")))
+}
+
+fn ensure_fields(rule: &RawRule, allowed: &[&str]) -> Result<(), PolicyError> {
+    if let Some(unexpected) = rule
+        .present_fields()
+        .into_iter()
+        .find(|field| !allowed.contains(field))
+    {
+        Err(config_error(
+            &rule.id,
+            format!("`{unexpected}` does not belong to this rule type"),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn config_error(rule_id: &str, detail: impl AsRef<str>) -> PolicyError {
+    PolicyError::new(
+        "invalid_policy_config",
+        format!("rule `{rule_id}`: {}", detail.as_ref()),
+    )
+}
+
+fn normalize_required_owner(value: &str) -> Option<String> {
+    let value = value.trim().trim_start_matches('@');
+    if value.is_empty()
+        || value.len() > 200
+        || value.chars().any(char::is_control)
+        || value.chars().any(char::is_whitespace)
+    {
+        None
+    } else {
+        Some(value.to_ascii_lowercase())
+    }
+}
+
+fn owner_matches(actual: &str, required: &str) -> bool {
+    let normalized = actual.trim().trim_start_matches('@').to_ascii_lowercase();
+    normalized == required || normalized.rsplit('/').next() == Some(required)
+}
+
+#[derive(Debug, Clone)]
+pub struct CheckOptions {
+    pub since: String,
+    pub config_path: PathBuf,
+    pub codeowners: Option<PathBuf>,
+    pub workflow_evidence_path: PathBuf,
+    pub depth: u32,
+    pub top: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyChangedFile {
+    pub path: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DependencyEdge {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ApiSurfaceChange {
+    pub file: String,
+    pub line: u32,
+    pub name: String,
+    pub kind: String,
+    pub component: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImpactRelation {
+    pub seed_file: String,
+    pub seed_line: u32,
+    pub seed_name: String,
+    pub impacted_file: String,
+    pub impacted_line: u32,
+    pub impacted_name: String,
+    pub minimum_depth: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BoundaryCrossing {
+    pub seed_file: String,
+    pub seed_line: u32,
+    pub seed_component: String,
+    pub impacted_file: String,
+    pub impacted_line: u32,
+    pub impacted_component: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RelatedTest {
+    pub file: String,
+    pub related_seed_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EvidenceGap {
+    pub family: String,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyInput {
+    pub baseline: ImpactBaseline,
+    pub changed_files: Vec<PolicyChangedFile>,
+    pub dependency_edges: Vec<DependencyEdge>,
+    pub new_cycles: Vec<Vec<String>>,
+    pub api_surface_changes: Vec<ApiSurfaceChange>,
+    pub impact_relations: Vec<ImpactRelation>,
+    pub boundary_crossings: Vec<BoundaryCrossing>,
+    pub related_tests: Vec<RelatedTest>,
+    pub owners: BTreeMap<String, Vec<String>>,
+    pub strict_workflow_files: BTreeMap<String, Vec<String>>,
+    pub gaps: Vec<EvidenceGap>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyRuleSummary {
+    pub id: String,
+    pub kind: &'static str,
+    pub description: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyLocation {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyViolation {
+    pub rule_id: String,
+    pub rule_kind: &'static str,
+    pub level: &'static str,
+    pub message: String,
+    pub location: PolicyLocation,
+    pub related_locations: Vec<PolicyLocation>,
+    pub properties: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PolicyDiagnostic {
+    pub rule_id: String,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyConfigIdentity {
+    pub path: String,
+    pub sha256: String,
+    pub version: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicySummary {
+    pub rules_evaluated: u32,
+    pub violations: u32,
+    pub diagnostics: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyReport {
+    pub schema_version: u32,
+    pub config: PolicyConfigIdentity,
+    pub baseline: ImpactBaseline,
+    pub passed: bool,
+    pub complete: bool,
+    pub summary: PolicySummary,
+    pub rules: Vec<PolicyRuleSummary>,
+    pub violations: Vec<PolicyViolation>,
+    pub diagnostics: Vec<PolicyDiagnostic>,
+    pub precision_notes: Vec<&'static str>,
+}
+
+struct LoadedConfig {
+    config: PolicyConfig,
+    identity: PolicyConfigIdentity,
+}
+
+pub fn check(
+    store: &Store,
+    root: &Path,
+    options: &CheckOptions,
+) -> Result<PolicyReport, PolicyError> {
+    check_with_impact_engine(store, root, options, &crate::queries::change_impact)
+}
+
+pub fn check_with_impact_engine(
+    store: &Store,
+    root: &Path,
+    options: &CheckOptions,
+    impact_engine: &ImpactEngine<'_>,
+) -> Result<PolicyReport, PolicyError> {
+    let root = root.canonicalize().map_err(|_| {
+        PolicyError::new("policy_root_unavailable", "project root cannot be resolved")
+    })?;
+    let loaded = load_config(&root, &options.config_path)?;
+    let input = evidence::collect(store, &root, &loaded.config, options, impact_engine)?;
+    let reloaded = load_config(&root, &options.config_path)?;
+    if loaded.identity.sha256 != reloaded.identity.sha256 {
+        return Err(PolicyError::new(
+            "policy_snapshot_changed",
+            "policy config changed during evaluation",
+        ));
+    }
+    Ok(evaluate(&loaded.config, input, loaded.identity))
+}
+
+fn load_config(root: &Path, requested: &Path) -> Result<LoadedConfig, PolicyError> {
+    let path = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        root.join(requested)
+    };
+    let path = path.canonicalize().map_err(|_| {
+        PolicyError::new(
+            "policy_config_unavailable",
+            format!("cannot read `{}`", display_path(root, &path)),
+        )
+    })?;
+    if !path.starts_with(root) {
+        return Err(PolicyError::new(
+            "invalid_policy_config",
+            "policy config must resolve inside the repository",
+        ));
+    }
+    let metadata = std::fs::metadata(&path).map_err(|_| {
+        PolicyError::new(
+            "policy_config_unavailable",
+            format!("cannot read `{}`", display_path(root, &path)),
+        )
+    })?;
+    if !metadata.is_file() || metadata.len() == 0 || metadata.len() > CONFIG_BYTE_LIMIT {
+        return Err(PolicyError::new(
+            "invalid_policy_config",
+            "policy config must be a non-empty regular file no larger than 1 MiB",
+        ));
+    }
+    let source = std::fs::read(&path).map_err(|_| {
+        PolicyError::new(
+            "policy_config_unavailable",
+            format!("cannot read `{}`", display_path(root, &path)),
+        )
+    })?;
+    let config = parse_config(&source)?;
+    Ok(LoadedConfig {
+        identity: PolicyConfigIdentity {
+            path: display_path(root, &path),
+            sha256: crate::hex::encode(&Sha256::digest(&source)),
+            version: config.version,
+        },
+        config,
+    })
+}
+
+fn display_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+pub fn evaluate(
+    config: &PolicyConfig,
+    input: PolicyInput,
+    identity: PolicyConfigIdentity,
+) -> PolicyReport {
+    let changed = input
+        .changed_files
+        .iter()
+        .map(|file| file.path.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut violations = Vec::new();
+    let mut diagnostics = BTreeSet::new();
+    let mut output_limit_rule = None;
+    let mut rules_evaluated = 0u32;
+
+    macro_rules! record_violation {
+        ($rule:expr, $label:lifetime, $value:expr) => {{
+            if violations.len() + diagnostics.len() >= POLICY_RESULT_LIMIT {
+                output_limit_rule = Some($rule.id.clone());
+                break $label;
+            }
+            violations.push($value);
+        }};
+    }
+
+    'rules: for rule in &config.rules {
+        rules_evaluated += 1;
+        for gap in input
+            .gaps
+            .iter()
+            .filter(|gap| gap.family == rule.kind.family())
+        {
+            if !insert_diagnostic_bounded(
+                &mut diagnostics,
+                PolicyDiagnostic {
+                    rule_id: rule.id.clone(),
+                    code: gap.code.clone(),
+                    message: gap.message.clone(),
+                },
+                violations.len(),
+            ) {
+                output_limit_rule = Some(rule.id.clone());
+                break 'rules;
+            }
+        }
+
+        match &rule.kind {
+            PolicyRuleKind::DependencyDirection { from, deny_imports } => {
+                for edge in input.dependency_edges.iter().filter(|edge| {
+                    changed.contains(edge.from.as_str())
+                        && from.matches(&edge.from)
+                        && deny_imports.matches(&edge.to)
+                }) {
+                    record_violation!(rule, 'rules, violation(
+                        rule,
+                        format!(
+                            "Changed `{}` imports forbidden architecture target `{}`.",
+                            edge.from, edge.to
+                        ),
+                        location(&edge.from, None, "Forbidden import source"),
+                        vec![location(&edge.to, None, "Forbidden import target")],
+                        BTreeMap::from([
+                            ("fromPattern".into(), json!(from.as_str())),
+                            ("denyImportsPattern".into(), json!(deny_imports.as_str())),
+                        ]),
+                    ));
+                }
+            }
+            PolicyRuleKind::NewCycles { scope, maximum } => {
+                let cycles = input
+                    .new_cycles
+                    .iter()
+                    .filter(|cycle| cycle.iter().any(|path| scope.matches(path)))
+                    .collect::<Vec<_>>();
+                if cycles.len() as u32 > *maximum {
+                    let first = cycles[0];
+                    let related = first
+                        .iter()
+                        .skip(1)
+                        .map(|path| location(path, None, "New cycle member"))
+                        .collect();
+                    record_violation!(rule, 'rules, violation(
+                        rule,
+                        format!(
+                            "{} new import cycle(s) intersect `{}`, exceeding the budget of {}.",
+                            cycles.len(),
+                            scope.as_str(),
+                            maximum
+                        ),
+                        location(&first[0], None, "New dependency cycle"),
+                        related,
+                        BTreeMap::from([
+                            ("scope".into(), json!(scope.as_str())),
+                            ("newCycles".into(), json!(cycles.len())),
+                            ("maximum".into(), json!(maximum)),
+                        ]),
+                    ));
+                }
+            }
+            PolicyRuleKind::ApiOwner { scope, owner } => {
+                for change in input.api_surface_changes.iter().filter(|change| {
+                    scope
+                        .as_ref()
+                        .is_none_or(|pattern| pattern.matches(&change.file))
+                }) {
+                    let actual = input
+                        .owners
+                        .get(&change.file)
+                        .map(Vec::as_slice)
+                        .unwrap_or(&[]);
+                    if !actual.iter().any(|value| owner_matches(value, owner)) {
+                        record_violation!(rule, 'rules, violation(
+                            rule,
+                            format!(
+                                "Observed API change `{} {}` in `{}` requires CODEOWNER `{}`.",
+                                change.kind, change.name, change.file, owner
+                            ),
+                            location(&change.file, Some(change.line), "API surface change"),
+                            Vec::new(),
+                            BTreeMap::from([
+                                ("requiredOwner".into(), json!(owner)),
+                                ("observedOwners".into(), json!(actual)),
+                                ("component".into(), json!(change.component)),
+                            ]),
+                        ));
+                    }
+                }
+            }
+            PolicyRuleKind::BlastRadius { scope, maximum } => {
+                let impacted = input
+                    .impact_relations
+                    .iter()
+                    .filter(|relation| scope.matches(&relation.seed_file))
+                    .map(|relation| {
+                        (
+                            relation.impacted_file.as_str(),
+                            relation.impacted_line,
+                            relation.impacted_name.as_str(),
+                        )
+                    })
+                    .collect::<BTreeSet<_>>();
+                if impacted.len() as u32 > *maximum {
+                    let seed = input
+                        .impact_relations
+                        .iter()
+                        .find(|relation| scope.matches(&relation.seed_file))
+                        .expect("non-empty impacted set has a seed");
+                    record_violation!(rule, 'rules, violation(
+                        rule,
+                        format!(
+                            "Static blast radius for `{}` is {} symbols, exceeding the budget of {}.",
+                            scope.as_str(),
+                            impacted.len(),
+                            maximum
+                        ),
+                        location(&seed.seed_file, Some(seed.seed_line), "Changed blast-radius seed"),
+                        Vec::new(),
+                        BTreeMap::from([
+                            ("scope".into(), json!(scope.as_str())),
+                            ("impactedSymbols".into(), json!(impacted.len())),
+                            ("maximum".into(), json!(maximum)),
+                        ]),
+                    ));
+                }
+            }
+            PolicyRuleKind::RelatedTests { scope } => {
+                let scoped_changes = input
+                    .changed_files
+                    .iter()
+                    .filter(|file| scope.matches(&file.path))
+                    .collect::<Vec<_>>();
+                let related = input.related_tests.iter().any(|test| {
+                    scope.matches(&test.file)
+                        || test
+                            .related_seed_files
+                            .iter()
+                            .any(|path| scope.matches(path))
+                });
+                if !scoped_changes.is_empty() && !related {
+                    record_violation!(rule, 'rules, violation(
+                        rule,
+                        format!(
+                            "Changed scope `{}` has no related test candidate.",
+                            scope.as_str()
+                        ),
+                        location(
+                            &scoped_changes[0].path,
+                            None,
+                            "Changed scope without related tests",
+                        ),
+                        Vec::new(),
+                        BTreeMap::from([("scope".into(), json!(scope.as_str()))]),
+                    ));
+                }
+            }
+            PolicyRuleKind::OwnershipBoundary { scope } => {
+                for crossing in input
+                    .boundary_crossings
+                    .iter()
+                    .filter(|crossing| scope.matches(&crossing.seed_file))
+                {
+                    let source = input
+                        .owners
+                        .get(&crossing.seed_file)
+                        .map(Vec::as_slice)
+                        .unwrap_or(&[]);
+                    let target = input
+                        .owners
+                        .get(&crossing.impacted_file)
+                        .map(Vec::as_slice)
+                        .unwrap_or(&[]);
+                    if source.is_empty() || target.is_empty() {
+                        if !insert_diagnostic_bounded(
+                            &mut diagnostics,
+                            PolicyDiagnostic {
+                                rule_id: rule.id.clone(),
+                                code: "ownership_unresolved".into(),
+                                message: format!(
+                                    "CODEOWNERS did not resolve both sides of `{}` -> `{}`.",
+                                    crossing.seed_file, crossing.impacted_file
+                                ),
+                            },
+                            violations.len(),
+                        ) {
+                            output_limit_rule = Some(rule.id.clone());
+                            break 'rules;
+                        }
+                        continue;
+                    }
+                    let overlaps = source.iter().any(|left| {
+                        target
+                            .iter()
+                            .any(|right| normalized_owner(left) == normalized_owner(right))
+                    });
+                    if !overlaps {
+                        record_violation!(rule, 'rules, violation(
+                            rule,
+                            format!(
+                                "Change crosses disjoint ownership sets from `{}` to `{}`.",
+                                crossing.seed_component, crossing.impacted_component
+                            ),
+                            location(
+                                &crossing.seed_file,
+                                Some(crossing.seed_line),
+                                "Changed owner boundary source",
+                            ),
+                            vec![location(
+                                &crossing.impacted_file,
+                                Some(crossing.impacted_line),
+                                "Impacted owner boundary target",
+                            )],
+                            BTreeMap::from([
+                                ("sourceOwners".into(), json!(source)),
+                                ("targetOwners".into(), json!(target)),
+                            ]),
+                        ));
+                    }
+                }
+            }
+            PolicyRuleKind::StrictWorkflow { critical } => {
+                for file in input.changed_files.iter().filter(|file| {
+                    critical.matches(&file.path)
+                        && !input.strict_workflow_files.contains_key(&file.path)
+                }) {
+                    record_violation!(rule, 'rules, violation(
+                        rule,
+                        format!(
+                            "Critical change `{}` has no matching held strict-workflow evidence.",
+                            file.path
+                        ),
+                        location(&file.path, None, "Critical changed file"),
+                        Vec::new(),
+                        BTreeMap::from([("criticalPattern".into(), json!(critical.as_str()))]),
+                    ));
+                }
+            }
+        }
+    }
+
+    if let Some(rule_id) = output_limit_rule {
+        if violations.len() + diagnostics.len() >= POLICY_RESULT_LIMIT && violations.pop().is_none()
+        {
+            diagnostics.pop_last();
+        }
+        diagnostics.insert(PolicyDiagnostic {
+            rule_id,
+            code: "policy_result_limit".into(),
+            message: format!(
+                "Policy findings reached the bounded {POLICY_RESULT_LIMIT}-result output limit; remaining evidence was not evaluated."
+            ),
+        });
+    }
+
+    violations.sort_by(|left, right| {
+        (
+            &left.rule_id,
+            &left.location.path,
+            left.location.line,
+            &left.message,
+        )
+            .cmp(&(
+                &right.rule_id,
+                &right.location.path,
+                right.location.line,
+                &right.message,
+            ))
+    });
+    let diagnostics = diagnostics.into_iter().collect::<Vec<_>>();
+    let complete = diagnostics.is_empty();
+    let passed = complete && violations.is_empty();
+    let rules = config
+        .rules
+        .iter()
+        .map(|rule| PolicyRuleSummary {
+            id: rule.id.clone(),
+            kind: rule.kind.name(),
+            description: rule.kind.description(),
+        })
+        .collect::<Vec<_>>();
+
+    PolicyReport {
+        schema_version: 1,
+        config: identity,
+        baseline: input.baseline,
+        passed,
+        complete,
+        summary: PolicySummary {
+            rules_evaluated,
+            violations: violations.len() as u32,
+            diagnostics: diagnostics.len() as u32,
+        },
+        rules,
+        violations,
+        diagnostics,
+        precision_notes: vec![
+            "Policy graph topology comes from the default syntactic index; SCIP and runtime overlays do not add or remove policy edges in v1.",
+            "api_surface_changed means an observed changed seed crosses an inferred top-level component boundary; it is not a declaration-level export claim.",
+            "CODEOWNERS evaluation uses working-tree syntax and does not prove that an owner exists, has access, or approved the change.",
+            "Related tests are bounded graph-linked or in-scope candidates, not proof that a test executed or passed.",
+            "Strict workflow evidence validates local canonical artifact consistency; it does not verify an audit signature or remote CI execution.",
+        ],
+    }
+}
+
+fn insert_diagnostic_bounded(
+    diagnostics: &mut BTreeSet<PolicyDiagnostic>,
+    diagnostic: PolicyDiagnostic,
+    violation_count: usize,
+) -> bool {
+    if diagnostics.contains(&diagnostic) {
+        return true;
+    }
+    if diagnostics.len() + violation_count >= POLICY_RESULT_LIMIT {
+        return false;
+    }
+    diagnostics.insert(diagnostic);
+    true
+}
+
+fn normalized_owner(value: &str) -> String {
+    value.trim().trim_start_matches('@').to_ascii_lowercase()
+}
+
+fn violation(
+    rule: &PolicyRule,
+    message: String,
+    location: PolicyLocation,
+    related_locations: Vec<PolicyLocation>,
+    properties: BTreeMap<String, Value>,
+) -> PolicyViolation {
+    PolicyViolation {
+        rule_id: rule.id.clone(),
+        rule_kind: rule.kind.name(),
+        level: "error",
+        message,
+        location,
+        related_locations,
+        properties,
+    }
+}
+
+fn location(path: &str, line: Option<u32>, message: &str) -> PolicyLocation {
+    PolicyLocation {
+        path: path.to_string(),
+        line,
+        message: message.to_string(),
+    }
+}
+
+pub fn render_text(report: &PolicyReport) -> String {
+    let verdict = if report.passed {
+        "PASS"
+    } else if report.complete {
+        "FAIL"
+    } else {
+        "INCOMPLETE"
+    };
+    let mut output = format!(
+        "Architecture policy: {verdict}\n  config: {} ({})\n  baseline: {}\n  rules: {} | violations: {} | diagnostics: {}\n",
+        report.config.path,
+        &report.config.sha256[..12],
+        report.baseline.baseline_oid,
+        report.summary.rules_evaluated,
+        report.summary.violations,
+        report.summary.diagnostics,
+    );
+    for violation in &report.violations {
+        let line = violation
+            .location
+            .line
+            .map(|line| format!(":{line}"))
+            .unwrap_or_default();
+        output.push_str(&format!(
+            "  error [{}] {}{} — {}\n",
+            violation.rule_id, violation.location.path, line, violation.message
+        ));
+    }
+    for diagnostic in &report.diagnostics {
+        output.push_str(&format!(
+            "  incomplete [{}:{}] {}\n",
+            diagnostic.rule_id, diagnostic.code, diagnostic.message
+        ));
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_RULES: &[u8] = br#"
+version: 1
+rules:
+  - id: domain-must-not-import-infrastructure
+    from: src/domain/**
+    deny_imports: src/infrastructure/**
+  - id: no-new-payment-cycles
+    scope: services/payment/**
+    max_new_cycles: 0
+  - id: public-api-review
+    when: api_surface_changed
+    require_owner: platform
+  - id: payment-blast-budget
+    scope: services/payment/**
+    max_blast_radius: 1
+  - id: payment-needs-tests
+    scope: services/payment/**
+    require_tests: true
+  - id: payment-owner-boundary
+    scope: services/payment/**
+    deny_ownership_crossings: true
+  - id: critical-payment-workflow
+    critical: services/payment/**
+    require_workflow: strict
+"#;
+
+    fn identity() -> PolicyConfigIdentity {
+        PolicyConfigIdentity {
+            path: "mastermind-policy.yml".into(),
+            sha256: "0".repeat(64),
+            version: 1,
+        }
+    }
+
+    fn baseline() -> ImpactBaseline {
+        ImpactBaseline {
+            requested_ref: "main".into(),
+            baseline_oid: "1".repeat(40),
+            head_oid: "2".repeat(40),
+            includes_worktree: true,
+            includes_untracked: true,
+        }
+    }
+
+    #[test]
+    fn parses_the_developer_facing_policy_dsl() {
+        let config = parse_config(ALL_RULES).unwrap();
+        assert_eq!(config.version, 1);
+        assert_eq!(config.rules.len(), 7);
+        assert_eq!(
+            config.rules[0].id, "critical-payment-workflow",
+            "rules are normalized by stable id"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_ambiguous_and_noop_rules() {
+        for source in [
+            br#"rules: [{id: bad, scope: "**", require_tests: true, surprise: yes}]"#.as_slice(),
+            br#"rules: [{id: bad, scope: "**", require_tests: true, max_new_cycles: 0}]"#
+                .as_slice(),
+            br#"rules: [{id: bad, scope: "**", require_tests: false}]"#.as_slice(),
+        ] {
+            let error = parse_config(source).unwrap_err();
+            assert_eq!(error.code(), "invalid_policy_config");
+        }
+        let too_many = format!(
+            "rules:\n{}",
+            (0..=RULE_LIMIT)
+                .map(|index| format!(
+                    "  - id: rule-{index}\n    scope: src/**\n    require_tests: true\n"
+                ))
+                .collect::<String>()
+        );
+        assert_eq!(
+            parse_config(too_many.as_bytes()).unwrap_err().code(),
+            "invalid_policy_config"
+        );
+    }
+
+    #[test]
+    fn all_seven_rule_families_evaluate_from_one_structured_input() {
+        let config = parse_config(ALL_RULES).unwrap();
+        let input = PolicyInput {
+            baseline: baseline(),
+            changed_files: vec![
+                PolicyChangedFile {
+                    path: "src/domain/order.ts".into(),
+                    status: "modified".into(),
+                },
+                PolicyChangedFile {
+                    path: "services/payment/charge.ts".into(),
+                    status: "modified".into(),
+                },
+            ],
+            dependency_edges: vec![DependencyEdge {
+                from: "src/domain/order.ts".into(),
+                to: "src/infrastructure/db.ts".into(),
+            }],
+            new_cycles: vec![vec![
+                "services/payment/charge.ts".into(),
+                "services/payment/gateway.ts".into(),
+            ]],
+            api_surface_changes: vec![ApiSurfaceChange {
+                file: "services/payment/charge.ts".into(),
+                line: 7,
+                name: "charge".into(),
+                kind: "function".into(),
+                component: "services".into(),
+            }],
+            impact_relations: vec![
+                ImpactRelation {
+                    seed_file: "services/payment/charge.ts".into(),
+                    seed_line: 7,
+                    seed_name: "charge".into(),
+                    impacted_file: "api/checkout.ts".into(),
+                    impacted_line: 20,
+                    impacted_name: "checkout".into(),
+                    minimum_depth: 1,
+                },
+                ImpactRelation {
+                    seed_file: "services/payment/charge.ts".into(),
+                    seed_line: 7,
+                    seed_name: "charge".into(),
+                    impacted_file: "worker/retry.ts".into(),
+                    impacted_line: 30,
+                    impacted_name: "retry".into(),
+                    minimum_depth: 2,
+                },
+            ],
+            boundary_crossings: vec![BoundaryCrossing {
+                seed_file: "services/payment/charge.ts".into(),
+                seed_line: 7,
+                seed_component: "services".into(),
+                impacted_file: "api/checkout.ts".into(),
+                impacted_line: 20,
+                impacted_component: "api".into(),
+            }],
+            related_tests: Vec::new(),
+            owners: BTreeMap::from([
+                (
+                    "services/payment/charge.ts".into(),
+                    vec!["@payments".into()],
+                ),
+                ("api/checkout.ts".into(), vec!["@platform".into()]),
+            ]),
+            strict_workflow_files: BTreeMap::new(),
+            gaps: Vec::new(),
+        };
+
+        let report = evaluate(&config, input, identity());
+        assert!(!report.passed);
+        assert!(report.complete);
+        assert_eq!(report.summary.violations, 7);
+        assert_eq!(
+            report
+                .violations
+                .iter()
+                .map(|violation| violation.rule_kind)
+                .collect::<BTreeSet<_>>()
+                .len(),
+            7
+        );
+        let sarif = crate::sarif_export::architecture_policy(&report);
+        assert_eq!(sarif["version"], "2.1.0");
+        assert_eq!(
+            sarif["runs"][0]["tool"]["driver"]["rules"]
+                .as_array()
+                .unwrap()
+                .len(),
+            7
+        );
+        assert_eq!(sarif["runs"][0]["results"].as_array().unwrap().len(), 7);
+        assert!(sarif["runs"][0]["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|result| result["level"] == "error"));
+        assert!(sarif["runs"][0]["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(
+                |result| result["partialFingerprints"]["primaryLocationLineHash"]
+                    .as_str()
+                    .is_some_and(|fingerprint| {
+                        fingerprint.len() == 18 && fingerprint.ends_with(":1")
+                    })
+            ));
+    }
+
+    #[test]
+    fn unrelated_test_in_same_top_level_component_does_not_satisfy_scope() {
+        let config = parse_config(
+            br#"
+rules:
+  - id: payment-tests
+    scope: services/payment/**
+    require_tests: true
+"#,
+        )
+        .unwrap();
+        let report = evaluate(
+            &config,
+            PolicyInput {
+                baseline: baseline(),
+                changed_files: vec![PolicyChangedFile {
+                    path: "services/payment/charge.ts".into(),
+                    status: "modified".into(),
+                }],
+                dependency_edges: Vec::new(),
+                new_cycles: Vec::new(),
+                api_surface_changes: Vec::new(),
+                impact_relations: Vec::new(),
+                boundary_crossings: Vec::new(),
+                related_tests: vec![RelatedTest {
+                    file: "services/shipping/test_rate.ts".into(),
+                    related_seed_files: Vec::new(),
+                }],
+                owners: BTreeMap::new(),
+                strict_workflow_files: BTreeMap::new(),
+                gaps: Vec::new(),
+            },
+            identity(),
+        );
+        assert_eq!(report.summary.violations, 1);
+        assert_eq!(report.violations[0].rule_id, "payment-tests");
+    }
+
+    #[test]
+    fn sarif_fingerprints_distinguish_findings_on_the_same_source_file() {
+        let config = parse_config(
+            br#"
+rules:
+  - id: dependency-direction
+    from: src/domain/**
+    deny_imports: src/infrastructure/**
+"#,
+        )
+        .unwrap();
+        let report = evaluate(
+            &config,
+            PolicyInput {
+                baseline: baseline(),
+                changed_files: vec![PolicyChangedFile {
+                    path: "src/domain/order.ts".into(),
+                    status: "modified".into(),
+                }],
+                dependency_edges: vec![
+                    DependencyEdge {
+                        from: "src/domain/order.ts".into(),
+                        to: "src/infrastructure/db.ts".into(),
+                    },
+                    DependencyEdge {
+                        from: "src/domain/order.ts".into(),
+                        to: "src/infrastructure/cache.ts".into(),
+                    },
+                ],
+                new_cycles: Vec::new(),
+                api_surface_changes: Vec::new(),
+                impact_relations: Vec::new(),
+                boundary_crossings: Vec::new(),
+                related_tests: Vec::new(),
+                owners: BTreeMap::new(),
+                strict_workflow_files: BTreeMap::new(),
+                gaps: Vec::new(),
+            },
+            identity(),
+        );
+        let sarif = crate::sarif_export::architecture_policy(&report);
+        let fingerprints = sarif["runs"][0]["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|result| {
+                result["partialFingerprints"]["primaryLocationLineHash"]
+                    .as_str()
+                    .unwrap()
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(fingerprints.len(), 2);
+    }
+
+    #[test]
+    fn policy_findings_are_bounded_and_fail_closed() {
+        let config = parse_config(
+            br#"
+rules:
+  - id: bounded-imports
+    from: src/domain/**
+    deny_imports: src/infrastructure/**
+"#,
+        )
+        .unwrap();
+        let mut changed_files = Vec::new();
+        let mut dependency_edges = Vec::new();
+        for index in 0..=POLICY_RESULT_LIMIT {
+            let source = format!("src/domain/file_{index}.ts");
+            changed_files.push(PolicyChangedFile {
+                path: source.clone(),
+                status: "modified".into(),
+            });
+            dependency_edges.push(DependencyEdge {
+                from: source,
+                to: format!("src/infrastructure/file_{index}.ts"),
+            });
+        }
+        let report = evaluate(
+            &config,
+            PolicyInput {
+                baseline: baseline(),
+                changed_files,
+                dependency_edges,
+                new_cycles: Vec::new(),
+                api_surface_changes: Vec::new(),
+                impact_relations: Vec::new(),
+                boundary_crossings: Vec::new(),
+                related_tests: Vec::new(),
+                owners: BTreeMap::new(),
+                strict_workflow_files: BTreeMap::new(),
+                gaps: vec![EvidenceGap {
+                    family: FAMILY_IMPORT_GRAPH.into(),
+                    code: "fixture_evidence_note".into(),
+                    message: "fixture diagnostic".into(),
+                }],
+            },
+            identity(),
+        );
+        assert!(!report.complete);
+        assert!(!report.passed);
+        assert_eq!(report.violations.len(), POLICY_RESULT_LIMIT - 2);
+        assert_eq!(
+            report.violations.len() + report.diagnostics.len(),
+            POLICY_RESULT_LIMIT
+        );
+        assert_eq!(report.summary.rules_evaluated, 1);
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "policy_result_limit"));
+        let sarif = crate::sarif_export::architecture_policy(&report);
+        assert_eq!(
+            sarif["runs"][0]["results"].as_array().unwrap().len(),
+            POLICY_RESULT_LIMIT
+        );
+    }
+
+    #[test]
+    fn incomplete_evidence_fails_closed_without_inventing_a_violation() {
+        let config =
+            parse_config(br#"rules: [{id: cycles, scope: "src/**", max_new_cycles: 0}]"#).unwrap();
+        let report = evaluate(
+            &config,
+            PolicyInput {
+                baseline: baseline(),
+                changed_files: Vec::new(),
+                dependency_edges: Vec::new(),
+                new_cycles: Vec::new(),
+                api_surface_changes: Vec::new(),
+                impact_relations: Vec::new(),
+                boundary_crossings: Vec::new(),
+                related_tests: Vec::new(),
+                owners: BTreeMap::new(),
+                strict_workflow_files: BTreeMap::new(),
+                gaps: vec![EvidenceGap {
+                    family: FAMILY_CYCLES.into(),
+                    code: "import_graph_work_limit".into(),
+                    message: "cycle comparison was bounded".into(),
+                }],
+            },
+            identity(),
+        );
+        assert!(!report.passed);
+        assert!(!report.complete);
+        assert!(report.violations.is_empty());
+        assert_eq!(report.diagnostics[0].code, "import_graph_work_limit");
+        let sarif = crate::sarif_export::architecture_policy(&report);
+        assert_eq!(
+            sarif["runs"][0]["results"][0]["ruleId"],
+            "mastermind/policy-evaluation-incomplete"
+        );
+    }
+}

--- a/mcp/servers/mmcg/src/policy/evidence.rs
+++ b/mcp/servers/mmcg/src/policy/evidence.rs
@@ -1,0 +1,1149 @@
+use super::{
+    ApiSurfaceChange, BoundaryCrossing, CheckOptions, DependencyEdge, EvidenceGap, ImpactRelation,
+    PolicyChangedFile, PolicyConfig, PolicyError, PolicyInput, PolicyRuleKind, RelatedTest,
+    FAMILY_API, FAMILY_CYCLES, FAMILY_IMPACT, FAMILY_IMPORT_GRAPH, FAMILY_OWNERSHIP, FAMILY_TESTS,
+    FAMILY_WORKFLOW,
+};
+use crate::diff::{run_bounded_git_with_limit, WorkingTreeDiffError};
+use crate::evidence::{EvidenceExtensionOptions, EvidenceOptions};
+use crate::indexer::{extractor_for_path, parse_blob, MAX_INDEXABLE_FILE_SIZE};
+use crate::queries::{ChangeImpactResponse, ImpactEngine};
+use crate::run_task::RunState;
+use crate::store::{PendingFile, Store};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+const IMPORT_EDGE_LIMIT: usize = 50_000;
+const BASELINE_CYCLE_FILE_LIMIT: usize = 500;
+const BASELINE_CYCLE_BYTE_LIMIT: usize = 32 * 1024 * 1024;
+const WORKFLOW_TASK_LIMIT: usize = 1_000;
+const WORKFLOW_ARTIFACT_BYTE_LIMIT: u64 = 1024 * 1024;
+
+pub(super) fn collect(
+    store: &Store,
+    root: &Path,
+    config: &PolicyConfig,
+    options: &CheckOptions,
+    impact_engine: &ImpactEngine<'_>,
+) -> Result<PolicyInput, PolicyError> {
+    crate::lens::validate_index_snapshot(store, root, None)
+        .map_err(|error| PolicyError::new("policy_evidence_unavailable", error.code()))?;
+    let impact = impact_engine(store, root, &options.since, options.depth, options.top)
+        .map_err(|error| PolicyError::new("policy_evidence_unavailable", error.code()))?;
+    let mut gaps = impact_gaps(&impact, config);
+    let changed_files = impact
+        .changes
+        .files
+        .items
+        .iter()
+        .map(|file| PolicyChangedFile {
+            path: file.path.clone(),
+            status: file.status.clone(),
+        })
+        .collect::<Vec<_>>();
+    let changed_paths = changed_files
+        .iter()
+        .map(|file| file.path.clone())
+        .collect::<BTreeSet<_>>();
+    let relevant_workflow_paths = changed_paths
+        .iter()
+        .filter(|path| {
+            config.rules.iter().any(|rule| {
+                matches!(
+                    &rule.kind,
+                    PolicyRuleKind::StrictWorkflow { critical } if critical.matches(path)
+                )
+            })
+        })
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let needs_import_graph = config.rules.iter().any(|rule| {
+        matches!(
+            rule.kind,
+            PolicyRuleKind::DependencyDirection { .. } | PolicyRuleKind::NewCycles { .. }
+        )
+    });
+    let mut dependency_edges = Vec::new();
+    let mut new_cycles = Vec::new();
+    if needs_import_graph {
+        let (pairs, truncated) = store
+            .map_import_edges_capped_filtered("", "root", IMPORT_EDGE_LIMIT, false)
+            .map_err(|_| {
+                PolicyError::new(
+                    "policy_evidence_unavailable",
+                    "cannot read the indexed import graph",
+                )
+            })?;
+        if truncated {
+            for family in [FAMILY_IMPORT_GRAPH, FAMILY_CYCLES] {
+                gaps.push(gap(
+                    family,
+                    "import_graph_work_limit",
+                    "The repository import graph exceeds the 50,000-edge policy work limit.",
+                ));
+            }
+        } else {
+            dependency_edges = pairs
+                .iter()
+                .map(|(from, to)| DependencyEdge {
+                    from: from.clone(),
+                    to: to.clone(),
+                })
+                .collect();
+            if config
+                .rules
+                .iter()
+                .any(|rule| matches!(rule.kind, PolicyRuleKind::NewCycles { .. }))
+            {
+                let current_cycles = crate::queries::map_cycle_components(&pairs);
+                match compare_cycles_to_baseline(
+                    root,
+                    &impact.baseline.baseline_oid,
+                    config,
+                    &changed_paths,
+                    current_cycles,
+                ) {
+                    Ok(cycles) => new_cycles = cycles,
+                    Err(message) => gaps.push(gap(
+                        FAMILY_CYCLES,
+                        "baseline_cycle_evidence_incomplete",
+                        message,
+                    )),
+                }
+            }
+        }
+    }
+
+    let api_surface_changes = api_surface_changes(&impact);
+    let impact_relations = impact_relations(&impact);
+    let boundary_crossings = impact
+        .api_crossings
+        .items
+        .iter()
+        .map(|crossing| BoundaryCrossing {
+            seed_file: crossing.seed.file.clone(),
+            seed_line: crossing.seed.line,
+            seed_component: crossing.changed_component.clone(),
+            impacted_file: crossing.impacted.file.clone(),
+            impacted_line: crossing.impacted.line,
+            impacted_component: crossing.impacted_component.clone(),
+        })
+        .collect();
+    let related_tests = impact
+        .tests
+        .items
+        .iter()
+        .map(|candidate| {
+            let mut seeds = BTreeSet::new();
+            for evidence in &candidate.evidence {
+                if let Some(seed) = &evidence.seed {
+                    seeds.insert(seed.file.clone());
+                }
+            }
+            RelatedTest {
+                file: candidate.symbol.file.clone(),
+                related_seed_files: seeds.into_iter().collect(),
+            }
+        })
+        .collect();
+
+    let needs_ownership = config.rules.iter().any(|rule| {
+        matches!(
+            rule.kind,
+            PolicyRuleKind::ApiOwner { .. } | PolicyRuleKind::OwnershipBoundary { .. }
+        )
+    });
+    let owners = if needs_ownership {
+        let snapshot = crate::evidence::collect_with_store(
+            root,
+            &EvidenceOptions {
+                codeowners: options.codeowners.clone(),
+                discover_codeowners: options.codeowners.is_none(),
+                ..EvidenceOptions::default()
+            },
+            &EvidenceExtensionOptions::default(),
+            &impact,
+            store,
+            None,
+        );
+        if snapshot.partial {
+            let detail = snapshot
+                .diagnostics
+                .items
+                .iter()
+                .map(|diagnostic| diagnostic.code)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>()
+                .join(", ");
+            gaps.push(gap(
+                FAMILY_OWNERSHIP,
+                "codeowners_evidence_incomplete",
+                if detail.is_empty() {
+                    "CODEOWNERS evidence was incomplete.".to_string()
+                } else {
+                    format!("CODEOWNERS evidence was incomplete: {detail}.")
+                },
+            ));
+            gaps.push(gap(
+                FAMILY_API,
+                "codeowners_evidence_incomplete",
+                "Required-owner evaluation could not read complete CODEOWNERS evidence.",
+            ));
+        }
+        snapshot
+            .files
+            .items
+            .into_iter()
+            .filter_map(|file| {
+                file.ownership
+                    .map(|ownership| (file.path, ownership.codeowners))
+            })
+            .collect()
+    } else {
+        BTreeMap::new()
+    };
+
+    let needs_workflow = config
+        .rules
+        .iter()
+        .any(|rule| matches!(rule.kind, PolicyRuleKind::StrictWorkflow { .. }));
+    let strict_workflow_files = if needs_workflow {
+        let (files, workflow_gaps) = collect_workflow_evidence(
+            root,
+            &options.workflow_evidence_path,
+            &impact.baseline.baseline_oid,
+            &relevant_workflow_paths,
+        );
+        gaps.extend(workflow_gaps);
+        files
+    } else {
+        BTreeMap::new()
+    };
+
+    crate::lens::validate_index_snapshot(store, root, None)
+        .map_err(|error| PolicyError::new("policy_snapshot_changed", error.code()))?;
+    let rechecked = impact_engine(store, root, &options.since, options.depth, options.top)
+        .map_err(|error| PolicyError::new("policy_snapshot_changed", error.code()))?;
+    let first = serde_json::to_value(&impact)
+        .map_err(|_| PolicyError::new("policy_evidence_unavailable", "serialize impact"))?;
+    let second = serde_json::to_value(&rechecked)
+        .map_err(|_| PolicyError::new("policy_evidence_unavailable", "serialize impact"))?;
+    if impact.snapshot_token != rechecked.snapshot_token || first != second {
+        return Err(PolicyError::new(
+            "policy_snapshot_changed",
+            "repository or index evidence changed during evaluation",
+        ));
+    }
+
+    gaps.sort();
+    gaps.dedup();
+    Ok(PolicyInput {
+        baseline: impact.baseline,
+        changed_files,
+        dependency_edges,
+        new_cycles,
+        api_surface_changes,
+        impact_relations,
+        boundary_crossings,
+        related_tests,
+        owners,
+        strict_workflow_files,
+        gaps,
+    })
+}
+
+fn impact_gaps(response: &ChangeImpactResponse, config: &PolicyConfig) -> Vec<EvidenceGap> {
+    let active = config
+        .rules
+        .iter()
+        .map(|rule| rule.kind.family())
+        .collect::<BTreeSet<_>>();
+    let mut gaps = Vec::new();
+    if response.changes.files.truncated {
+        for family in [
+            FAMILY_IMPORT_GRAPH,
+            FAMILY_CYCLES,
+            FAMILY_API,
+            FAMILY_IMPACT,
+            FAMILY_TESTS,
+            FAMILY_OWNERSHIP,
+            FAMILY_WORKFLOW,
+        ] {
+            if active.contains(family) {
+                gaps.push(gap(
+                    family,
+                    "changed_file_limit",
+                    "The changed-file set exceeded the change-impact work limit.",
+                ));
+            }
+        }
+    }
+    if response.changes.symbols.truncated {
+        for family in [FAMILY_API, FAMILY_IMPACT, FAMILY_TESTS, FAMILY_OWNERSHIP] {
+            if active.contains(family) {
+                gaps.push(gap(
+                    family,
+                    "changed_symbol_limit",
+                    "The changed-symbol set exceeded the change-impact work limit.",
+                ));
+            }
+        }
+    }
+    if response.impact.truncated && active.contains(FAMILY_IMPACT) {
+        gaps.push(gap(
+            FAMILY_IMPACT,
+            response
+                .impact
+                .truncation_reason
+                .as_deref()
+                .unwrap_or("impact_limit"),
+            "Static impact results were truncated before the blast radius was complete.",
+        ));
+    }
+    if response.api_crossings.truncated {
+        for family in [FAMILY_API, FAMILY_OWNERSHIP] {
+            if active.contains(family) {
+                gaps.push(gap(
+                    family,
+                    response
+                        .api_crossings
+                        .truncation_reason
+                        .as_deref()
+                        .unwrap_or("crossing_limit"),
+                    "Cross-component API evidence was truncated.",
+                ));
+            }
+        }
+    }
+    if response.tests.truncated && active.contains(FAMILY_TESTS) {
+        gaps.push(gap(
+            FAMILY_TESTS,
+            response
+                .tests
+                .truncation_reason
+                .as_deref()
+                .unwrap_or("test_limit"),
+            "Related-test candidates were truncated.",
+        ));
+    }
+    gaps
+}
+
+fn gap(
+    family: impl Into<String>,
+    code: impl Into<String>,
+    message: impl Into<String>,
+) -> EvidenceGap {
+    EvidenceGap {
+        family: family.into(),
+        code: code.into(),
+        message: message.into(),
+    }
+}
+
+fn api_surface_changes(response: &ChangeImpactResponse) -> Vec<ApiSurfaceChange> {
+    let mut changes = BTreeMap::new();
+    for crossing in &response.api_crossings.items {
+        changes
+            .entry((
+                crossing.seed.file.clone(),
+                crossing.seed.line,
+                crossing.seed.name.clone(),
+                crossing.seed.kind.clone(),
+            ))
+            .or_insert_with(|| ApiSurfaceChange {
+                file: crossing.seed.file.clone(),
+                line: crossing.seed.line,
+                name: crossing.seed.name.clone(),
+                kind: crossing.seed.kind.clone(),
+                component: crossing.changed_component.clone(),
+            });
+    }
+    changes.into_values().collect()
+}
+
+fn impact_relations(response: &ChangeImpactResponse) -> Vec<ImpactRelation> {
+    let mut relations = Vec::new();
+    for impacted in &response.impact.items {
+        for seed in &impacted.seeds {
+            relations.push(ImpactRelation {
+                seed_file: seed.file.clone(),
+                seed_line: seed.line,
+                seed_name: seed.name.clone(),
+                impacted_file: impacted.symbol.file.clone(),
+                impacted_line: impacted.symbol.line,
+                impacted_name: impacted.symbol.name.clone(),
+                minimum_depth: impacted.minimum_depth,
+            });
+        }
+    }
+    relations.sort_by(|left, right| {
+        (
+            &left.seed_file,
+            left.seed_line,
+            &left.impacted_file,
+            left.impacted_line,
+            &left.impacted_name,
+        )
+            .cmp(&(
+                &right.seed_file,
+                right.seed_line,
+                &right.impacted_file,
+                right.impacted_line,
+                &right.impacted_name,
+            ))
+    });
+    relations
+}
+
+fn compare_cycles_to_baseline(
+    root: &Path,
+    baseline_oid: &str,
+    config: &PolicyConfig,
+    changed_paths: &BTreeSet<String>,
+    current_cycles: Vec<Vec<String>>,
+) -> Result<Vec<Vec<String>>, String> {
+    let scopes = config
+        .rules
+        .iter()
+        .filter_map(|rule| match &rule.kind {
+            PolicyRuleKind::NewCycles { scope, .. } => Some(scope),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let candidates = current_cycles
+        .into_iter()
+        .filter(|cycle| cycle.iter().any(|path| changed_paths.contains(path)))
+        .filter(|cycle| {
+            scopes
+                .iter()
+                .any(|scope| cycle.iter().any(|path| scope.matches(path)))
+        })
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+    let members = candidates
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    if members.len() > BASELINE_CYCLE_FILE_LIMIT {
+        return Err(format!(
+            "Cycle baseline comparison needs {} files, above the {}-file limit.",
+            members.len(),
+            BASELINE_CYCLE_FILE_LIMIT
+        ));
+    }
+    if members
+        .iter()
+        .any(|path| path.chars().any(char::is_control))
+    {
+        return Err("Cycle paths containing control characters cannot be compared safely.".into());
+    }
+    let paths = members.into_iter().collect::<Vec<_>>();
+    let blobs = baseline_blobs(root, baseline_oid, &paths)
+        .map_err(|error| format!("Cannot read baseline cycle members: {}.", error_code(error)))?;
+    let mut files = BTreeMap::new();
+    for path in &paths {
+        let Some(bytes) = blobs.get(path).and_then(Option::as_ref) else {
+            continue;
+        };
+        if bytes.len() as u64 > MAX_INDEXABLE_FILE_SIZE {
+            return Err(format!(
+                "Baseline cycle member `{path}` exceeds the source size limit."
+            ));
+        }
+        let extractor = extractor_for_path(Path::new(path))
+            .ok_or_else(|| format!("Baseline cycle member `{path}` has no extractor."))?;
+        let pending = parse_blob(path, bytes, 0, extractor.as_ref())
+            .map_err(|_| format!("Baseline cycle member `{path}` could not be parsed."))?;
+        files.insert(path.clone(), pending);
+    }
+    let baseline_edges = import_edges_from_pending(&files);
+    let baseline_cycles = crate::queries::map_cycle_components(&baseline_edges)
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    Ok(candidates
+        .into_iter()
+        .filter(|cycle| !baseline_cycles.contains(cycle))
+        .collect())
+}
+
+fn baseline_blobs(
+    root: &Path,
+    baseline_oid: &str,
+    paths: &[String],
+) -> Result<BTreeMap<String, Option<Vec<u8>>>, WorkingTreeDiffError> {
+    let mut input = Vec::new();
+    for path in paths {
+        input.extend_from_slice(baseline_oid.as_bytes());
+        input.push(b':');
+        input.extend_from_slice(path.as_bytes());
+        input.push(b'\n');
+    }
+    let output = run_bounded_git_with_limit(
+        root,
+        &["cat-file", "--batch"],
+        Some(&input),
+        BASELINE_CYCLE_BYTE_LIMIT,
+    )?;
+    if !output.success {
+        return Err(WorkingTreeDiffError::InvalidRef);
+    }
+    let mut cursor = 0usize;
+    let mut blobs = BTreeMap::new();
+    for path in paths {
+        let relative_newline = output
+            .stdout
+            .get(cursor..)
+            .and_then(|remaining| remaining.iter().position(|byte| *byte == b'\n'))
+            .ok_or(WorkingTreeDiffError::InvalidRef)?;
+        let header_end = cursor + relative_newline;
+        let header = &output.stdout[cursor..header_end];
+        cursor = header_end + 1;
+        if header.ends_with(b" missing") {
+            blobs.insert(path.clone(), None);
+            continue;
+        }
+        let header = std::str::from_utf8(header).map_err(|_| WorkingTreeDiffError::InvalidRef)?;
+        let size = header
+            .split_whitespace()
+            .nth(2)
+            .and_then(|value| value.parse::<usize>().ok())
+            .ok_or(WorkingTreeDiffError::InvalidRef)?;
+        let end = cursor
+            .checked_add(size)
+            .filter(|end| *end < output.stdout.len())
+            .ok_or(WorkingTreeDiffError::GitOutputLimit)?;
+        blobs.insert(path.clone(), Some(output.stdout[cursor..end].to_vec()));
+        cursor = end + 1;
+    }
+    Ok(blobs)
+}
+
+fn error_code(error: WorkingTreeDiffError) -> &'static str {
+    error.code()
+}
+
+fn import_edges_from_pending(files: &BTreeMap<String, PendingFile>) -> Vec<(String, String)> {
+    let mut targets: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (path, file) in files {
+        for symbol in &file.symbols {
+            targets
+                .entry(symbol.name.clone())
+                .or_default()
+                .push(path.clone());
+        }
+    }
+    let paths = files.keys().cloned().collect::<BTreeSet<_>>();
+    let mut pairs = BTreeSet::new();
+    for (source, file) in files {
+        for edge in file.edges.iter().filter(|edge| edge.kind == "imports") {
+            if file.language == "cpp" {
+                if let Some(encoded) = &edge.to_path {
+                    for target in resolve_cpp_include(source, encoded, &paths) {
+                        if &target != source {
+                            pairs.insert((source.clone(), target));
+                        }
+                    }
+                }
+            } else if let Some(resolved) = targets.get(&edge.to_name) {
+                for target in resolved {
+                    if target != source {
+                        pairs.insert((source.clone(), target.clone()));
+                    }
+                }
+            }
+        }
+    }
+    pairs.into_iter().collect()
+}
+
+fn resolve_cpp_include(source: &str, encoded: &str, paths: &BTreeSet<String>) -> BTreeSet<String> {
+    let include = encoded
+        .strip_suffix("::*")
+        .unwrap_or(encoded)
+        .replace('\\', "/");
+    let mut resolved = BTreeSet::new();
+    if let Some(path) = normalize_relative(&include) {
+        if paths.contains(&path) {
+            resolved.insert(path);
+        }
+    }
+    if let Some(parent) = source.rsplit_once('/').map(|(parent, _)| parent) {
+        if let Some(path) = normalize_relative(&format!("{parent}/{include}")) {
+            if paths.contains(&path) {
+                resolved.insert(path);
+            }
+        }
+    }
+    if resolved.is_empty() {
+        let lower = include.to_ascii_lowercase();
+        let basename = lower.rsplit('/').next().unwrap_or(&lower);
+        for candidate in paths {
+            let candidate_lower = candidate.to_ascii_lowercase();
+            if candidate_lower.rsplit('/').next() == Some(basename)
+                && (!lower.contains('/')
+                    || candidate_lower == lower
+                    || candidate_lower.ends_with(&format!("/{lower}")))
+            {
+                resolved.insert(candidate.clone());
+            }
+        }
+    }
+    resolved
+}
+
+fn normalize_relative(path: &str) -> Option<String> {
+    let mut parts = Vec::new();
+    for part in path.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                parts.pop()?;
+            }
+            value => parts.push(value),
+        }
+    }
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
+fn collect_workflow_evidence(
+    root: &Path,
+    requested: &Path,
+    baseline_oid: &str,
+    relevant_files: &BTreeSet<String>,
+) -> (BTreeMap<String, Vec<String>>, Vec<EvidenceGap>) {
+    if relevant_files.is_empty() {
+        return (BTreeMap::new(), Vec::new());
+    }
+    let path = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        root.join(requested)
+    };
+    if !path.exists() {
+        return (BTreeMap::new(), Vec::new());
+    }
+    let metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => metadata,
+        _ => {
+            return (
+                BTreeMap::new(),
+                vec![gap(
+                    FAMILY_WORKFLOW,
+                    "workflow_evidence_invalid",
+                    "Workflow evidence must be a real directory, not a symlink.",
+                )],
+            )
+        }
+    };
+    let _ = metadata;
+    let mut task_dirs = match std::fs::read_dir(&path) {
+        Ok(entries) => entries
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .collect::<Vec<_>>(),
+        Err(_) => {
+            return (
+                BTreeMap::new(),
+                vec![gap(
+                    FAMILY_WORKFLOW,
+                    "workflow_evidence_unreadable",
+                    "Workflow evidence directory could not be read.",
+                )],
+            )
+        }
+    };
+    task_dirs.sort();
+    let mut gaps = Vec::new();
+    if task_dirs.len() > WORKFLOW_TASK_LIMIT {
+        task_dirs.truncate(WORKFLOW_TASK_LIMIT);
+        gaps.push(gap(
+            FAMILY_WORKFLOW,
+            "workflow_task_limit",
+            "Workflow evidence exceeded the 1,000-task work limit.",
+        ));
+    }
+
+    let mut files: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for task_dir in task_dirs {
+        if !is_real_directory(&task_dir) {
+            continue;
+        }
+        let spec_path = task_dir.join("spec.md");
+        let state_path = task_dir.join("state.json");
+        let audit_path = task_dir.join("audit.md");
+        let Some(spec_body) = read_small_regular_file(&spec_path) else {
+            continue;
+        };
+        let parsed = crate::spec::parse_str(&spec_path.to_string_lossy(), &spec_body);
+        let Some(frontmatter) = parsed.frontmatter else {
+            continue;
+        };
+        if frontmatter.mode.as_deref() != Some("strict") {
+            continue;
+        }
+        let touches = frontmatter
+            .touches
+            .iter()
+            .filter_map(|touch| normalize_evidence_path(&touch.file))
+            .collect::<BTreeSet<_>>();
+        if touches.is_disjoint(relevant_files) {
+            continue;
+        }
+        let Some(state_body) = read_small_regular_file(&state_path) else {
+            continue;
+        };
+        let Ok(state) = serde_json::from_str::<RunState>(&state_body) else {
+            continue;
+        };
+        if state.baseline_ref != baseline_oid
+            || !matches!(state.status.as_str(), "history_review_required" | "learned")
+            || state.spec_hash != crate::run_task::hash_text(&spec_body)
+        {
+            continue;
+        }
+        if !state_spec_matches(&state.spec_path, &spec_path, &task_dir) {
+            continue;
+        }
+        let Some(audit) = read_small_regular_file(&audit_path) else {
+            continue;
+        };
+        if !audit
+            .lines()
+            .next()
+            .is_some_and(|line| line.starts_with("✅ Held"))
+        {
+            continue;
+        }
+        let Some(expected_snapshot) = state.held_snapshot_sha256.as_deref() else {
+            continue;
+        };
+        let touch_files = touches.iter().cloned().collect::<Vec<_>>();
+        match crate::run_task::strict_workflow_snapshot(root, baseline_oid, &touch_files) {
+            Ok(current_snapshot) if current_snapshot == expected_snapshot => {}
+            Ok(_) => continue,
+            Err(message) => {
+                gaps.push(gap(
+                    FAMILY_WORKFLOW,
+                    "workflow_snapshot_unavailable",
+                    message,
+                ));
+                continue;
+            }
+        }
+        let evidence_path = task_dir
+            .strip_prefix(root)
+            .unwrap_or(&task_dir)
+            .to_string_lossy()
+            .replace('\\', "/");
+        for path in touches.intersection(relevant_files) {
+            files
+                .entry(path.clone())
+                .or_default()
+                .push(evidence_path.clone());
+        }
+    }
+    for paths in files.values_mut() {
+        paths.sort();
+        paths.dedup();
+    }
+    (files, gaps)
+}
+
+fn state_spec_matches(state_spec: &str, current_spec: &Path, task_dir: &Path) -> bool {
+    if Path::new(state_spec)
+        .canonicalize()
+        .ok()
+        .zip(current_spec.canonicalize().ok())
+        .is_some_and(|(state, current)| state == current)
+    {
+        return true;
+    }
+    let Some(task_id) = task_dir.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let normalized = state_spec.replace('\\', "/");
+    let suffix = format!(".mastermind/tasks/{task_id}/spec.md");
+    normalized == suffix || normalized.ends_with(&format!("/{suffix}"))
+}
+
+fn is_real_directory(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .is_ok_and(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink())
+}
+
+fn read_small_regular_file(path: &Path) -> Option<String> {
+    let metadata = std::fs::symlink_metadata(path).ok()?;
+    if !metadata.is_file()
+        || metadata.file_type().is_symlink()
+        || metadata.len() == 0
+        || metadata.len() > WORKFLOW_ARTIFACT_BYTE_LIMIT
+    {
+        return None;
+    }
+    std::fs::read_to_string(path).ok()
+}
+
+fn normalize_evidence_path(path: &str) -> Option<String> {
+    let path = path.trim().replace('\\', "/");
+    if path.is_empty()
+        || path.starts_with('/')
+        || path.starts_with("//")
+        || path.as_bytes().get(1) == Some(&b':')
+        || path
+            .split('/')
+            .any(|part| part == ".." || part.chars().any(char::is_control))
+    {
+        None
+    } else {
+        Some(
+            path.split('/')
+                .filter(|part| !part.is_empty() && *part != ".")
+                .collect::<Vec<_>>()
+                .join("/"),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn held_strict_workflow_evidence_is_bound_to_baseline_and_touched_file() {
+        let root = tempfile::tempdir().unwrap();
+        run(root.path(), &["init", "-b", "main"]);
+        run(root.path(), &["config", "user.email", "policy@example.com"]);
+        run(root.path(), &["config", "user.name", "Policy Test"]);
+        let task = root.path().join(".mastermind/tasks/001-payment");
+        let source = root.path().join("services/payment/charge.ts");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(&source, "export function charge() { return 0; }\n").unwrap();
+        run(root.path(), &["add", "."]);
+        run(root.path(), &["commit", "-m", "baseline"]);
+        let baseline = output(root.path(), &["rev-parse", "HEAD"]);
+        fs::write(&source, "export function charge() { return 1; }\n").unwrap();
+        fs::create_dir_all(&task).unwrap();
+        let spec_body =
+            "---\nmode: strict\ntouches:\n  - file: services/payment/charge.ts\n---\n# Payment\n";
+        fs::write(task.join("spec.md"), spec_body).unwrap();
+        let touch_files = vec!["services/payment/charge.ts".to_string()];
+        let held_snapshot =
+            crate::run_task::strict_workflow_snapshot(root.path(), &baseline, &touch_files)
+                .unwrap();
+        fs::write(
+            task.join("state.json"),
+            serde_json::to_vec(&RunState {
+                status: "learned".into(),
+                risk: Some("low".into()),
+                next_step: Some("close".into()),
+                blocking_reason: None,
+                last_artifact: Some("audit.md".into()),
+                spec_path: "/original/checkout/.mastermind/tasks/001-payment/spec.md".into(),
+                spec_hash: crate::run_task::hash_text(spec_body),
+                baseline_ref: baseline.clone(),
+                held_snapshot_sha256: Some(held_snapshot),
+                started_at: 1,
+                iteration: 1,
+                allow_no_index: false,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(task.join("audit.md"), "✅ Held — spec.md\n").unwrap();
+        let relevant = BTreeSet::from(["services/payment/charge.ts".to_string()]);
+
+        let (files, gaps) = collect_workflow_evidence(
+            root.path(),
+            Path::new(".mastermind/tasks"),
+            &baseline,
+            &relevant,
+        );
+        assert!(gaps.is_empty());
+        assert_eq!(
+            files["services/payment/charge.ts"],
+            [".mastermind/tasks/001-payment"]
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let original_mode = fs::metadata(&source).unwrap().permissions().mode();
+            let mut executable = fs::metadata(&source).unwrap().permissions();
+            executable.set_mode(original_mode | 0o111);
+            fs::set_permissions(&source, executable).unwrap();
+            let (mode_stale, _) = collect_workflow_evidence(
+                root.path(),
+                Path::new(".mastermind/tasks"),
+                &baseline,
+                &relevant,
+            );
+            assert!(mode_stale.is_empty());
+            let mut restored = fs::metadata(&source).unwrap().permissions();
+            restored.set_mode(original_mode);
+            fs::set_permissions(&source, restored).unwrap();
+        }
+
+        let (wrong_baseline, _) = collect_workflow_evidence(
+            root.path(),
+            Path::new(".mastermind/tasks"),
+            &"2".repeat(40),
+            &relevant,
+        );
+        assert!(wrong_baseline.is_empty());
+
+        fs::write(&source, "export function charge() { return 2; }\n").unwrap();
+        let (stale, gaps) = collect_workflow_evidence(
+            root.path(),
+            Path::new(".mastermind/tasks"),
+            &baseline,
+            &relevant,
+        );
+        assert!(stale.is_empty());
+        assert!(
+            gaps.is_empty(),
+            "a stale held artifact is not current evidence"
+        );
+    }
+
+    #[test]
+    fn baseline_graph_detects_a_new_cycle_without_checkout_mutation() {
+        let root = tempfile::tempdir().unwrap();
+        let repo = root.path();
+        run(repo, &["init"]);
+        run(repo, &["config", "user.email", "policy@example.com"]);
+        run(repo, &["config", "user.name", "Policy Test"]);
+        fs::write(
+            repo.join("a.py"),
+            "from b import b\ndef a():\n    return b()\n",
+        )
+        .unwrap();
+        fs::write(repo.join("b.py"), "def b():\n    return 1\n").unwrap();
+        run(repo, &["add", "."]);
+        run(repo, &["commit", "-m", "baseline"]);
+        let baseline = output(repo, &["rev-parse", "HEAD"]);
+        fs::write(
+            repo.join("b.py"),
+            "from a import a\ndef b():\n    return a()\n",
+        )
+        .unwrap();
+        let config =
+            super::super::parse_config(br#"rules: [{id: cycles, scope: "**", max_new_cycles: 0}]"#)
+                .unwrap();
+        let cycles = compare_cycles_to_baseline(
+            repo,
+            baseline.trim(),
+            &config,
+            &BTreeSet::from(["b.py".into()]),
+            vec![vec!["a.py".into(), "b.py".into()]],
+        )
+        .unwrap();
+        assert_eq!(cycles, [vec!["a.py", "b.py"]]);
+    }
+
+    #[test]
+    fn full_check_connects_all_policy_families_to_real_repository_evidence() {
+        let root = tempfile::tempdir().unwrap();
+        let repo = root.path();
+        run(repo, &["init", "-b", "main"]);
+        run(repo, &["config", "user.email", "policy@example.com"]);
+        run(repo, &["config", "user.name", "Policy Test"]);
+        for directory in [
+            "src/domain",
+            "src/infrastructure",
+            "services/payment",
+            "api",
+            ".mastermind",
+        ] {
+            fs::create_dir_all(repo.join(directory)).unwrap();
+        }
+        fs::write(
+            repo.join("src/infrastructure/db.py"),
+            "def save():\n    return True\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("src/domain/order.py"),
+            "from src.infrastructure.db import save\ndef order():\n    return save()\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("services/payment/a.py"),
+            "from services.payment.b import b\ndef a():\n    return b()\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("services/payment/b.py"),
+            "def b():\n    return 1\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("services/payment/charge.py"),
+            "def charge():\n    return 1\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("api/checkout.py"),
+            "from services.payment.charge import charge\ndef checkout():\n    return charge()\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("CODEOWNERS"),
+            "/services/payment/ @payments\n/api/ @platform\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("mastermind-policy.yml"),
+            r#"version: 1
+rules:
+  - id: direction
+    from: src/domain/**
+    deny_imports: src/infrastructure/**
+  - id: cycles
+    scope: services/payment/**
+    max_new_cycles: 0
+  - id: api-owner
+    when: api_surface_changed
+    require_owner: platform
+  - id: blast
+    scope: services/payment/**
+    max_blast_radius: 0
+  - id: tests
+    scope: services/payment/**
+    require_tests: true
+  - id: owner-boundary
+    scope: services/payment/**
+    deny_ownership_crossings: true
+  - id: workflow
+    critical: services/payment/**
+    require_workflow: strict
+"#,
+        )
+        .unwrap();
+        run(repo, &["add", "."]);
+        run(repo, &["commit", "-m", "baseline"]);
+
+        let index = repo.join(".mastermind/mmcg.db");
+        let mut store = Store::open(&index).unwrap();
+        crate::indexer::Indexer::new(repo)
+            .index_all(&mut store, true)
+            .unwrap();
+        fs::write(
+            repo.join("services/payment/b.py"),
+            "from services.payment.a import a\ndef b():\n    return a()\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("services/payment/charge.py"),
+            "def charge():\n    return 2\n",
+        )
+        .unwrap();
+        fs::write(
+            repo.join("src/domain/order.py"),
+            "from src.infrastructure.db import save\ndef order():\n    return bool(save())\n",
+        )
+        .unwrap();
+        crate::indexer::Indexer::new(repo)
+            .index_all(&mut store, true)
+            .unwrap();
+
+        let report = super::super::check(
+            &store,
+            repo,
+            &super::super::CheckOptions {
+                since: "main".into(),
+                config_path: "mastermind-policy.yml".into(),
+                codeowners: None,
+                workflow_evidence_path: ".mastermind/tasks".into(),
+                depth: 3,
+                top: 500,
+            },
+        )
+        .unwrap();
+        let violated = report
+            .violations
+            .iter()
+            .map(|violation| violation.rule_id.as_str())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            violated,
+            BTreeSet::from([
+                "api-owner",
+                "blast",
+                "cycles",
+                "direction",
+                "owner-boundary",
+                "tests",
+                "workflow",
+            ]),
+            "violations: {:#?}; diagnostics: {:#?}",
+            report.violations,
+            report.diagnostics
+        );
+        assert!(report.complete, "diagnostics: {:#?}", report.diagnostics);
+    }
+
+    #[test]
+    fn deletion_only_stale_index_is_rejected_before_policy_evaluation() {
+        let root = tempfile::tempdir().unwrap();
+        let repo = root.path();
+        run(repo, &["init", "-b", "main"]);
+        run(repo, &["config", "user.email", "policy@example.com"]);
+        run(repo, &["config", "user.name", "Policy Test"]);
+        fs::write(repo.join("a.py"), "def a():\n    return 1\n").unwrap();
+        fs::write(
+            repo.join("mastermind-policy.yml"),
+            "rules:\n  - id: direction\n    from: src/**\n    deny_imports: vendor/**\n",
+        )
+        .unwrap();
+        run(repo, &["add", "."]);
+        run(repo, &["commit", "-m", "baseline"]);
+        fs::create_dir_all(repo.join(".mastermind")).unwrap();
+        let mut store = Store::open(repo.join(".mastermind/mmcg.db")).unwrap();
+        crate::indexer::Indexer::new(repo)
+            .index_all(&mut store, true)
+            .unwrap();
+        fs::remove_file(repo.join("a.py")).unwrap();
+
+        let error = super::super::check(
+            &store,
+            repo,
+            &super::super::CheckOptions {
+                since: "main".into(),
+                config_path: "mastermind-policy.yml".into(),
+                codeowners: None,
+                workflow_evidence_path: ".mastermind/tasks".into(),
+                depth: 3,
+                top: 500,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "policy_evidence_unavailable");
+        assert!(error.to_string().contains("index_stale"));
+    }
+
+    fn run(root: &Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    fn output(root: &Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    }
+}

--- a/mcp/servers/mmcg/src/queries.rs
+++ b/mcp/servers/mmcg/src/queries.rs
@@ -497,6 +497,8 @@ pub struct Collection<T> {
 #[derive(Debug, Clone, Serialize)]
 pub struct ChangeImpactResponse {
     pub schema_version: u32,
+    #[serde(skip)]
+    pub(crate) snapshot_token: String,
     pub baseline: ImpactBaseline,
     pub scope: ImpactScope,
     pub changes: ImpactChanges,
@@ -1403,6 +1405,7 @@ pub fn change_impact(
     };
     Ok(ChangeImpactResponse {
         schema_version: 1,
+        snapshot_token: working.snapshot_token,
         baseline: ImpactBaseline {
             requested_ref: git_ref.to_string(),
             baseline_oid: working.baseline_oid,
@@ -2199,7 +2202,7 @@ fn boundary_scope(scope: &str, kind: &str, component: &str) -> Option<MapBoundar
     }
 }
 
-fn map_cycle_components(edges: &[(String, String)]) -> Vec<Vec<String>> {
+pub(crate) fn map_cycle_components(edges: &[(String, String)]) -> Vec<Vec<String>> {
     let mut graph: std::collections::BTreeMap<String, Vec<String>> = Default::default();
     let mut reverse: std::collections::BTreeMap<String, Vec<String>> = Default::default();
     for (from, to) in edges {

--- a/mcp/servers/mmcg/src/run_task.rs
+++ b/mcp/servers/mmcg/src/run_task.rs
@@ -22,10 +22,16 @@ use crate::spec::{self, ParsedSpec};
 use crate::store::Store;
 use crate::verify_spec;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeSet, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+const STRICT_EVIDENCE_FILE_LIMIT: usize = 1_000;
+const STRICT_EVIDENCE_TOTAL_BYTE_LIMIT: u64 = 32 * 1024 * 1024;
+const STRICT_EVIDENCE_GIT_BYTE_LIMIT: usize = 2 * 1024 * 1024;
 
 /// Controller-owned handshake between pre- and post-flight. Canonical task
 /// specs keep it beside the spec as `<task>/state.json`; legacy flat specs use
@@ -50,6 +56,11 @@ pub struct RunState {
     pub spec_hash: String,
     /// `git rev-parse HEAD` captured at pre-flight — the audit's `--since`.
     pub baseline_ref: String,
+    /// SHA-256 binding a held strict audit to the exact declared touch files.
+    /// Older state files deserialize without it and are not accepted as
+    /// architecture-policy evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub held_snapshot_sha256: Option<String>,
     /// Unix epoch seconds at pre-flight.
     pub started_at: u64,
     /// Iteration count — +1 on every pre-flight entry; first fresh run is `1`.
@@ -353,10 +364,148 @@ pub fn delete_state(path: &Path) -> std::io::Result<()> {
 /// Rust toolchain — fine for "did the spec change between pre and post" on the
 /// same machine. Cross-toolchain-upgrade false positives are harmless (warn,
 /// not block).
-fn hash_text(text: &str) -> String {
+pub(crate) fn hash_text(text: &str) -> String {
     let mut h = DefaultHasher::new();
     text.hash(&mut h);
     format!("{:016x}", h.finish())
+}
+
+pub(crate) fn strict_workflow_snapshot(
+    repo_root: &Path,
+    baseline_ref: &str,
+    touch_files: &[String],
+) -> Result<String, String> {
+    if !matches!(baseline_ref.len(), 40 | 64)
+        || !baseline_ref.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err("strict-workflow baseline must be an exact Git object ID".into());
+    }
+    let mut paths = BTreeSet::new();
+    for file in touch_files {
+        let normalized = crate::audit_bundle::normalize_relative_path(Path::new(file))
+            .map_err(|_| format!("invalid strict-workflow touch path `{file}`"))?;
+        if normalized.starts_with(".mastermind/tasks/")
+            || normalized.starts_with(".mastermind/releases/")
+        {
+            return Err(format!(
+                "strict-workflow evidence cannot attest its own artifact path `{normalized}`"
+            ));
+        }
+        paths.insert(normalized);
+    }
+    if paths.is_empty() || paths.len() > STRICT_EVIDENCE_FILE_LIMIT {
+        return Err(format!(
+            "strict-workflow evidence requires 1..={STRICT_EVIDENCE_FILE_LIMIT} touch files"
+        ));
+    }
+
+    let root = repo_root
+        .canonicalize()
+        .map_err(|_| "strict-workflow repository root is unavailable".to_string())?;
+    let mut digest = Sha256::new();
+    digest.update(b"mastermind-strict-workflow-snapshot-v1\0");
+    digest.update(baseline_ref.as_bytes());
+    digest.update([0]);
+    let mut git_args = vec![
+        "-c",
+        "diff.external=",
+        "diff",
+        "--raw",
+        "--no-abbrev",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-renames",
+        baseline_ref,
+        "--",
+    ];
+    git_args.extend(paths.iter().map(String::as_str));
+    let raw = crate::diff::run_bounded_git_with_limit(
+        &root,
+        &git_args,
+        None,
+        STRICT_EVIDENCE_GIT_BYTE_LIMIT,
+    )
+    .map_err(|error| format!("strict-workflow git snapshot failed: {}", error.code()))?;
+    if !raw.success {
+        return Err("strict-workflow baseline is unavailable".into());
+    }
+    digest.update(b"git-raw\0");
+    digest.update(raw.stdout);
+    digest.update([0]);
+    let mut total_bytes = 0u64;
+
+    for relative in &paths {
+        digest.update(relative.as_bytes());
+        digest.update([0]);
+        let mut current = root.clone();
+        let parts = relative.split('/').collect::<Vec<_>>();
+        let mut missing = false;
+        for (index, part) in parts.iter().enumerate() {
+            current.push(part);
+            match std::fs::symlink_metadata(&current) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    return Err(format!(
+                        "strict-workflow touch path `{relative}` traverses a symlink"
+                    ));
+                }
+                Ok(metadata) if index + 1 < parts.len() && !metadata.is_dir() => {
+                    return Err(format!(
+                        "strict-workflow touch path `{relative}` has a non-directory parent"
+                    ));
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    missing = true;
+                    break;
+                }
+                Err(_) => {
+                    return Err(format!(
+                        "strict-workflow touch path `{relative}` cannot be inspected"
+                    ));
+                }
+            }
+        }
+        if missing {
+            digest.update(b"missing\0");
+            continue;
+        }
+
+        let metadata = std::fs::symlink_metadata(&current)
+            .map_err(|_| format!("strict-workflow touch path `{relative}` cannot be inspected"))?;
+        if !metadata.is_file() {
+            return Err(format!(
+                "strict-workflow touch path `{relative}` is not a regular file"
+            ));
+        }
+        if metadata.len() > crate::audit_bundle::BUNDLE_INPUT_MAX as u64 {
+            return Err(format!(
+                "strict-workflow touch file `{relative}` exceeds the 16 MiB limit"
+            ));
+        }
+        total_bytes = total_bytes
+            .checked_add(metadata.len())
+            .filter(|total| *total <= STRICT_EVIDENCE_TOTAL_BYTE_LIMIT)
+            .ok_or_else(|| {
+                "strict-workflow touch files exceed the 32 MiB total limit".to_string()
+            })?;
+        digest.update(b"file\0");
+        digest.update(metadata.len().to_le_bytes());
+
+        let mut file = std::fs::File::open(&current)
+            .map_err(|_| format!("strict-workflow touch file `{relative}` cannot be read"))?;
+        let mut buffer = [0u8; 64 * 1024];
+        loop {
+            let read = file
+                .read(&mut buffer)
+                .map_err(|_| format!("strict-workflow touch file `{relative}` cannot be read"))?;
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+        }
+        digest.update([0]);
+    }
+    Ok(crate::hex::encode(&digest.finalize()))
 }
 
 fn timestamp_now() -> u64 {
@@ -805,6 +954,7 @@ fn run_pre(
         spec_path: resolved_spec_path.display().to_string(),
         spec_hash: hash_text(&spec_body),
         baseline_ref: head.clone(),
+        held_snapshot_sha256: None,
         started_at: timestamp_now(),
         iteration,
         allow_no_index: opts.allow_no_index,
@@ -993,6 +1143,28 @@ fn run_post(
     }
 
     if matches!(outcome, Outcome::PostHeld) {
+        let held_snapshot_sha256 = match parsed.frontmatter.as_ref() {
+            Some(frontmatter)
+                if frontmatter.mode.as_deref() == Some("strict")
+                    && !frontmatter.touches.is_empty() =>
+            {
+                let touches = frontmatter
+                    .touches
+                    .iter()
+                    .map(|touch| touch.file.clone())
+                    .collect::<Vec<_>>();
+                match strict_workflow_snapshot(repo_root, &state.baseline_ref, &touches) {
+                    Ok(snapshot) => Some(snapshot),
+                    Err(error) => {
+                        eprintln!(
+                            "warning: held audit has no architecture-policy snapshot: {error}"
+                        );
+                        None
+                    }
+                }
+            }
+            _ => None,
+        };
         let notes = compute_release_notes(
             &parsed,
             &spec_body,
@@ -1049,6 +1221,7 @@ fn run_post(
         complete.risk = Some("low".into());
         complete.blocking_reason = None;
         complete.last_artifact = Some("history-review.md".into());
+        complete.held_snapshot_sha256 = held_snapshot_sha256;
         if let Err(error) = save_state(state_path, &complete) {
             eprintln!(
                 "error: persisting post-flight state `{}`: {error}",
@@ -1326,6 +1499,7 @@ verifications: []\n\
             spec_path: "specs/foo.md".into(),
             spec_hash: "deadbeefcafef00d".into(),
             baseline_ref: "abc1234".into(),
+            held_snapshot_sha256: Some("feedface".into()),
             started_at: 123456,
             iteration: 0,
             allow_no_index: true,
@@ -1335,6 +1509,7 @@ verifications: []\n\
         assert_eq!(loaded.spec_path, state.spec_path);
         assert_eq!(loaded.spec_hash, state.spec_hash);
         assert_eq!(loaded.baseline_ref, state.baseline_ref);
+        assert_eq!(loaded.held_snapshot_sha256, state.held_snapshot_sha256);
         assert_eq!(loaded.started_at, state.started_at);
         assert!(loaded.allow_no_index);
         delete_state(&path).unwrap();
@@ -1674,6 +1849,16 @@ verifications: []\n\
         fs::write(
             &spec_path,
             "\
+---
+mode: strict
+touches:
+  - file: src/lib.py
+    language: python
+    symbols:
+      - name: stays
+verify:
+  - cmd: python3 -m py_compile src/lib.py
+---
 # Clean add
 
 ## Goals
@@ -1732,6 +1917,10 @@ verifications: []\n\
         // remains an explicit lifecycle phase.
         let completed = load_state(&state_path).unwrap().expect("review state");
         assert_eq!(completed.status, "history_review_required");
+        assert!(
+            completed.held_snapshot_sha256.is_some(),
+            "a held strict task must persist an exact touch-file snapshot"
+        );
         assert_eq!(completed.next_step.as_deref(), Some("review_history"));
         assert_eq!(
             completed.last_artifact.as_deref(),

--- a/mcp/servers/mmcg/src/sarif_export.rs
+++ b/mcp/servers/mmcg/src/sarif_export.rs
@@ -3,12 +3,15 @@
 //! The exporter reports only evidence already returned by bounded map/impact
 //! queries. It never upgrades a partial graph into a claim of completeness.
 
+use crate::policy::PolicyReport;
 use crate::queries::{ChangeImpactResponse, ProjectMapResponse};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 const SARIF_SCHEMA: &str = "https://json.schemastore.org/sarif-2.1.0.json";
 const CYCLE_RULE: &str = "mastermind/dependency-cycle";
 const CROSSING_RULE: &str = "mastermind/component-boundary-change";
+const POLICY_INCOMPLETE_RULE: &str = "mastermind/policy-evaluation-incomplete";
 
 pub fn project_map(map: &ProjectMapResponse) -> Value {
     let mut partial_reasons = Vec::new();
@@ -162,6 +165,127 @@ pub fn change_impact(response: &ChangeImpactResponse) -> Value {
     )
 }
 
+pub fn architecture_policy(report: &PolicyReport) -> Value {
+    let mut rules = report
+        .rules
+        .iter()
+        .map(|item| policy_rule(&item.id, item.kind, item.description))
+        .collect::<Vec<_>>();
+    if !report.diagnostics.is_empty() {
+        rules.push(policy_rule(
+            POLICY_INCOMPLETE_RULE,
+            "policy-evaluation-incomplete",
+            "Architecture policy evidence was incomplete, so the check cannot pass.",
+        ));
+    }
+
+    let mut results = report
+        .violations
+        .iter()
+        .map(|violation| {
+            let related = violation
+                .related_locations
+                .iter()
+                .enumerate()
+                .map(|(index, related)| {
+                    let mut value = location(&related.path, related.line);
+                    value["id"] = json!(index + 1);
+                    value["message"] = json!({ "text": safe_message_text(&related.message, 240) });
+                    value
+                })
+                .collect::<Vec<_>>();
+            let mut properties = violation.properties.clone();
+            properties.insert("policyRuleKind".into(), json!(violation.rule_kind));
+            properties.insert("baselineOid".into(), json!(report.baseline.baseline_oid));
+            properties.insert("headOid".into(), json!(report.baseline.head_oid));
+            let fingerprint = stable_fingerprint(&json!({
+                "ruleId": violation.rule_id,
+                "ruleKind": violation.rule_kind,
+                "path": violation.location.path,
+                "message": violation.message,
+                "relatedPaths": violation
+                    .related_locations
+                    .iter()
+                    .map(|location| location.path.as_str())
+                    .collect::<Vec<_>>(),
+                "properties": violation.properties
+            }));
+            json!({
+                "ruleId": violation.rule_id,
+                "level": violation.level,
+                "message": { "text": safe_message_text(&violation.message, 1_000) },
+                "partialFingerprints": { "primaryLocationLineHash": fingerprint },
+                "locations": [{
+                    "message": { "text": safe_message_text(&violation.location.message, 240) },
+                    "physicalLocation": physical_location(
+                        &violation.location.path,
+                        violation.location.line
+                    )
+                }],
+                "relatedLocations": related,
+                "properties": properties
+            })
+        })
+        .collect::<Vec<_>>();
+    results.extend(report.diagnostics.iter().map(|diagnostic| {
+        let fingerprint = stable_fingerprint(&json!({
+            "ruleId": diagnostic.rule_id,
+            "code": diagnostic.code,
+            "configPath": report.config.path
+        }));
+        json!({
+            "ruleId": POLICY_INCOMPLETE_RULE,
+            "level": "error",
+            "partialFingerprints": { "primaryLocationLineHash": fingerprint },
+            "message": {
+                "text": safe_message_text(
+                    &format!(
+                        "Policy rule '{}' could not be evaluated completely ({}): {}",
+                        diagnostic.rule_id, diagnostic.code, diagnostic.message
+                    ),
+                    1_000
+                )
+            },
+            "locations": [location(&report.config.path, None)],
+            "properties": {
+                "policyRuleId": diagnostic.rule_id,
+                "diagnosticCode": diagnostic.code,
+                "baselineOid": report.baseline.baseline_oid,
+                "headOid": report.baseline.head_oid
+            }
+        })
+    }));
+
+    document(
+        "mastermind/policy-check/",
+        rules,
+        results,
+        json!({
+            "analysis": "architecture-policy",
+            "configPath": report.config.path,
+            "configSha256": report.config.sha256,
+            "configVersion": report.config.version,
+            "requestedRef": report.baseline.requested_ref,
+            "baselineOid": report.baseline.baseline_oid,
+            "headOid": report.baseline.head_oid,
+            "includesWorktree": report.baseline.includes_worktree,
+            "includesUntracked": report.baseline.includes_untracked,
+            "passed": report.passed,
+            "partial": !report.complete,
+            "rulesEvaluated": report.summary.rules_evaluated,
+            "violations": report.summary.violations,
+            "diagnostics": report.summary.diagnostics,
+            "precisionNotes": report.precision_notes
+        }),
+    )
+}
+
+fn stable_fingerprint(value: &Value) -> String {
+    let bytes = serde_json::to_vec(value).expect("JSON value serialization is infallible");
+    let digest = crate::hex::encode(&Sha256::digest(bytes));
+    format!("{}:1", &digest[..16])
+}
+
 fn document(
     automation_id: &str,
     rules: Vec<Value>,
@@ -229,6 +353,24 @@ fn rule(id: &str, name: &str, description: &str, help: &str) -> Value {
             "precision": "high",
             "problem.severity": "warning",
             "tags": ["architecture", "mastermind"]
+        }
+    })
+}
+
+fn policy_rule(id: &str, name: &str, description: &str) -> Value {
+    json!({
+        "id": id,
+        "name": name,
+        "shortDescription": { "text": description },
+        "fullDescription": { "text": description },
+        "help": {
+            "text": "Change the architecture, add the required evidence, or update the repository-owned policy deliberately."
+        },
+        "defaultConfiguration": { "level": "error" },
+        "properties": {
+            "precision": "medium",
+            "problem.severity": "error",
+            "tags": ["architecture", "policy", "mastermind"]
         }
     })
 }
@@ -312,6 +454,7 @@ mod tests {
         };
         let response = ChangeImpactResponse {
             schema_version: 1,
+            snapshot_token: "snapshot".into(),
             baseline: ImpactBaseline {
                 requested_ref: "main".into(),
                 baseline_oid: "111".into(),

--- a/mcp/servers/mmcg/tests/policy_cli.rs
+++ b/mcp/servers/mmcg/tests/policy_cli.rs
@@ -1,0 +1,72 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+#[test]
+fn policy_cli_emits_sarif_and_uses_exit_status_as_the_gate() {
+    let root = tempfile::tempdir().unwrap();
+    let repo = root.path();
+    git(repo, &["init", "-b", "main"]);
+    git(repo, &["config", "user.email", "policy@example.com"]);
+    git(repo, &["config", "user.name", "Policy Test"]);
+    fs::create_dir_all(repo.join("src")).unwrap();
+    fs::write(repo.join("src/app.py"), "def app():\n    return 1\n").unwrap();
+    fs::write(
+        repo.join("mastermind-policy.yml"),
+        "rules:\n  - id: critical\n    critical: src/**\n    require_workflow: strict\n",
+    )
+    .unwrap();
+    git(repo, &["add", "."]);
+    git(repo, &["commit", "-m", "baseline"]);
+
+    let binary = env!("CARGO_BIN_EXE_mmcg");
+    let indexed = Command::new(binary)
+        .args(["index", ".", "--force"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    assert!(indexed.status.success(), "{:?}", indexed);
+
+    let clean = policy(binary, repo);
+    assert!(clean.status.success(), "{:?}", clean);
+    let clean: Value = serde_json::from_slice(&clean.stdout).unwrap();
+    assert_eq!(clean["runs"][0]["properties"]["passed"], true);
+    assert_eq!(clean["runs"][0]["results"].as_array().unwrap().len(), 0);
+
+    fs::write(repo.join("src/app.py"), "def app():\n    return 2\n").unwrap();
+    let refreshed = Command::new(binary)
+        .args(["index", ".", "--force"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    assert!(refreshed.status.success(), "{:?}", refreshed);
+
+    let failed = policy(binary, repo);
+    assert!(
+        !failed.status.success(),
+        "policy violation must exit non-zero"
+    );
+    let failed: Value = serde_json::from_slice(&failed.stdout).unwrap();
+    assert_eq!(failed["runs"][0]["properties"]["passed"], false);
+    assert_eq!(failed["runs"][0]["properties"]["partial"], false);
+    assert_eq!(failed["runs"][0]["results"][0]["ruleId"], "critical");
+    assert_eq!(failed["runs"][0]["results"][0]["level"], "error");
+}
+
+fn policy(binary: &str, root: &Path) -> Output {
+    Command::new(binary)
+        .args(["policy", "check", "--since", "HEAD", "--format", "sarif"])
+        .current_dir(root)
+        .output()
+        .unwrap()
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{:?}", output);
+}

--- a/scripts/test_audit_workflow_security.py
+++ b/scripts/test_audit_workflow_security.py
@@ -512,6 +512,9 @@ class RepositoryDeliveryContractTests(unittest.TestCase):
     def test_docker_action_uses_default_root_user_for_workspace_access(self):
         dockerfile = (ROOT / "Dockerfile.audit-action").read_text(encoding="utf-8")
         self.assertIn("COPY mcp/servers/mmcg/benches ./mcp/servers/mmcg/benches", dockerfile)
+        self.assertIn(
+            "COPY mcp/servers/mmcg/build.rs ./mcp/servers/mmcg/build.rs", dockerfile
+        )
         self.assertIsNone(
             re.search(r"^USER\s+", dockerfile, flags=re.MULTILINE),
             "GitHub Docker Actions must use the default root user for GITHUB_WORKSPACE",

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1341,6 +1341,8 @@ def validate_audit_action_security() -> list[Issue]:
             issues.append(Issue(docker_path, "error", "Docker Action must build with Rust 1.96 and the Cargo lockfile"))
         if "COPY mcp/servers/mmcg/benches ./mcp/servers/mmcg/benches" not in docker_text:
             issues.append(Issue(docker_path, "error", "Docker Action must include Cargo's declared benchmark target"))
+        if "COPY mcp/servers/mmcg/build.rs ./mcp/servers/mmcg/build.rs" not in docker_text:
+            issues.append(Issue(docker_path, "error", "Docker Action must include Cargo's declared build script"))
         if "COPY --chmod=0755 scripts/audit-action-entrypoint.sh" not in docker_text:
             issues.append(Issue(docker_path, "error", "Docker Action must install an executable entrypoint"))
         if re.search(r"^USER\s+", docker_text, re.MULTILINE):


### PR DESCRIPTION
## Summary

- add a closed v1 YAML policy DSL and `mastermind policy check --since <ref>`
- evaluate forbidden dependency directions, new cycles, public API ownership, blast-radius budgets, related tests, ownership crossings, and strict workflow evidence
- emit deterministic text, JSON, and GitHub SARIF output with stable fingerprints
- fail closed on stale or incomplete graph, Git, CODEOWNERS, and workflow evidence
- bind reusable strict workflow evidence to the exact baseline and touched-file snapshot

## Example

```yaml
rules:
  - id: domain-must-not-import-infrastructure
    from: src/domain/**
    deny_imports: src/infrastructure/**

  - id: no-new-payment-cycles
    scope: services/payment/**
    max_new_cycles: 0
```

```bash
mastermind policy check --since main --format sarif > mastermind-policy.sarif
```

## Verification

- `just check`
  - Rust: 481 library + 49 CLI + 20 golden + 1 policy CLI E2E = 551 tests
  - validator: 39 artifacts, 0 errors, 0 warnings
  - npm: 17 tests
  - Lens DOM/static: 1 test
  - workflow security fixtures: 36 tests
  - eval harness: 16 tests
  - rustfmt and clippy clean
  - cargo-deny advisories, bans, licenses, and sources pass; only the existing allowed duplicate warnings remain
- `cargo package --locked --allow-dirty` completed and verified the packaged crate
- `git diff --check` passed

## Scope and safety

- local, deterministic evaluation only; no Rego or OPA runtime
- no database migration and no source mutation
- no publish, tag, release, or deployment action performed
- rollback is a normal revert of this commit

## Review status

Automated proof is green. This PR is draft because the architecture change still needs an independent review before it is marked ready.