### PR TITLE
feat(mmcg): add temporal architecture graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `mastermind temporal --since <ref>` and read-only `mmcg_temporal` compare a
+  bounded Git-baseline architecture with the indexed worktree. Schema v1 covers
+  component and public-boundary drift, new/resolved/membership-changed cycles, centrality and
+  hotspot movement, base/head CODEOWNERS changes, and exact history records that
+  may need review after paths or APIs disappear. Baseline blobs are rewound only
+  in a private writable SQLite snapshot, and Lens renders the same payload.
+  Snapshot revision checks, cooperative cancellation, fully deleted scopes,
+  ownership-only CODEOWNERS drift, and bounded hostile diagnostics fail closed.
 - `mastermind policy check --since <ref>` evaluates a strict v1
   `mastermind-policy.yml` DSL over normalized codegraph, Git, CODEOWNERS, test,
   and workflow evidence. It covers forbidden dependency directions, new-cycle

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ cd your-project
 mastermind index .
 mastermind map .
 mastermind impact --since main
+mastermind temporal --since main
 mastermind policy check --since main
 mastermind ui --since main
 ```
@@ -103,6 +104,23 @@ mastermind map . --production-only   # hide tests, fixtures, examples, generated
 
 The map highlights languages, components, entry points, dependency boundaries, hotspots, and cycles without asking an agent to grep the entire repository.
 
+### Review architecture over time
+
+```bash
+mastermind temporal --since main
+mastermind temporal --since HEAD~5 --path services/payment --format json
+```
+
+Temporal Graph compares the indexed working copy with a resolved Git baseline.
+It reports added and removed components and boundaries, introduced, resolved,
+and membership-changed cycles, centrality and hotspot drift, CODEOWNERS changes,
+public API drift, and indexed history records that exactly mention removed or
+signature-drifted architecture paths. The baseline is reconstructed by
+rewinding changed Git blobs in a private temporary SQLite snapshot; Mastermind
+does not checkout files or write to the source index. Ownership-only rules and
+fully deleted scopes are preserved, concurrent index revisions fail closed,
+and every section marks bounded partial projections explicitly.
+
 ### Review a change in Mastermind Lens
 
 ```bash
@@ -137,6 +155,10 @@ listed account has GitHub write access or replace base-branch review policy.
 Unreadable, oversized, invalid, or truncated sources remain visible as partial
 diagnostics. Reports and history are parsed in memory and are never written to
 the repository or codegraph database.
+
+Lens also renders the same Temporal Graph response below the blast trace. A
+temporal failure is isolated and labelled instead of turning missing evidence
+into a clean architecture verdict; snapshot races still fail the whole refresh.
 
 ### Understand change and test impact
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -102,6 +102,7 @@ Analyze the current worktree against a baseline:
 
 ```bash
 mastermind impact --since main
+mastermind temporal --since main
 ```
 
 ## Build a personal style profile without project initialization
@@ -199,5 +200,6 @@ is outside `.mastermind/` and can be shared normally.
 - Run `mastermind map .` to learn a repository.
 - Run `mastermind demo hallucinated-symbol` for a zero-setup audit example.
 - Run `mastermind impact --since main` before submitting a change.
+- Run `mastermind temporal --since main` when architecture drift matters.
 - Read [How the workflow works](workflow.md) to use checked task specs.
 - Add [verifiable audits](github-action.md) to CI.

--- a/docs/integrations/generic-mcp.md
+++ b/docs/integrations/generic-mcp.md
@@ -9,7 +9,7 @@
 | transport | stdio |
 | command | `mastermind serve` |
 | protocol | MCP 2025-11-25; legacy 2024-11-05 |
-| tools | 25: 24 read-only, 1 additive local write (see below) |
+| tools | 26: 25 read-only, 1 additive local write (see below) |
 | resources | none |
 | prompts | none |
 
@@ -67,7 +67,8 @@ The `--index` flag is global and must come before `serve`.
   `mmcg_symbols_in_file`.
 - Relationships and architecture: `mmcg_callers`, `mmcg_callees`,
   `mmcg_imports`, `mmcg_imported_by`, `mmcg_impact`, `mmcg_api_surface`,
-  `mmcg_centrality`, `mmcg_dependency_cycles`, `mmcg_unreferenced`, `mmcg_semantic`, `mmcg_map`.
+  `mmcg_centrality`, `mmcg_dependency_cycles`, `mmcg_unreferenced`,
+  `mmcg_semantic`, `mmcg_map`, `mmcg_temporal`.
 - Change analysis: `mmcg_symbols_changed_since`, `mmcg_change_class`,
   `mmcg_change_impact`, `mmcg_test_impact`, `mmcg_recent_changes`.
 - Workflow state: `mmcg_tasks`, `mmcg_history`, `mmcg_status`, `mmcg_scratchpad_read`, and the

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -2,7 +2,7 @@
 
 This is the exhaustive technical reference for the mmcg engine. For the shortest path to a working installation, start with [Getting started](../getting-started.md); for the product overview, return to the [Mastermind README](../../README.md).
 
-A small Rust binary that builds a structural index of a codebase (Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, C/C++). It serves the graph over **MCP** (24 read-only tools plus one additive local scratchpad write), but MCP is only one surface. The same binary provides spec gates (`verify-spec` / `audit-spec`), project setup (`init` / `doctor`), and the user-global style miner.
+A small Rust binary that builds a structural index of a codebase (Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, C/C++). It serves the graph over **MCP** (25 read-only tools plus one additive local scratchpad write), but MCP is only one surface. The same binary provides spec gates (`verify-spec` / `audit-spec`), project setup (`init` / `doctor`), and the user-global style miner.
 
 > Installed via npm (`@xcraftmind/mastermind`)? The command is **`mastermind`** — the same binary. The `mmcg` name used throughout this doc is the cargo-installed alias (`cargo install mmcg`).
 
@@ -69,7 +69,7 @@ The Mastermind workflow needs structural queries every few seconds (planner deci
 
 mmcg is intentionally narrow:
 - Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++ — extend by adding a parser, not by depending on multi-language toolchains
-- 25 MCP tools: 24 read-only structural/semantic tools plus `mmcg_scratchpad_append`, which makes an additive write to the gitignored local index
+- 26 MCP tools: 25 read-only structural/semantic tools plus `mmcg_scratchpad_append`, which makes an additive write to the gitignored local index
 
 ## Performance model
 
@@ -135,6 +135,10 @@ mmcg map . --format sarif > mastermind-map.sarif
 mmcg impact --since main --format text --depth 3 --top 100
 mmcg impact --since HEAD~1 --format json
 mmcg impact --since main --format sarif > mastermind-impact.sarif
+
+# Compare bounded architecture snapshots over time.
+mmcg temporal --since main
+mmcg temporal --since HEAD~5 --path services/payment --format json
 
 # Evaluate repository-owned architecture rules. Violations and incomplete
 # evidence both exit non-zero.
@@ -305,6 +309,55 @@ inspect definitions and relationships directly. Lens loads a valid imported
 overlay automatically, shows its producer and precision diagnostics, and only
 decorates exact returned endpoint and display-name pairs. `mmcg map`, callers,
 impact, and all existing tools continue to work unchanged without SCIP.
+
+## Temporal Graph (`mmcg temporal`)
+
+`mmcg temporal --since REF` compares the indexed working copy with a resolved
+Git commit without checking out the old tree. Mastermind clones the exact
+current SQLite connection snapshot into a private temporary writable database,
+batch-loads the changed blobs at the baseline, rewinds only supported changed
+source paths, and runs the same bounded `project_map` engine on both sides.
+The repository index, source files, Git index, and source WAL/SHM files remain
+unchanged. Data-version plus source database/WAL metadata are rechecked so a
+concurrent watcher cannot mix two SQLite revisions into one result. A fully
+deleted selected scope is reconstructed from the baseline instead of failing
+as an empty head map.
+
+Schema v1 reports:
+
+- added, removed, and file/language-drifted components;
+- added, removed, and signature-drifted cross-component boundaries. The same
+  evidence is exposed as `public_api`; it is observed external graph use, not a
+  claim about a language's declared visibility;
+- introduced, resolved, and membership-changed dependency cycles. Expanding or
+  merging an existing SCC is not mislabeled as a newly introduced cycle;
+- in-degree and rank movement for symbols observed in both bounded hotspot
+  windows, plus entries/exits from those windows;
+- CODEOWNERS changes across the bounded selected source paths, changed files,
+  and returned boundary paths, using the base and head files independently with
+  last-match-wins semantics. This includes ownership-only rule changes;
+- review candidates when current indexed history exactly mentions a deleted
+  path, removed component, removed public boundary, or signature-drifted public
+  API. This is a correlation signal, not proof that an ADR or decision is
+  obsolete.
+
+The file change set is capped at 10,000 and must be complete before rewind; an
+overflow fails closed. Output sections have their own limits, and the response
+sets `partial: true` when either project-map projection or a temporal section is
+truncated. Component, boundary, cycle, and hotspot claims therefore describe
+the returned deterministic window when the underlying map is partial. Ownership
+checks at most 500 relevant paths; history scans at most 5,000 derived artifacts
+and 32 MiB and returns at most 500 candidates. Diagnostics are capped at 100
+with an explicit `diagnostics_truncated` flag. Git, CODEOWNERS, history, rewind,
+and SQLite phases cooperatively observe the request budget/cancel signal.
+Temporal topology is Tree-sitter syntactic evidence in v1; SCIP, runtime,
+coverage, and test overlays keep their separate provenance in Lens.
+
+The same response is available through read-only `mmcg_temporal` and appears in
+Lens below the blast trace. Lens renders bounded identities for component,
+boundary/API, cycle, hotspot, ownership, and history events. It isolates a
+bounded temporal-unavailable result so ordinary impact evidence remains usable,
+but a repository, Git, or SQLite snapshot race still fails the refresh.
 
 ## Mastermind Lens (`mmcg ui`)
 
@@ -570,6 +623,7 @@ Run `mmcg watch` in a separate terminal so the index stays current while you wor
 | `mmcg_centrality` | optional `prefix`, `language`, `kind`, `top` (default 20) | Rank symbols by in-degree (distinct callers). Pre-flight "where is the gravity" — top hits are the structural attractors of the codebase or a subdirectory. Use to learn what to read first on unfamiliar code. Excludes synthetic `<module>` rows and zero-degree symbols. |
 | `mmcg_semantic` | `symbol`, optional `top` (default 100, max 500) | Compiler-resolved SCIP definitions, references, implementations, type definitions, and explicit provenance. Returns `fallback_active: true` instead of an error when no overlay exists. Stale document facts are omitted with diagnostics. |
 | `mmcg_map` | optional `path` (default `.`), `depth` (1–6, default 2), `top` (1–100, default 20), `production_only` (default `false`) | Schema-v1 architecture briefing with lexical file/directory scope: `%` and `_` are literal bytes, selected-directory components are relative to that directory, root components remain repository-relative, and selected files retain their paths. `production_only` excludes conventional test/fixture/example/generated/vendor path segments and test filenames (`test_*`, `*_test.*`, `*.test.*`, `*.spec.*`, `*Test.*`, `*Tests.*`) before bounded queries run. Hotspots prefer unambiguous definitions before pooled same-name collisions. JSON, text, Mermaid, and CLI SARIF are projections of the same result; Mermaid includes component counts/languages, boundaries, hotspots, and cycle rings, while SARIF exports returned cycles as architecture findings. Caps are 50,000 aggregation paths, 20 languages, 20 components, 20 boundaries/component and 400 globally, 50 entry points, 100 hotspots, 50,000 scoped cycle edges, 50 cycles, and 500 cycle memberships. `path_work_limit` marks path-derived partial aggregates; `top_probe` marks a hotspot or per-component boundary cap+1 probe; `global_probe_limit` marks components whose certainty was prevented by the 401st global boundary row; cycle `work_limit` returns no cycles because SCC analysis was skipped before truncated edges could be analyzed. |
+| `mmcg_temporal` | `since`, optional `root`, `path` (default `.`), `depth` (1–5, default 2), `top` (1–100, default 20), `production_only`, `codeowners` | Schema-v1 base-vs-indexed-worktree architecture delta. It rewinds changed Git blobs only in a private SQLite snapshot and reports components, public boundaries/API, cycles, centrality/hotspot drift, base/head CODEOWNERS changes, exact history review candidates, provenance, limits, and partial diagnostics. A truncated 10,000-file change set fails closed. |
 | `mmcg_change_impact` | `since`, optional `root`, `depth` (1–5), `top` (1–500) | Stable schema-v1 analysis of the resolved baseline against staged, unstaged, and untracked content. Reports added/removed/signature/body-changed symbols, batched transitive callers, component crossings, ranked test candidates, a `disciplines` block routing the change to an evidence set, exact collection metadata, caps, and precision notes. Root, SHA-256 index freshness, Git snapshot, and SQLite snapshot checks fail closed with stable codes. |
 | `mmcg_test_impact` | `since`, optional `root`, `depth` (1–5), `top` (1–500) | Exact test-focused projection of `mmcg_change_impact`. Changed tests and depth-1 graph tests are direct, deeper graph tests are transitive, and scoped filename candidates are heuristic. Focused candidates never replace the repository's full required gate. |
 | `mmcg_tasks` | `query`, optional `top` (default 10) | Full-text search past task specs (`.mastermind/tasks/<NNN>-<name>/spec.md`). FTS5 MATCH syntax (bare words AND-joined, `"phrases"`, `OR`/`NOT`). Returns paths, titles, and snippet excerpts with `«match»` highlights ranked by BM25. Use as planner pre-flight: "have we touched this area before?" surfaces past designs and prior verdicts. Top-level files prefixed with `_` (e.g. `_lessons.md`) and bare `.md` files at the top of `tasks/` (legacy 0.6.x layout) are intentionally excluded. |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -22,6 +22,7 @@ readable for compatibility, but new tasks should use `verified` or `strict`.
 mastermind index .
 mastermind map .
 mastermind impact --since main
+mastermind temporal --since main
 # implement the change
 mastermind impact --since main
 # run focused tests and the repository-required gate

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -7,4 +7,4 @@
 ### servers/
 | Server | Transport | Description |
 |---|---|---|
-| [`mmcg`](servers/mmcg/README.md) | stdio | Mastermind Codegraph — 25 MCP tools: 24 read-only structural/semantic tools plus one additive local scratchpad write, over a local SQLite index. Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Truth layer for the Mastermind workflow. |
+| [`mmcg`](servers/mmcg/README.md) | stdio | Mastermind Codegraph — 26 MCP tools: 25 read-only structural/semantic tools plus one additive local scratchpad write, over a local SQLite index. Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Truth layer for the Mastermind workflow. |

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -63,6 +63,7 @@ mmcg enrich --scip index.scip # optional compiler-resolved overlay
 mmcg status
 mmcg map .
 mmcg impact --since main
+mmcg temporal --since main
 mmcg ui --since main
 ```
 
@@ -94,14 +95,14 @@ See the [client integration guides](https://github.com/xcrft/mastermind/tree/mai
 |---|---|
 | Symbol graph | Search, callers, callees, imports, outlines, API surface |
 | Semantic overlay | Optional SCIP definitions, references, implementations, and provenance |
-| Architecture | Project map, centrality, dependency cycles, unreferenced candidates |
+| Architecture | Project map, temporal drift, centrality, dependency cycles, unreferenced candidates |
 | Change analysis | Git-aware symbol changes, blast radius, component crossings |
 | Local review UI | Read-only diff-first Lens with bounded SARIF, coverage, JUnit, OTLP, project-knowledge, ownership, and churn overlays |
 | Test selection | Direct, transitive, and heuristic candidates with evidence |
 | Workflow gates | `verify-spec`, `audit-spec`, and `run-task` |
 | Local coordination | Bounded additive scratchpad and indexed project history |
 
-The MCP surface contains 24 read-only tools and one additive local scratchpad
+The MCP surface contains 25 read-only tools and one additive local scratchpad
 write. Results are bounded and return precision or truncation notes when the
 engine cannot prove completeness.
 

--- a/mcp/servers/mmcg/assets/lens/app.js
+++ b/mcp/servers/mmcg/assets/lens/app.js
@@ -407,6 +407,8 @@
     const impact = record(raw.impact);
     const evidence = record(raw.evidence);
     const semantic = record(raw.semantic);
+    const temporalEnvelope = record(raw.temporal);
+    const temporal = record(temporalEnvelope.data);
     const changes = record(impact.changes);
 
     const files = collection(changes.files);
@@ -551,6 +553,27 @@
       mapComponents.items,
       nodes
     );
+    const precisionNotes = collectPrecisionNotes(map, impact, evidence, semantic);
+    array(temporal.diagnostics).forEach(function (value) {
+      const item = record(value);
+      precisionNotes.push({
+        code: text(item.code, "Temporal precision"),
+        message: text(item.message, ""),
+        source: "Temporal",
+      });
+    });
+    const temporalDiagnostic = record(temporalEnvelope.diagnostic);
+    if (Object.keys(temporalDiagnostic).length > 0) {
+      precisionNotes.push({
+        code: text(temporalDiagnostic.code, "Temporal unavailable"),
+        message: text(temporalDiagnostic.message, ""),
+        source: "Temporal",
+      });
+    }
+    const truncations = collectTruncations(map, impact, evidence, semantic);
+    appendTemporalTruncations(truncations, temporal);
+    const limits = collectLimits(raw, map, impact, evidence);
+    flattenPrimitiveEntries("Temporal", temporal.limits, 0, limits);
 
     return {
       raw: raw,
@@ -569,6 +592,8 @@
       mapComponents: mapComponents,
       evidence: evidence,
       semantic: semantic,
+      temporalEnvelope: temporalEnvelope,
+      temporal: temporal,
       evidenceSources: evidenceSources,
       evidenceFiles: evidenceFiles,
       evidenceDiagnostics: evidenceDiagnostics,
@@ -578,10 +603,42 @@
       nodes: nodes,
       edges: edges,
       components: componentRows,
-      precisionNotes: collectPrecisionNotes(map, impact, evidence, semantic),
-      truncations: collectTruncations(map, impact, evidence, semantic),
-      limits: collectLimits(raw, map, impact, evidence),
+      precisionNotes: precisionNotes,
+      truncations: truncations,
+      limits: limits,
     };
+  }
+
+  function appendTemporalTruncations(output, temporal) {
+    const components = record(temporal.components);
+    const boundaries = record(temporal.boundaries);
+    const cycles = record(temporal.cycles);
+    const hotspots = record(temporal.hotspots);
+    const ownership = record(temporal.ownership);
+    [
+      ["Temporal components added", components.added],
+      ["Temporal components removed", components.removed],
+      ["Temporal components changed", components.changed],
+      ["Temporal boundaries added", boundaries.added],
+      ["Temporal boundaries removed", boundaries.removed],
+      ["Temporal boundaries changed", boundaries.changed],
+      ["Temporal cycles introduced", cycles.added],
+      ["Temporal cycles resolved", cycles.removed],
+      ["Temporal cycles changed", cycles.changed],
+      ["Temporal centrality", temporal.centrality],
+      ["Temporal hotspot entries", hotspots.entered],
+      ["Temporal hotspot exits", hotspots.exited],
+      ["Temporal ownership", ownership.changes],
+      ["Temporal history review", temporal.history_review_candidates],
+    ].forEach(function (entry) {
+      const value = collection(entry[1]);
+      if (value.truncated || value.totalUnknown) {
+        output.push({ label: entry[0], reason: value.reason || "bounded projection" });
+      }
+    });
+    if (temporal.partial === true && !output.some(function (item) { return item.label.startsWith("Temporal"); })) {
+      output.push({ label: "Temporal architecture", reason: "bounded base/head map" });
+    }
   }
 
   function buildComponentRows(affectedItems, mapItems, nodes) {
@@ -804,6 +861,16 @@
     elements.overlayButtons = Array.from(document.querySelectorAll("[data-overlay]"));
     elements.evidenceSummary = byId("evidence-summary");
     elements.evidenceSourceList = byId("evidence-source-list");
+    elements.temporalSummary = byId("temporal-summary");
+    elements.temporalEvents = byId("temporal-events");
+    elements.temporalMetric = {
+      components: byId("temporal-components"),
+      boundaries: byId("temporal-boundaries"),
+      cycles: byId("temporal-cycles"),
+      centrality: byId("temporal-centrality"),
+      ownership: byId("temporal-ownership"),
+      history: byId("temporal-history"),
+    };
     elements.componentList = byId("component-list");
     elements.graphFrame = byId("graph-frame");
     elements.graph = byId("trace-graph");
@@ -993,6 +1060,7 @@
     renderNotices();
     renderEvidenceSources();
     renderComponents();
+    renderTemporal();
     renderMethodLedger();
     setEnabled(true);
     renderGraph();
@@ -1102,8 +1170,127 @@
           "Do not read this trace as complete: " + labels.join("; ") + suffix + ". See the calibration record below."
         );
       }
+      if (text(state.model.temporalEnvelope.status, "unavailable") !== "available") {
+        const diagnostic = record(state.model.temporalEnvelope.diagnostic);
+        appendNotice(
+          "warning",
+          "Temporal · " + text(diagnostic.code, "unavailable"),
+          text(diagnostic.message, "The base/head architecture comparison was not returned; the ordinary diff trace remains available.")
+        );
+      }
     }
     elements.noticeStack.hidden = elements.noticeStack.childElementCount === 0;
+  }
+
+  function temporalPair(added, removed, changed) {
+    const plus = totalOrReturned(collection(added));
+    const minus = totalOrReturned(collection(removed));
+    const drift = changed === undefined ? null : totalOrReturned(collection(changed));
+    return "+" + displayNumber(plus) + " −" + displayNumber(minus) + (drift === null ? "" : " ~" + displayNumber(drift));
+  }
+
+  function renderTemporal() {
+    clearNode(elements.temporalEvents);
+    const envelope = state.model.temporalEnvelope;
+    const temporal = state.model.temporal;
+    if (text(envelope.status, "unavailable") !== "available" || Object.keys(temporal).length === 0) {
+      Object.values(elements.temporalMetric).forEach(function (element) {
+        element.textContent = "—";
+      });
+      const diagnostic = record(envelope.diagnostic);
+      elements.temporalSummary.textContent = text(
+        diagnostic.message,
+        "Temporal architecture is unavailable for this snapshot; the current impact trace is still valid."
+      );
+      elements.temporalEvents.appendChild(createElement("p", "temporal-events__empty", "No base/head architecture delta was returned."));
+      return;
+    }
+
+    const summary = record(temporal.summary);
+    const components = record(temporal.components);
+    const boundaries = record(temporal.boundaries);
+    const cycles = record(temporal.cycles);
+    const ownership = record(temporal.ownership);
+    const hotspots = record(temporal.hotspots);
+    elements.temporalMetric.components.textContent = temporalPair(components.added, components.removed, components.changed);
+    elements.temporalMetric.boundaries.textContent = temporalPair(boundaries.added, boundaries.removed, boundaries.changed);
+    elements.temporalMetric.cycles.textContent = temporalPair(cycles.added, cycles.removed, cycles.changed);
+    elements.temporalMetric.centrality.textContent = "↑" + displayNumber(finiteNumber(summary.centrality_increases));
+    elements.temporalMetric.ownership.textContent = displayNumber(finiteNumber(summary.ownership_changes));
+    elements.temporalMetric.history.textContent = displayNumber(finiteNumber(summary.history_review_candidates));
+    const changed = summary.architecture_changed === true;
+    elements.temporalSummary.textContent = changed
+      ? "Architecture drift detected between " + text(record(temporal.baseline).requested_ref, "the baseline") + " and the indexed working copy" + (temporal.partial === true ? "; bounded projection is partial." : ".")
+      : "No architecture drift was observed in the returned base/head projection.";
+
+    const events = [];
+    collection(components.added).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "added", label: "Component added", detail: text(item.path, "component") + " · " + displayNumber(finiteNumber(item.file_count)) + " files" });
+    });
+    collection(components.removed).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "removed", label: "Component removed", detail: text(item.path, "component") + " · " + displayNumber(finiteNumber(item.file_count)) + " files at baseline" });
+    });
+    collection(components.changed).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "changed", label: "Component shape changed", detail: text(item.path, "component") + " · " + displayNumber(finiteNumber(item.base_file_count)) + " → " + displayNumber(finiteNumber(item.head_file_count)) + " files" });
+    });
+    collection(cycles.added).items.forEach(function (value) {
+      events.push({ kind: "cycle", label: "Cycle introduced", detail: array(value).map(function (path) { return text(path, ""); }).filter(Boolean).join(" → ") });
+    });
+    collection(cycles.removed).items.forEach(function (value) {
+      events.push({ kind: "removed", label: "Cycle resolved", detail: array(value).map(function (path) { return text(path, ""); }).filter(Boolean).join(" → ") });
+    });
+    collection(cycles.changed).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "changed", label: "Cycle membership changed", detail: "+ " + array(item.added_members).join(", ") + " · − " + array(item.removed_members).join(", ") });
+    });
+    collection(boundaries.added).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "added", label: "Public boundary added", detail: text(item.name, "symbol") + " · " + text(item.component, "component") + " · " + text(item.file, "unknown file") });
+    });
+    collection(boundaries.removed).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "removed", label: "Public boundary removed", detail: text(item.name, "symbol") + " · " + text(item.component, "component") + " · " + text(item.file, "unknown file") });
+    });
+    collection(boundaries.changed).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "changed", label: "Public API drift", detail: text(item.name, "symbol") + " · " + text(item.file, "unknown file") });
+    });
+    collection(temporal.centrality).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "gravity", label: "Centrality drift", detail: text(item.name, "symbol") + " · " + displayNumber(finiteNumber(item.base_in_degree)) + " → " + displayNumber(finiteNumber(item.head_in_degree)) });
+    });
+    collection(hotspots.entered).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "gravity", label: "Hotspot entered", detail: text(item.name, "symbol") + " · " + text(item.file, "unknown file") + " · rank " + displayNumber(finiteNumber(item.rank)) });
+    });
+    collection(hotspots.exited).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "removed", label: "Hotspot exited", detail: text(item.name, "symbol") + " · " + text(item.file, "unknown file") + " · baseline rank " + displayNumber(finiteNumber(item.rank)) });
+    });
+    collection(ownership.changes).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "owner", label: "Ownership changed", detail: text(item.path, "unknown path") + " · " + array(item.base_owners).join(", ") + " → " + array(item.head_owners).join(", ") });
+    });
+    collection(temporal.history_review_candidates).items.forEach(function (value) {
+      const item = record(value);
+      events.push({ kind: "history", label: "History needs review", detail: text(item.artifact_path, "artifact") + " mentions " + text(item.referenced_path, "changed path") });
+    });
+    if (events.length === 0) {
+      elements.temporalEvents.appendChild(createElement("p", "temporal-events__empty", "No architecture events were observed in the returned projection."));
+      return;
+    }
+    events.slice(0, 12).forEach(function (event) {
+      const row = createElement("article", "temporal-event temporal-event--" + event.kind);
+      row.appendChild(createElement("span", "temporal-event__kind", event.label));
+      row.appendChild(createElement("span", "temporal-event__detail", event.detail));
+      elements.temporalEvents.appendChild(row);
+    });
+    if (events.length > 12) {
+      elements.temporalEvents.appendChild(createElement("p", "temporal-events__empty", "+" + (events.length - 12) + " more bounded events in the JSON snapshot."));
+    }
   }
 
   function renderEvidenceSources() {

--- a/mcp/servers/mmcg/assets/lens/app.test.cjs
+++ b/mcp/servers/mmcg/assets/lens/app.test.cjs
@@ -190,6 +190,8 @@ const ELEMENT_IDS = [
   "trace-context", "mobile-trace-list", "trace-count", "inspector-body", "precision-list",
   "precision-count", "limits-list", "limits-count", "schema-label", "status-region",
   "evidence-summary", "evidence-source-list",
+  "temporal-summary", "temporal-events", "temporal-components", "temporal-boundaries",
+  "temporal-cycles", "temporal-centrality", "temporal-ownership", "temporal-history",
   "metric-files", "metric-files-note", "metric-symbols", "metric-symbols-note", "metric-impact",
   "metric-impact-note", "metric-crossings", "metric-crossings-note", "metric-tests",
   "metric-tests-note",
@@ -259,6 +261,50 @@ function fixture() {
     schema_version: 1,
     repository: { name: "example", root_label: "." },
     options: { since: "main", path: ".", depth: 3, top: 100, production_only: false },
+    temporal: {
+      status: "available",
+      data: {
+        schema_version: 1,
+        baseline: { requested_ref: "main" },
+        summary: {
+          architecture_changed: true,
+          components_added: 1, components_removed: 0,
+          boundaries_added: 1, boundaries_removed: 0, boundaries_changed: 0,
+          cycles_introduced: 1, cycles_resolved: 0,
+          centrality_increases: 1, hotspot_entries: 1, hotspot_exits: 0,
+          cycles_changed: 0,
+          ownership_changes: 1, history_review_candidates: 1,
+        },
+        components: {
+          added: { total: 1, returned: 1, truncated: false, items: [{ path: "payments", file_count: 1, languages: [{ language: "rust", file_count: 1 }] }] },
+          removed: { total: 1, returned: 1, truncated: false, items: [{ path: "legacy", file_count: 1, languages: [{ language: "python", file_count: 1 }] }] },
+          changed: { total: 0, returned: 0, truncated: false, items: [] },
+        },
+        boundaries: {
+          added: { total: 1, returned: 1, truncated: false, items: [{ component: "payments", file: "src/auth.rs", name: "charge</span>", kind: "function", line: 42 }] },
+          removed: { total: 0, returned: 0, truncated: false, items: [] },
+          changed: { total: 0, returned: 0, truncated: false, items: [] },
+        },
+        cycles: {
+          added: { total: 1, returned: 1, truncated: false, items: [["payments/api.rs", "ledger/api.rs"]] },
+          removed: { total: 1, returned: 1, truncated: false, items: [["legacy/a.py", "legacy/b.py"]] },
+          changed: { total: 0, returned: 0, truncated: false, items: [] },
+        },
+        centrality: { total: 1, returned: 1, truncated: false, items: [{ file: "src/auth.rs", name: "authorize", kind: "function", base_in_degree: 2, head_in_degree: 5, in_degree_delta: 3 }] },
+        hotspots: {
+          entered: { total: 1, returned: 1, truncated: false, items: [{ file: "src/auth.rs", name: "authorize", kind: "function", rank: 1, in_degree: 5 }] },
+          exited: { total: 1, returned: 1, truncated: false, items: [{ file: "legacy/auth.py", name: "legacy_auth", kind: "function", rank: 2, in_degree: 3 }] },
+          moved: { total: 1, returned: 1, truncated: false, items: [] },
+        },
+        ownership: {
+          changes: { total: 1, returned: 1, truncated: false, items: [{ path: "src/auth.rs", base_owners: ["@platform"], head_owners: ["@security"] }] },
+        },
+        history_review_candidates: { total: 1, returned: 1, truncated: false, items: [{ artifact_path: "docs/adr/004-auth.md", referenced_path: "src/legacy.rs", trigger: "path_deleted" }] },
+        limits: { ownership_paths: 500 },
+        diagnostics: [],
+        partial: false,
+      },
+    },
     semantic: {
       schema_version: 1,
       available: true,
@@ -427,7 +473,7 @@ function fixture() {
   };
 }
 
-async function renderFixture() {
+async function renderFixture(payload) {
   const harness = createDocument();
   const window = {
     setTimeout(handler) {
@@ -446,7 +492,7 @@ async function renderFixture() {
     document: harness.document,
     window: window,
     ResizeObserver: window.ResizeObserver,
-    fetch: async () => ({ ok: true, status: 200, json: async () => fixture() }),
+    fetch: async () => ({ ok: true, status: 200, json: async () => payload || fixture() }),
     Intl: Intl,
     Date: Date,
     Map: Map,
@@ -484,6 +530,33 @@ async function main() {
   assert.match(harness.nodes.get("evidence-summary").textContent, /8 sources · 3 matched trace files/i);
   assert.equal(harness.nodes.get("evidence-source-list").querySelectorAll(".evidence-source").length, 8);
   assert.match(harness.nodes.get("evidence-source-list").textContent, /repository verified/i);
+  assert.match(harness.nodes.get("temporal-summary").textContent, /Architecture drift detected/i);
+  assert.equal(harness.nodes.get("temporal-components").textContent, "+1 −1 ~0");
+  assert.equal(harness.nodes.get("temporal-cycles").textContent, "+1 −1 ~0");
+  assert.match(harness.nodes.get("temporal-events").textContent, /Cycle introduced/i);
+  assert.match(harness.nodes.get("temporal-events").textContent, /Component removed/i);
+  assert.match(harness.nodes.get("temporal-events").textContent, /Cycle resolved/i);
+  assert.match(harness.nodes.get("temporal-events").textContent, /Hotspot entered/i);
+  assert.match(harness.nodes.get("temporal-events").textContent, /Hotspot exited/i);
+  assert.match(harness.nodes.get("temporal-events").textContent, /charge<\/span>/i);
+  assert.match(harness.nodes.get("temporal-events").textContent, /History needs review/i);
+
+  const unavailable = fixture();
+  unavailable.temporal = {
+    status: "unavailable",
+    diagnostic: { code: "snapshot_unavailable", message: "Temporal snapshot stayed bounded." },
+  };
+  const unavailableHarness = await renderFixture(unavailable);
+  assert.equal(unavailableHarness.nodes.get("temporal-components").textContent, "—");
+  assert.match(unavailableHarness.nodes.get("temporal-summary").textContent, /stayed bounded/i);
+  assert.match(unavailableHarness.nodes.get("notice-stack").textContent, /Temporal · snapshot_unavailable/i);
+
+  const partial = fixture();
+  partial.temporal.data.partial = true;
+  partial.temporal.data.diagnostics = [{ code: "bounded_map_projection", message: "Only the returned temporal window is comparable." }];
+  const partialHarness = await renderFixture(partial);
+  assert.match(partialHarness.nodes.get("temporal-summary").textContent, /bounded projection is partial/i);
+  assert.match(partialHarness.nodes.get("precision-list").textContent, /returned temporal window/i);
   const changedCandidate = harness.nodes.get("mobile-trace-list").querySelectorAll(".mobile-candidate")[0];
   assert.ok(changedCandidate, "Changed claim with overlays must remain selectable on mobile");
   assert.equal(

--- a/mcp/servers/mmcg/assets/lens/index.html
+++ b/mcp/servers/mmcg/assets/lens/index.html
@@ -242,9 +242,30 @@
         </aside>
       </div>
 
+      <section class="temporal-deck" aria-labelledby="temporal-heading">
+        <header class="temporal-deck__heading">
+          <div>
+            <p class="section-index">07 / Temporal graph</p>
+            <h2 id="temporal-heading">Architecture over time</h2>
+          </div>
+          <p id="temporal-summary">Comparing the baseline architecture with the indexed working copy.</p>
+        </header>
+        <div class="temporal-metrics" id="temporal-metrics" aria-label="Temporal architecture summary">
+          <article><span>Components</span><strong id="temporal-components">—</strong></article>
+          <article><span>Boundaries / API</span><strong id="temporal-boundaries">—</strong></article>
+          <article><span>Cycles</span><strong id="temporal-cycles">—</strong></article>
+          <article><span>Centrality</span><strong id="temporal-centrality">—</strong></article>
+          <article><span>Ownership</span><strong id="temporal-ownership">—</strong></article>
+          <article><span>History review</span><strong id="temporal-history">—</strong></article>
+        </div>
+        <div class="temporal-events" id="temporal-events">
+          <p class="temporal-events__empty">Temporal evidence will appear after the scan.</p>
+        </div>
+      </section>
+
       <section class="method-ledger" aria-labelledby="method-heading">
         <header>
-          <p class="section-index">07 / Calibration record</p>
+          <p class="section-index">08 / Calibration record</p>
           <h2 id="method-heading">Precision &amp; limits</h2>
         </header>
         <div class="method-ledger__columns">

--- a/mcp/servers/mmcg/assets/lens/styles.css
+++ b/mcp/servers/mmcg/assets/lens/styles.css
@@ -410,6 +410,7 @@ body.is-refreshing .refresh-button__glyph {
 .component-deck h2,
 .trace-panel h2,
 .inspector h2,
+.temporal-deck h2,
 .method-ledger h2 {
   margin: 5px 0 0;
   font-size: 18px;
@@ -1650,6 +1651,122 @@ body.is-refreshing .refresh-button__glyph {
   font-size: 10px;
 }
 
+.temporal-deck {
+  margin-top: 40px;
+  border-top: 2px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  background: var(--surface);
+}
+
+.temporal-deck__heading {
+  display: flex;
+  min-height: 76px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--ink);
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.temporal-deck__heading > p {
+  max-width: 62ch;
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 11px;
+  text-align: right;
+}
+
+.temporal-metrics {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  border-bottom: 1px solid var(--rule-dark);
+}
+
+.temporal-metrics article {
+  min-width: 0;
+  padding: 13px 15px 15px;
+  border-right: 1px solid var(--rule);
+}
+
+.temporal-metrics article:last-child {
+  border-right: 0;
+}
+
+.temporal-metrics span {
+  display: block;
+  min-height: 28px;
+  color: var(--ink-faint);
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+}
+
+.temporal-metrics strong {
+  display: block;
+  color: var(--cobalt-dark);
+  font-family: var(--mono);
+  font-size: clamp(18px, 2vw, 27px);
+  letter-spacing: -0.055em;
+  overflow-wrap: anywhere;
+}
+
+.temporal-events {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.temporal-event {
+  display: grid;
+  grid-template-columns: minmax(125px, 0.42fr) minmax(0, 1fr);
+  gap: 16px;
+  min-width: 0;
+  padding: 11px 15px;
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.temporal-event:nth-child(2n) {
+  border-right: 0;
+}
+
+.temporal-event__kind {
+  color: var(--vermilion-dark);
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.temporal-event--added .temporal-event__kind,
+.temporal-event--owner .temporal-event__kind {
+  color: var(--moss-dark);
+}
+
+.temporal-event--gravity .temporal-event__kind,
+.temporal-event--history .temporal-event__kind {
+  color: var(--plum-dark);
+}
+
+.temporal-event__detail {
+  min-width: 0;
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 10px;
+  overflow-wrap: anywhere;
+}
+
+.temporal-events__empty {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 16px 20px;
+  color: var(--ink-faint);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
 .method-ledger {
   display: grid;
   grid-template-columns: minmax(210px, 0.68fr) minmax(0, 3.32fr);
@@ -1888,6 +2005,18 @@ input:focus-visible {
   .inspector-empty {
     min-height: 230px;
   }
+
+  .temporal-metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .temporal-metrics article:nth-child(3n) {
+    border-right: 0;
+  }
+
+  .temporal-metrics article:nth-child(-n + 3) {
+    border-bottom: 1px solid var(--rule);
+  }
 }
 
 @media (max-width: 720px) {
@@ -2021,6 +2150,25 @@ input:focus-visible {
 
   .component-deck__heading > p {
     display: none;
+  }
+
+  .temporal-deck__heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .temporal-deck__heading > p {
+    text-align: left;
+  }
+
+  .temporal-events {
+    grid-template-columns: 1fr;
+  }
+
+  .temporal-event,
+  .temporal-event:nth-child(2n) {
+    border-right: 0;
   }
 
   .workspace {

--- a/mcp/servers/mmcg/src/commands/query.rs
+++ b/mcp/servers/mmcg/src/commands/query.rs
@@ -67,6 +67,110 @@ pub fn dispatch_map(
     Ok(())
 }
 
+pub fn dispatch_temporal(
+    options: &mmcg::temporal::TemporalOptions,
+    format: crate::TemporalFormat,
+    root: &Path,
+    index_path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let store = Store::open_read_only(index_path)?;
+    let budget_ms = query_budget_ms_from_env(DEFAULT_CLI_BUDGET_MS);
+    store.push_work_budget(WorkBudget::from_millis(budget_ms));
+    let _budget_scope = WorkBudgetScope(&store);
+    let response = mmcg::temporal::analyze(&store, root, options)?;
+    match format {
+        crate::TemporalFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&response)?)
+        }
+        crate::TemporalFormat::Text => print!("{}", render_temporal_text(&response)),
+    }
+    Ok(())
+}
+
+pub fn render_temporal_text(response: &mmcg::temporal::TemporalResponse) -> String {
+    let mut output = format!(
+        "Temporal architecture · {} → working copy\nScope: {} · changed: {} · partial: {}\n\n",
+        safe_text(&response.baseline.requested_ref),
+        safe_text(&response.scope.path),
+        if response.summary.architecture_changed {
+            "yes"
+        } else {
+            "no"
+        },
+        if response.partial { "yes" } else { "no" }
+    );
+    output.push_str(&render_temporal_counts(&response.summary));
+    if !response.cycles.added.items.is_empty() {
+        output.push_str("\nIntroduced cycles\n");
+        for cycle in &response.cycles.added.items {
+            output.push_str(&format!("  {}\n", safe_text(&cycle.join(" -> "))));
+        }
+    }
+    if !response.cycles.changed.items.is_empty() {
+        output.push_str("\nChanged cycle membership\n");
+        for cycle in &response.cycles.changed.items {
+            output.push_str(&format!(
+                "  +[{}] -[{}]\n",
+                safe_text(&cycle.added_members.join(", ")),
+                safe_text(&cycle.removed_members.join(", "))
+            ));
+        }
+    }
+    if !response.centrality.items.is_empty() {
+        output.push_str("\nCentrality drift\n");
+        for item in &response.centrality.items {
+            output.push_str(&format!(
+                "  {} — {} → {} ({:+})\n",
+                safe_text(&item.name),
+                item.base_in_degree,
+                item.head_in_degree,
+                item.in_degree_delta
+            ));
+        }
+    }
+    if !response.history_review_candidates.items.is_empty() {
+        output.push_str("\nHistory review candidates\n");
+        for item in &response.history_review_candidates.items {
+            output.push_str(&format!(
+                "  {} mentions {} ({})\n",
+                safe_text(&item.artifact_path),
+                safe_text(&item.referenced_path),
+                safe_text(&item.trigger)
+            ));
+        }
+    }
+    if !response.diagnostics.is_empty() {
+        output.push_str("\nPrecision notes\n");
+        for item in &response.diagnostics {
+            output.push_str(&format!(
+                "  {} — {}\n",
+                safe_text(&item.code),
+                safe_text(&item.message)
+            ));
+        }
+    }
+    output
+}
+
+fn render_temporal_counts(summary: &mmcg::temporal::TemporalSummary) -> String {
+    format!(
+        "Components  +{}  -{}\nBoundaries  +{}  -{}  ~{}\nCycles      +{}  -{}  ~{}\nCentrality  {} increases · hotspots +{} -{}\nOwnership   {} changes\nHistory     {} review candidates\n",
+        summary.components_added,
+        summary.components_removed,
+        summary.boundaries_added,
+        summary.boundaries_removed,
+        summary.boundaries_changed,
+        summary.cycles_introduced,
+        summary.cycles_resolved,
+        summary.cycles_changed,
+        summary.centrality_increases,
+        summary.hotspot_entries,
+        summary.hotspot_exits,
+        summary.ownership_changes,
+        summary.history_review_candidates,
+    )
+}
+
 pub fn dispatch_history(
     query: &str,
     kind: Option<&str>,
@@ -482,6 +586,32 @@ mod map_tests {
         assert!(!label.contains("%%"));
         assert!(!label.contains('['));
         assert!(!label.contains('"'));
+    }
+
+    #[test]
+    fn temporal_text_summary_keeps_every_drift_category() {
+        let rendered = render_temporal_counts(&mmcg::temporal::TemporalSummary {
+            architecture_changed: true,
+            components_added: 1,
+            components_removed: 2,
+            boundaries_added: 3,
+            boundaries_removed: 4,
+            boundaries_changed: 5,
+            cycles_introduced: 6,
+            cycles_resolved: 7,
+            cycles_changed: 8,
+            centrality_increases: 9,
+            hotspot_entries: 10,
+            hotspot_exits: 11,
+            ownership_changes: 12,
+            history_review_candidates: 13,
+        });
+
+        assert!(rendered.contains("Components  +1  -2"));
+        assert!(rendered.contains("Boundaries  +3  -4  ~5"));
+        assert!(rendered.contains("Cycles      +6  -7  ~8"));
+        assert!(rendered.contains("hotspots +10 -11"));
+        assert!(rendered.contains("History     13 review candidates"));
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/diff.rs
+++ b/mcp/servers/mmcg/src/diff.rs
@@ -614,6 +614,17 @@ pub(crate) fn run_bounded_git_with_limit_until(
     output_limit: usize,
     deadline: Option<Instant>,
 ) -> Result<BoundedGitOutput, WorkingTreeDiffError> {
+    run_bounded_git_controlled(repo, args, input, output_limit, deadline, None)
+}
+
+fn run_bounded_git_controlled(
+    repo: &Path,
+    args: &[&str],
+    input: Option<&[u8]>,
+    output_limit: usize,
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<BoundedGitOutput, WorkingTreeDiffError> {
     let start = Instant::now();
     let mut child = git_command(args)
         .current_dir(repo)
@@ -654,6 +665,11 @@ pub(crate) fn run_bounded_git_with_limit_until(
     let status = loop {
         match child.try_wait() {
             Ok(Some(status)) => break status,
+            Ok(None) if interrupted.is_some_and(|check| check()) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(WorkingTreeDiffError::GitTimeout);
+            }
             Ok(None) if start.elapsed() < timeout => {
                 std::thread::sleep(CHILD_POLL_INTERVAL);
             }
@@ -708,10 +724,21 @@ fn resolve_commit(repo: &Path, git_ref: &str) -> Result<String, WorkingTreeDiffE
 }
 
 fn resolve_head(repo: &Path) -> Result<String, WorkingTreeDiffError> {
-    let output = run_bounded_git(
+    resolve_head_controlled(repo, None, None)
+}
+
+fn resolve_head_controlled(
+    repo: &Path,
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<String, WorkingTreeDiffError> {
+    let output = run_bounded_git_controlled(
         repo,
         &["rev-parse", "--verify", "--end-of-options", "HEAD^{commit}"],
         None,
+        GIT_OUTPUT_LIMIT,
+        deadline,
+        interrupted,
     )?;
     if !output.success {
         return Err(WorkingTreeDiffError::InvalidRef);
@@ -734,7 +761,16 @@ fn collect_worktree_paths(
     repo: &Path,
     baseline_oid: &str,
 ) -> Result<(Vec<WorkingTreeChangedFile>, Option<u32>, bool, u32), WorkingTreeDiffError> {
-    let diff = run_bounded_git(
+    collect_worktree_paths_controlled(repo, baseline_oid, None, None)
+}
+
+fn collect_worktree_paths_controlled(
+    repo: &Path,
+    baseline_oid: &str,
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<(Vec<WorkingTreeChangedFile>, Option<u32>, bool, u32), WorkingTreeDiffError> {
+    let diff = run_bounded_git_controlled(
         repo,
         &[
             "-c",
@@ -749,6 +785,9 @@ fn collect_worktree_paths(
             "--",
         ],
         None,
+        GIT_OUTPUT_LIMIT,
+        deadline,
+        interrupted,
     )?;
     if !diff.success {
         return Err(WorkingTreeDiffError::InvalidRef);
@@ -767,7 +806,7 @@ fn collect_worktree_paths(
     // `--full-name` keeps untracked paths repository-relative like the diff
     // side. Without it `ls-files` reports paths relative to `repo`, so a caller
     // passing a subdirectory would mix two path namespaces in one result.
-    let untracked = run_bounded_git(
+    let untracked = run_bounded_git_controlled(
         repo,
         &[
             "ls-files",
@@ -778,6 +817,9 @@ fn collect_worktree_paths(
             "--",
         ],
         None,
+        GIT_OUTPUT_LIMIT,
+        deadline,
+        interrupted,
     )?;
     if !untracked.success {
         return Err(WorkingTreeDiffError::GitUnavailable);
@@ -827,20 +869,66 @@ fn baseline_blobs(
     baseline_oid: &str,
     files: &[WorkingTreeChangedFile],
 ) -> Result<BTreeMap<String, Option<Vec<u8>>>, WorkingTreeDiffError> {
+    let paths = files
+        .iter()
+        .map(|file| file.path.clone())
+        .collect::<Vec<_>>();
+    baseline_blobs_for_paths(repo, baseline_oid, &paths)
+}
+
+/// Fetch a bounded set of blobs from one resolved baseline commit with a
+/// single `git cat-file --batch` process. Missing paths are returned as
+/// `None`, which is how temporal rewind represents files added after the
+/// baseline.
+pub(crate) fn baseline_blobs_for_paths(
+    repo: &Path,
+    baseline_oid: &str,
+    paths: &[String],
+) -> Result<BTreeMap<String, Option<Vec<u8>>>, WorkingTreeDiffError> {
+    baseline_blobs_for_paths_controlled(repo, baseline_oid, paths, None, None)
+}
+
+pub(crate) fn baseline_blobs_for_paths_controlled(
+    repo: &Path,
+    baseline_oid: &str,
+    paths: &[String],
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<BTreeMap<String, Option<Vec<u8>>>, WorkingTreeDiffError> {
+    if paths.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let deadline = deadline.or_else(|| Some(Instant::now() + git_timeout()));
+    let object_ids = baseline_blob_oids(repo, baseline_oid, paths, deadline, interrupted)?;
+    let requests = paths
+        .iter()
+        .filter_map(|path| object_ids.get(path).map(|oid| (path, oid)))
+        .collect::<Vec<_>>();
+    let mut blobs = paths
+        .iter()
+        .map(|path| (path.clone(), None))
+        .collect::<BTreeMap<_, _>>();
+    if requests.is_empty() {
+        return Ok(blobs);
+    }
     let mut input = Vec::new();
-    for file in files {
-        input.extend_from_slice(baseline_oid.as_bytes());
-        input.push(b':');
-        input.extend_from_slice(file.path.as_bytes());
+    for (_, oid) in &requests {
+        input.extend_from_slice(oid.as_bytes());
         input.push(b'\n');
     }
-    let output = run_bounded_git(repo, &["cat-file", "--batch"], Some(&input))?;
+    let output = run_bounded_git_controlled(
+        repo,
+        &["cat-file", "--batch"],
+        Some(&input),
+        GIT_OUTPUT_LIMIT,
+        deadline,
+        interrupted,
+    )?;
     if !output.success {
         return Err(WorkingTreeDiffError::InvalidRef);
     }
     let mut cursor = 0usize;
-    let mut blobs = BTreeMap::new();
-    for file in files {
+    for (path, expected_oid) in requests {
         let Some(relative_newline) = output.stdout[cursor..]
             .iter()
             .position(|byte| *byte == b'\n')
@@ -850,27 +938,146 @@ fn baseline_blobs(
         let header_end = cursor + relative_newline;
         let header = &output.stdout[cursor..header_end];
         cursor = header_end + 1;
-        if header.ends_with(b" missing") {
-            blobs.insert(file.path.clone(), None);
-            continue;
-        }
         let header_text =
             std::str::from_utf8(header).map_err(|_| WorkingTreeDiffError::InvalidRef)?;
-        let size = header_text
-            .split_whitespace()
-            .nth(2)
+        let mut fields = header_text.split_whitespace();
+        let returned_oid = fields.next().ok_or(WorkingTreeDiffError::InvalidRef)?;
+        let object_type = fields.next().ok_or(WorkingTreeDiffError::InvalidRef)?;
+        let size = fields
+            .next()
             .and_then(|value| value.parse::<usize>().ok())
             .ok_or(WorkingTreeDiffError::InvalidRef)?;
-        if cursor + size >= output.stdout.len() {
+        if returned_oid != expected_oid
+            || !matches!(object_type, "blob" | "commit" | "tree" | "tag")
+            || fields.next().is_some()
+        {
+            return Err(WorkingTreeDiffError::InvalidRef);
+        }
+        if cursor + size >= output.stdout.len() || output.stdout[cursor + size] != b'\n' {
             return Err(WorkingTreeDiffError::InvalidRef);
         }
         blobs.insert(
-            file.path.clone(),
+            path.clone(),
             Some(output.stdout[cursor..cursor + size].to_vec()),
         );
         cursor += size + 1;
     }
+    if cursor != output.stdout.len() {
+        return Err(WorkingTreeDiffError::InvalidRef);
+    }
     Ok(blobs)
+}
+
+fn baseline_blob_oids(
+    repo: &Path,
+    baseline_oid: &str,
+    paths: &[String],
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<BTreeMap<String, String>, WorkingTreeDiffError> {
+    const PATHSPEC_ARG_BYTES: usize = 32 * 1024;
+    const PATHS_PER_BATCH: usize = 256;
+
+    let requested = paths.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    let mut object_ids = BTreeMap::new();
+    let mut output_bytes = 0usize;
+    let mut offset = 0usize;
+    while offset < paths.len() {
+        let mut end = offset;
+        let mut argument_bytes = 0usize;
+        while end < paths.len() && end - offset < PATHS_PER_BATCH {
+            let path = &paths[end];
+            if path.as_bytes().contains(&0) {
+                return Err(WorkingTreeDiffError::InvalidRef);
+            }
+            let next_bytes = path.len().saturating_add(10);
+            if end > offset && argument_bytes.saturating_add(next_bytes) > PATHSPEC_ARG_BYTES {
+                break;
+            }
+            argument_bytes = argument_bytes.saturating_add(next_bytes);
+            end += 1;
+        }
+        let pathspecs = paths[offset..end]
+            .iter()
+            .map(|path| format!(":(literal){path}"))
+            .collect::<Vec<_>>();
+        let mut args = vec!["ls-tree", "-r", "-z", "--full-tree", baseline_oid, "--"];
+        args.extend(pathspecs.iter().map(String::as_str));
+        let output =
+            run_bounded_git_controlled(repo, &args, None, GIT_OUTPUT_LIMIT, deadline, interrupted)?;
+        if !output.success {
+            return Err(WorkingTreeDiffError::InvalidRef);
+        }
+        output_bytes = output_bytes.saturating_add(output.stdout.len());
+        if output_bytes > GIT_OUTPUT_LIMIT {
+            return Err(WorkingTreeDiffError::GitOutputLimit);
+        }
+        let mut entries = output.stdout.split(|byte| *byte == 0).peekable();
+        while let Some(entry) = entries.next() {
+            if entry.is_empty() {
+                if entries.peek().is_some() {
+                    return Err(WorkingTreeDiffError::InvalidRef);
+                }
+                break;
+            }
+            let tab = entry
+                .iter()
+                .position(|byte| *byte == b'\t')
+                .ok_or(WorkingTreeDiffError::InvalidRef)?;
+            let metadata =
+                std::str::from_utf8(&entry[..tab]).map_err(|_| WorkingTreeDiffError::InvalidRef)?;
+            let path = std::str::from_utf8(&entry[tab + 1..])
+                .map_err(|_| WorkingTreeDiffError::InvalidRef)?;
+            let mut fields = metadata.split_whitespace();
+            let _mode = fields.next().ok_or(WorkingTreeDiffError::InvalidRef)?;
+            let object_type = fields.next().ok_or(WorkingTreeDiffError::InvalidRef)?;
+            let oid = fields.next().ok_or(WorkingTreeDiffError::InvalidRef)?;
+            if !matches!(object_type, "blob" | "commit" | "tree" | "tag")
+                || fields.next().is_some()
+                || !requested.contains(path)
+                || object_ids
+                    .insert(path.to_string(), oid.to_string())
+                    .is_some()
+            {
+                return Err(WorkingTreeDiffError::InvalidRef);
+            }
+        }
+        offset = end;
+    }
+    Ok(object_ids)
+}
+
+/// Recheck the inexpensive filesystem/Git token used by temporal analysis
+/// without parsing every changed source file a third time. Cooperative
+/// controls let MCP cancellation stop the extra Git work promptly.
+pub(crate) fn validate_working_tree_snapshot_controlled(
+    repo: &Path,
+    baseline_oid: &str,
+    expected_head_oid: &str,
+    expected_files: &[WorkingTreeChangedFile],
+    expected_token: &str,
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<(), WorkingTreeDiffError> {
+    if resolve_head_controlled(repo, deadline, interrupted)? != expected_head_oid {
+        return Err(WorkingTreeDiffError::SnapshotChanged);
+    }
+    let (files, _, truncated, _) =
+        collect_worktree_paths_controlled(repo, baseline_oid, deadline, interrupted)?;
+    if truncated || files != expected_files {
+        return Err(WorkingTreeDiffError::SnapshotChanged);
+    }
+    let token = working_tree_snapshot_token_controlled(
+        repo,
+        expected_head_oid,
+        &files,
+        deadline,
+        interrupted,
+    )?;
+    if token != expected_token {
+        return Err(WorkingTreeDiffError::SnapshotChanged);
+    }
+    Ok(())
 }
 
 pub(crate) fn working_tree_snapshot_token(
@@ -878,7 +1085,24 @@ pub(crate) fn working_tree_snapshot_token(
     head_oid: &str,
     files: &[WorkingTreeChangedFile],
 ) -> Result<String, WorkingTreeDiffError> {
-    let index = run_bounded_git(repo, &["write-tree"], None)?;
+    working_tree_snapshot_token_controlled(repo, head_oid, files, None, None)
+}
+
+fn working_tree_snapshot_token_controlled(
+    repo: &Path,
+    head_oid: &str,
+    files: &[WorkingTreeChangedFile],
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<String, WorkingTreeDiffError> {
+    let index = run_bounded_git_controlled(
+        repo,
+        &["write-tree"],
+        None,
+        GIT_OUTPUT_LIMIT,
+        deadline,
+        interrupted,
+    )?;
     if !index.success {
         return Err(WorkingTreeDiffError::SnapshotChanged);
     }
@@ -886,6 +1110,9 @@ pub(crate) fn working_tree_snapshot_token(
     digest.update(head_oid.as_bytes());
     digest.update(&index.stdout);
     for file in files {
+        if interrupted.is_some_and(|check| check()) {
+            return Err(WorkingTreeDiffError::GitTimeout);
+        }
         digest.update(file.path.as_bytes());
         digest.update([0]);
         digest.update(file.status.as_bytes());
@@ -1403,6 +1630,55 @@ mod tests {
         let second = symbols_changed_in_worktree(store.store(), &dir, "HEAD").unwrap();
         assert_eq!(first.files, second.files);
         assert_eq!(first.files[0].path, "line\nbreak.py");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn baseline_blob_batch_is_nul_safe_for_newline_paths() {
+        let dir = init_repo("baseline_blob_nul");
+        let tracked = "src/evil\nname.py";
+        let baseline_body = b"def baseline():\n    return 1\n";
+        write(&dir, tracked, std::str::from_utf8(baseline_body).unwrap());
+        run(&dir, &["add", "-A"]);
+        run(&dir, &["commit", "-q", "-m", "baseline"]);
+        let baseline = resolve_commit(&dir, "HEAD").unwrap();
+
+        let missing = "src/missing\nname.py".to_string();
+        let blobs =
+            baseline_blobs_for_paths(&dir, &baseline, &[tracked.to_string(), missing.clone()])
+                .unwrap();
+
+        assert_eq!(blobs.get(tracked), Some(&Some(baseline_body.to_vec())));
+        assert_eq!(blobs.get(&missing), Some(&None));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn baseline_blob_batch_preserves_gitlink_compatibility() {
+        let dir = init_repo("baseline_blob_gitlink");
+        write(&dir, "README.md", "baseline\n");
+        run(&dir, &["add", "-A"]);
+        run(&dir, &["commit", "-q", "-m", "target"]);
+        let target = resolve_commit(&dir, "HEAD").unwrap();
+        run(
+            &dir,
+            &[
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                &format!("160000,{target},vendor/lib"),
+            ],
+        );
+        run(&dir, &["commit", "-q", "-m", "gitlink"]);
+        let baseline = resolve_commit(&dir, "HEAD").unwrap();
+
+        let blobs = baseline_blobs_for_paths(&dir, &baseline, &["vendor/lib".to_string()]).unwrap();
+
+        assert!(blobs
+            .get("vendor/lib")
+            .and_then(|value| value.as_ref())
+            .is_some_and(|bytes| !bytes.is_empty()));
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/mcp/servers/mmcg/src/evidence.rs
+++ b/mcp/servers/mmcg/src/evidence.rs
@@ -1893,7 +1893,7 @@ fn excerpt_around(body: &str, start: usize, end: usize) -> String {
     truncate_text(output.trim(), 280)
 }
 
-fn discover_codeowners(root: &Path) -> Option<PathBuf> {
+pub(crate) fn discover_codeowners(root: &Path) -> Option<PathBuf> {
     exact_directory(root, ".github")
         .and_then(|directory| exact_regular_file(&directory, "CODEOWNERS"))
         .or_else(|| exact_regular_file(root, "CODEOWNERS"))
@@ -2310,6 +2310,114 @@ struct OwnerRule {
     matchers: Vec<GlobMatcher>,
     owners: Vec<String>,
     owners_truncated: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct CodeownersResolution {
+    pub owners_by_path: BTreeMap<String, Vec<String>>,
+    pub partial: bool,
+    pub diagnostics_truncated: bool,
+    pub diagnostics: Vec<String>,
+}
+
+/// Resolve CODEOWNERS text for a bounded path set using the same last-match
+/// semantics as Lens evidence. This pure projection is shared by temporal
+/// analysis so base and head ownership are compared with identical syntax.
+#[cfg(test)]
+pub(crate) fn resolve_codeowners_bytes(
+    bytes: &[u8],
+    paths: &[String],
+) -> Result<CodeownersResolution, &'static str> {
+    resolve_codeowners_bytes_controlled(bytes, paths, &|| false)
+}
+
+pub(crate) fn resolve_codeowners_bytes_controlled(
+    bytes: &[u8],
+    paths: &[String],
+    interrupted: &dyn Fn() -> bool,
+) -> Result<CodeownersResolution, &'static str> {
+    const MATCH_WORK_LIMIT: usize = 5_000_000;
+    if bytes.len() as u64 >= MAX_CODEOWNERS_BYTES {
+        return Err("codeowners_too_large");
+    }
+    let text = std::str::from_utf8(strip_utf8_bom(bytes)).map_err(|_| "invalid_utf8")?;
+    let mut rules = Vec::new();
+    let mut partial = false;
+    let mut diagnostics = Vec::new();
+    let mut diagnostics_truncated = false;
+    for (line_index, line) in text.lines().enumerate() {
+        if interrupted() {
+            return Err("work_interrupted");
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if rules.len() >= MAX_CODEOWNER_RULES {
+            partial = true;
+            diagnostics.push("codeowner_rule_limit".to_string());
+            break;
+        }
+        match parse_owner_rule(trimmed) {
+            Ok(rule) => {
+                if rule.owners_truncated {
+                    partial = true;
+                    if diagnostics.len() < MAX_DIAGNOSTICS.saturating_sub(1) {
+                        diagnostics.push(format!("codeowner_owner_limit:{}", line_index + 1));
+                    } else {
+                        diagnostics_truncated = true;
+                    }
+                }
+                rules.push(rule);
+            }
+            Err(()) => {
+                partial = true;
+                if diagnostics.len() < MAX_DIAGNOSTICS.saturating_sub(1) {
+                    diagnostics.push(format!("invalid_codeowner_pattern:{}", line_index + 1));
+                } else {
+                    diagnostics_truncated = true;
+                }
+            }
+        }
+    }
+    let mut owners_by_path = BTreeMap::new();
+    let mut operations = 0usize;
+    'paths: for path in paths {
+        let mut owners = None;
+        for rule in &rules {
+            operations = operations.saturating_add(1);
+            if operations.is_multiple_of(1_024) && interrupted() {
+                return Err("work_interrupted");
+            }
+            if operations > MATCH_WORK_LIMIT {
+                partial = true;
+                if diagnostics.len() < MAX_DIAGNOSTICS.saturating_sub(1) {
+                    diagnostics.push("codeowner_match_work_limit".to_string());
+                } else {
+                    diagnostics_truncated = true;
+                }
+                break 'paths;
+            }
+            if rule.matches(path) {
+                owners = Some(rule.owners.clone());
+            }
+        }
+        if let Some(owners) = owners {
+            owners_by_path.insert(path.clone(), owners);
+        }
+    }
+    if diagnostics_truncated {
+        diagnostics.truncate(MAX_DIAGNOSTICS.saturating_sub(1));
+        diagnostics.push("codeowner_diagnostic_limit".to_string());
+    }
+    diagnostics.sort();
+    diagnostics.dedup();
+    Ok(CodeownersResolution {
+        owners_by_path,
+        partial,
+        diagnostics_truncated,
+        diagnostics,
+    })
 }
 
 impl OwnerRule {
@@ -2906,5 +3014,19 @@ mod tests {
         assert!(snapshot.partial);
         assert_eq!(snapshot.sources.items[0].status, "error");
         assert_eq!(snapshot.diagnostics.items[0].code, "codeowners_too_large");
+    }
+
+    #[test]
+    fn pure_codeowners_resolution_bounds_invalid_line_diagnostics() {
+        let bytes = "!\n".repeat(MAX_CODEOWNER_RULES + 10_000);
+        let resolution =
+            resolve_codeowners_bytes(bytes.as_bytes(), &["src/pay.rs".to_string()]).unwrap();
+
+        assert!(resolution.partial);
+        assert!(resolution.diagnostics.len() <= MAX_DIAGNOSTICS);
+        assert!(resolution
+            .diagnostics
+            .iter()
+            .any(|value| value == "codeowner_diagnostic_limit"));
     }
 }

--- a/mcp/servers/mmcg/src/lens.rs
+++ b/mcp/servers/mmcg/src/lens.rs
@@ -52,8 +52,24 @@ pub struct LensSnapshot {
     pub options: LensOptions,
     pub map: ProjectMapResponse,
     pub impact: ChangeImpactResponse,
+    pub temporal: LensTemporalSnapshot,
     pub semantic: crate::scip_overlay::SemanticOverlaySnapshot,
     pub evidence: crate::evidence::EvidenceSnapshot,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensTemporalSnapshot {
+    pub status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<crate::temporal::TemporalResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<LensTemporalDiagnostic>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LensTemporalDiagnostic {
+    pub code: &'static str,
+    pub message: &'static str,
 }
 
 #[derive(Debug)]
@@ -337,6 +353,12 @@ fn build_snapshot_until(
         return Err(LensError::AnalysisTimeout);
     }
 
+    let index_version = store
+        .data_version()
+        .map_err(|_| LensError::ImpactUnavailable(ChangeImpactError::SnapshotChanged))?;
+    let source_index_state = store
+        .source_index_state()
+        .map_err(|_| LensError::ImpactUnavailable(ChangeImpactError::SnapshotChanged))?;
     validate_index_snapshot(store, &root, deadline)?;
 
     let impact = queries::change_impact(
@@ -347,14 +369,61 @@ fn build_snapshot_until(
         options.top as usize,
     )
     .map_err(LensError::ImpactUnavailable)?;
-    let map = queries::project_map_with_options(
+    let map = match queries::project_map_with_options(
         store,
         &options.path,
         options.depth,
         options.top,
         options.production_only,
-    )
-    .map_err(LensError::MapUnavailable)?;
+    ) {
+        Ok(map) => map,
+        Err(error)
+            if error.contains("scope has no indexed files")
+                && crate::temporal::scope_has_deleted_file(&impact, &options.path)
+                    .map_err(LensError::MapUnavailable)? =>
+        {
+            queries::empty_project_map(&options.path, options.depth, options.production_only)
+                .map_err(LensError::MapUnavailable)?
+        }
+        Err(error) => return Err(LensError::MapUnavailable(error)),
+    };
+    let temporal_options = crate::temporal::TemporalOptions {
+        since: options.since.clone(),
+        path: options.path.clone(),
+        depth: options.depth,
+        top: options.top,
+        production_only: options.production_only,
+        codeowners: evidence_options.codeowners.clone(),
+    };
+    let temporal = match crate::temporal::analyze_with_impact(
+        store,
+        &root,
+        &temporal_options,
+        &impact,
+        Some(&map),
+    ) {
+        Ok(data) => LensTemporalSnapshot {
+            status: "available",
+            data: Some(data),
+            diagnostic: None,
+        },
+        Err(crate::temporal::TemporalError::SnapshotChanged) => {
+            return Err(LensError::ImpactUnavailable(
+                ChangeImpactError::SnapshotChanged,
+            ));
+        }
+        Err(crate::temporal::TemporalError::Impact(error)) => {
+            return Err(LensError::ImpactUnavailable(error));
+        }
+        Err(error) => LensTemporalSnapshot {
+            status: "unavailable",
+            data: None,
+            diagnostic: Some(LensTemporalDiagnostic {
+                code: error.code(),
+                message: "Temporal architecture could not be completed within its bounded snapshot contract.",
+            }),
+        },
+    };
     let semantic_paths = impact
         .changes
         .files
@@ -401,6 +470,19 @@ fn build_snapshot_until(
         .unwrap_or("repository")
         .to_string();
     let root_label = impact.scope.repository_relative_root.clone();
+    if store
+        .data_version()
+        .map_err(|_| LensError::ImpactUnavailable(ChangeImpactError::SnapshotChanged))?
+        != index_version
+        || store
+            .source_index_state()
+            .map_err(|_| LensError::ImpactUnavailable(ChangeImpactError::SnapshotChanged))?
+            != source_index_state
+    {
+        return Err(LensError::ImpactUnavailable(
+            ChangeImpactError::SnapshotChanged,
+        ));
+    }
 
     Ok(LensSnapshot {
         schema_version: 1,
@@ -408,6 +490,7 @@ fn build_snapshot_until(
         options: options.clone(),
         map,
         impact,
+        temporal,
         semantic,
         evidence,
     })
@@ -982,7 +1065,7 @@ mod tests {
     #[test]
     fn snapshot_wraps_the_shared_map_and_impact_schemas() {
         let (repo, _index_dir, index_path) = fixture();
-        let store = Store::open_read_only(index_path).unwrap();
+        let store = Store::open_read_only(&index_path).unwrap();
         let snapshot = build_snapshot(&store, repo.path(), &options()).unwrap();
         let json = serde_json::to_value(snapshot).unwrap();
 
@@ -992,12 +1075,79 @@ mod tests {
         assert_eq!(json["evidence"]["files"]["returned"], 0);
         assert_eq!(json["map"]["schema_version"], 1);
         assert_eq!(json["impact"]["schema_version"], 1);
+        assert_eq!(json["temporal"]["status"], "available");
+        assert_eq!(json["temporal"]["data"]["schema_version"], 1);
+        assert_eq!(
+            json["temporal"]["data"]["provenance"]["baseline_graph"],
+            "git_blob_rewind_private_sqlite_snapshot"
+        );
         assert_eq!(json["options"]["since"], "HEAD");
         assert_eq!(json["impact"]["changes"]["files"]["returned"], 1);
         assert_eq!(
             json["impact"]["changes"]["files"]["items"][0]["path"],
             "src/lib.rs"
         );
+    }
+
+    #[test]
+    fn snapshot_explains_a_fully_deleted_selected_scope() {
+        let repo = tempfile::tempdir().unwrap();
+        let index_dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(repo.path().join("legacy")).unwrap();
+        fs::write(
+            repo.path().join("legacy/api.py"),
+            "def legacy_api():\n    return 1\n",
+        )
+        .unwrap();
+        git(repo.path(), &["init", "-q"]);
+        git(repo.path(), &["config", "user.email", "lens@example.test"]);
+        git(repo.path(), &["config", "user.name", "Lens Test"]);
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-qm", "baseline"]);
+        fs::remove_file(repo.path().join("legacy/api.py")).unwrap();
+
+        let index_path = index_dir.path().join("mmcg.db");
+        let mut writable = Store::open(&index_path).unwrap();
+        Indexer::new(repo.path())
+            .index_all(&mut writable, true)
+            .unwrap();
+        drop(writable);
+        let store = Store::open_read_only(&index_path).unwrap();
+        let mut lens_options = options();
+        lens_options.path = "legacy".to_string();
+
+        let snapshot = build_snapshot(&store, repo.path(), &lens_options).unwrap();
+        let json = serde_json::to_value(snapshot).unwrap();
+
+        assert_eq!(json["map"]["files"]["total"], 0);
+        assert_eq!(json["temporal"]["status"], "available");
+        assert_eq!(
+            json["temporal"]["data"]["components"]["removed"]["items"][0]["path"],
+            "."
+        );
+
+        lens_options.path = "typo/never/existed".to_string();
+        let error = build_snapshot(&store, repo.path(), &lens_options)
+            .expect_err("a scope absent from both snapshots must not look clean");
+        assert!(matches!(error, LensError::MapUnavailable(_)));
+
+        fs::create_dir_all(repo.path().join("docs-only")).unwrap();
+        fs::write(repo.path().join("docs-only/README.md"), "temporary docs\n").unwrap();
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-qm", "docs baseline"]);
+        fs::remove_file(repo.path().join("docs-only/README.md")).unwrap();
+        drop(store);
+        let mut writable = Store::open(&index_path).unwrap();
+        Indexer::new(repo.path())
+            .index_all(&mut writable, true)
+            .unwrap();
+        drop(writable);
+        let store = Store::open_read_only(&index_path).unwrap();
+        lens_options.since = "HEAD".to_string();
+        lens_options.path = "docs-only".to_string();
+        let error = build_snapshot(&store, repo.path(), &lens_options)
+            .expect_err("a deleted non-source must not prove a deleted architecture scope");
+        assert!(matches!(error, LensError::MapUnavailable(_)));
     }
 
     #[test]
@@ -1249,6 +1399,7 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(body).unwrap();
         assert_eq!(json["schema_version"], 1);
         assert_eq!(json["map"]["schema_version"], 1);
+        assert_eq!(json["temporal"]["status"], "available");
         assert_eq!(json["impact"]["changes"]["files"]["returned"], 1);
         assert_eq!(directory_snapshot(index_dir.path()), index_before);
         drop(writer);

--- a/mcp/servers/mmcg/src/lib.rs
+++ b/mcp/servers/mmcg/src/lib.rs
@@ -31,6 +31,7 @@ pub mod scip_overlay;
 pub mod setup;
 pub mod spec;
 pub mod store;
+pub mod temporal;
 pub mod verify_spec;
 pub mod watcher;
 pub mod workflow_status;

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -5,6 +5,7 @@
 //!   mastermind setup claude   — register the codegraph with Claude Code (MCP)
 //!   mastermind index [PATH]   — build or refresh the index
 //!   mastermind enrich --scip  — add optional compiler-resolved evidence
+//!   mastermind temporal       — compare architecture at a Git baseline
 //!   mastermind ui --since REF — open the local diff-first Lens UI
 //!   mastermind serve          — run as MCP stdio server
 //!   mastermind doctor         — health-check the setup
@@ -58,6 +59,13 @@ pub enum ImpactFormat {
     Sarif,
 }
 
+#[derive(Copy, Clone, Debug, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum TemporalFormat {
+    Text,
+    Json,
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[clap(rename_all = "kebab-case")]
 pub enum PolicyFormat {
@@ -86,8 +94,9 @@ pub enum UninstallScope {
 over MCP, plus runs spec-driven workflow gates (verify-spec / audit-spec).\n\n\
 Onboard a project (run inside your repo):\n  \
 mastermind init                       scaffold .mastermind/, build the index, draft CONTEXT.md\n  \
-mastermind setup claude --write-mcp   register the codegraph with Claude Code (run once)\n  \
-mastermind ui --since main            inspect this change in the local read-only Lens UI\n  \
+  mastermind setup claude --write-mcp   register the codegraph with Claude Code (run once)\n  \
+mastermind temporal --since main        review architecture drift over time\n  \
+  mastermind ui --since main            inspect this change in the local read-only Lens UI\n  \
 mastermind doctor                     verify the setup\n\n\
 Installed via npm? `mastermind install` does the global setup (workflow agents + skills + MCP) in one step — then `mastermind init` per repo.\n\n\
 Then open the project in Claude Code — the codegraph tools (search, callers, impact, …) are available. \
@@ -149,6 +158,26 @@ enum Cmd {
         top: u32,
         #[arg(long, default_value = ".")]
         root: PathBuf,
+    },
+    /// Compare bounded architecture snapshots between a Git baseline and the indexed worktree.
+    Temporal {
+        #[arg(long)]
+        since: String,
+        #[arg(long, value_enum, default_value_t = TemporalFormat::Text)]
+        format: TemporalFormat,
+        #[arg(long, default_value = ".")]
+        root: PathBuf,
+        #[arg(long, default_value = ".")]
+        path: String,
+        #[arg(long, default_value_t = 2, value_parser = clap::value_parser!(u8).range(1..=5))]
+        depth: u8,
+        #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u32).range(1..=100))]
+        top: u32,
+        #[arg(long)]
+        production_only: bool,
+        /// Override the repository CODEOWNERS file used for ownership drift.
+        #[arg(long, value_name = "PATH")]
+        codeowners: Option<PathBuf>,
     },
     /// Evaluate repository-owned architecture rules over bounded change evidence.
     #[command(subcommand)]
@@ -962,6 +991,34 @@ fn run_cli_inner(
                 commands::query::render_change_impact(&response, format)?
             );
         }
+        Cmd::Temporal {
+            since,
+            format,
+            root,
+            path,
+            depth,
+            top,
+            production_only,
+            codeowners,
+        } => {
+            let root = root
+                .canonicalize()
+                .map_err(|_| mmcg::queries::ChangeImpactError::RootMismatch)?;
+            let index_path = index_path_for_root(index_override.as_deref(), &root);
+            commands::query::dispatch_temporal(
+                &mmcg::temporal::TemporalOptions {
+                    since,
+                    path,
+                    depth,
+                    top,
+                    production_only,
+                    codeowners,
+                },
+                format,
+                &root,
+                &index_path,
+            )?;
+        }
         Cmd::Policy(PolicyCmd::Check {
             since,
             root,
@@ -1671,6 +1728,49 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn temporal_graph_is_a_bounded_root_scoped_command() {
+        assert!(Cli::try_parse_from(["mastermind", "temporal"]).is_err());
+        let cli = Cli::try_parse_from([
+            "mastermind",
+            "temporal",
+            "--since",
+            "origin/main",
+            "--format",
+            "json",
+            "--path",
+            "services/payment",
+            "--depth",
+            "3",
+            "--top",
+            "50",
+            "--production-only",
+            "--codeowners",
+            ".github/CODEOWNERS",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.cmd,
+            Cmd::Temporal {
+                since,
+                format: TemporalFormat::Json,
+                root,
+                path,
+                depth: 3,
+                top: 50,
+                production_only: true,
+                codeowners: Some(codeowners),
+            } if since == "origin/main"
+                && root.as_path() == std::path::Path::new(".")
+                && path == "services/payment"
+                && codeowners.as_path() == std::path::Path::new(".github/CODEOWNERS")
+        ));
+        assert!(Cli::try_parse_from(
+            ["mastermind", "temporal", "--since", "main", "--depth", "6",]
+        )
+        .is_err());
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/mcp.rs
+++ b/mcp/servers/mmcg/src/mcp.rs
@@ -219,6 +219,7 @@ static TOOLS: &[ToolDef] = &[
     read_only_tool("mmcg_centrality", schema_centrality, handle_centrality),
     read_only_tool("mmcg_semantic", schema_semantic, handle_semantic),
     read_only_tool("mmcg_map", schema_map, handle_map),
+    read_only_tool("mmcg_temporal", schema_temporal, handle_temporal),
     read_only_tool(
         "mmcg_change_impact",
         schema_change_impact,
@@ -1377,6 +1378,26 @@ fn schema_map() -> Value {
     })
 }
 
+fn schema_temporal() -> Value {
+    json!({
+        "name": "mmcg_temporal",
+        "description": "Compare bounded base-vs-worktree architecture snapshots: components, cross-component boundaries/public API, cycles, centrality/hotspot drift, CODEOWNERS changes, and exact history review candidates. The baseline is rewound in a private temporary SQLite snapshot; the repository and source index remain read-only.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "since": { "type": "string", "description": "Git ref used as the baseline" },
+                "root": { "type": "string", "description": "Repository root; defaults to the index binding" },
+                "path": { "type": "string", "default": ".", "description": "Repository-relative architecture scope" },
+                "depth": { "type": "integer", "minimum": 1, "maximum": 5, "default": 2 },
+                "top": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
+                "production_only": { "type": "boolean", "default": false },
+                "codeowners": { "type": "string", "description": "Optional repository-relative CODEOWNERS override" }
+            },
+            "required": ["since"]
+        }
+    })
+}
+
 fn schema_semantic() -> Value {
     json!({
         "name": "mmcg_semantic",
@@ -1704,6 +1725,86 @@ fn handle_map(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
                 _ => HandlerError::internal("project_map_query", error),
             })?;
     serde_json::to_value(result)
+        .map_err(|error| HandlerError::internal("serialize_response", error))
+}
+
+fn handle_temporal(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
+    let since = str_arg(args, "since")?.to_string();
+    let root = match args.get("root") {
+        None => store
+            .meta_value("index_root")
+            .map_err(|error| HandlerError::internal("temporal_index_root", error))?
+            .map(std::path::PathBuf::from)
+            .ok_or_else(|| HandlerError::InvalidArguments("index_stale".to_string()))?
+            .canonicalize()
+            .map_err(|_| HandlerError::InvalidArguments("root_mismatch".to_string()))?,
+        Some(Value::String(value)) => std::path::PathBuf::from(value)
+            .canonicalize()
+            .map_err(|_| HandlerError::InvalidArguments("root_mismatch".to_string()))?,
+        Some(_) => {
+            return Err(HandlerError::InvalidArguments(
+                "Invalid argument: root".to_string(),
+            ))
+        }
+    };
+    let path = match args.get("path") {
+        None => ".".to_string(),
+        Some(Value::String(value)) => {
+            queries::normalize_map_path(value)
+                .map_err(|_| HandlerError::InvalidArguments("Invalid argument: path".into()))?;
+            value.clone()
+        }
+        Some(_) => {
+            return Err(HandlerError::InvalidArguments(
+                "Invalid argument: path".to_string(),
+            ))
+        }
+    };
+    let depth = match args.get("depth") {
+        None => 2,
+        Some(value) => value
+            .as_u64()
+            .filter(|value| (1..=5).contains(value))
+            .and_then(|value| u8::try_from(value).ok())
+            .ok_or_else(|| HandlerError::InvalidArguments("Invalid argument: depth".into()))?,
+    };
+    let top = match args.get("top") {
+        None => 20,
+        Some(value) => value
+            .as_u64()
+            .filter(|value| (1..=100).contains(value))
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or_else(|| HandlerError::InvalidArguments("Invalid argument: top".into()))?,
+    };
+    let production_only = match args.get("production_only") {
+        None => false,
+        Some(value) => value.as_bool().ok_or_else(|| {
+            HandlerError::InvalidArguments("Invalid argument: production_only".into())
+        })?,
+    };
+    let codeowners = match args.get("codeowners") {
+        None => None,
+        Some(Value::String(value)) => Some(std::path::PathBuf::from(value)),
+        Some(_) => {
+            return Err(HandlerError::InvalidArguments(
+                "Invalid argument: codeowners".to_string(),
+            ))
+        }
+    };
+    let response = crate::temporal::analyze(
+        store,
+        &root,
+        &crate::temporal::TemporalOptions {
+            since,
+            path,
+            depth,
+            top,
+            production_only,
+            codeowners,
+        },
+    )
+    .map_err(|error| HandlerError::InvalidArguments(error.code().to_string()))?;
+    serde_json::to_value(response)
         .map_err(|error| HandlerError::internal("serialize_response", error))
 }
 
@@ -2437,7 +2538,7 @@ mod tests {
     #[test]
     fn tool_annotations_match_behavior_table() {
         let legacy = tools_list(ProtocolVersion::Legacy);
-        assert_eq!(legacy["tools"].as_array().unwrap().len(), 25);
+        assert_eq!(legacy["tools"].as_array().unwrap().len(), 26);
         assert!(legacy["tools"]
             .as_array()
             .unwrap()
@@ -2446,7 +2547,7 @@ mod tests {
 
         let current = tools_list(ProtocolVersion::Current);
         let tools = current["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 25);
+        assert_eq!(tools.len(), 26);
         let mut readers = 0;
         for tool in tools {
             let annotations = &tool["annotations"];
@@ -2465,7 +2566,7 @@ mod tests {
                 readers += 1;
             }
         }
-        assert_eq!(readers, 24);
+        assert_eq!(readers, 25);
     }
 
     #[test]
@@ -2689,6 +2790,69 @@ mod tests {
     }
 
     #[test]
+    fn temporal_tool_returns_schema_v1_and_is_read_only() {
+        let (root, mut store) = impact_fixture("temporal");
+        let actual = handle_temporal(
+            &mut store,
+            &json!({
+                "since": "HEAD",
+                "root": root.to_string_lossy(),
+                "path": ".",
+                "depth": 2,
+                "top": 20
+            }),
+        )
+        .unwrap();
+        assert_eq!(actual["schema_version"], 1);
+        assert_eq!(
+            actual["provenance"]["head_graph"],
+            "indexed_worktree_snapshot"
+        );
+        let listed = tools_list(ProtocolVersion::Current);
+        let temporal = listed["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|tool| tool["name"] == "mmcg_temporal")
+            .unwrap();
+        assert_eq!(temporal["annotations"], json!({ "readOnlyHint": true }));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn temporal_tool_maps_midflight_non_sql_cancel_to_cancelled() {
+        let (root, mut store) = impact_fixture("temporal_cancel");
+        let cancel = store.cancel_handle();
+        let _hook = crate::temporal::install_temporal_test_hook(
+            crate::temporal::TemporalTestStage::AfterImpact,
+            move || cancel.cancel(),
+        );
+
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({
+                "name": "mmcg_temporal",
+                "arguments": {
+                    "since": "HEAD",
+                    "root": root.to_string_lossy(),
+                    "path": ".",
+                    "depth": 2,
+                    "top": 20
+                }
+            }),
+        )
+        .unwrap();
+        let content = unwrap_content(&result);
+
+        assert_eq!(
+            content.get("code").and_then(Value::as_str),
+            Some("cancelled")
+        );
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
     fn test_impact_is_an_exact_projection_of_change_impact() {
         let (root, mut store) = impact_fixture("projection");
         let full = handle_change_impact(
@@ -2764,8 +2928,9 @@ mod tests {
         }
         let order: Vec<_> = TOOLS.iter().map(|tool| tool.name).collect();
         let map = order.iter().position(|name| *name == "mmcg_map").unwrap();
-        assert_eq!(order[map + 1], "mmcg_change_impact");
-        assert_eq!(order[map + 2], "mmcg_test_impact");
+        assert_eq!(order[map + 1], "mmcg_temporal");
+        assert_eq!(order[map + 2], "mmcg_change_impact");
+        assert_eq!(order[map + 3], "mmcg_test_impact");
         std::fs::remove_file(path).ok();
     }
 
@@ -3059,7 +3224,7 @@ mod tests {
     #[test]
     fn tools_list_covers_every_handler() {
         let listed: Vec<&str> = TOOLS.iter().map(|t| t.name).collect();
-        assert_eq!(listed.len(), 25, "expected 25 tools, got {}", listed.len());
+        assert_eq!(listed.len(), 26, "expected 26 tools, got {}", listed.len());
         for name in &listed {
             assert!(
                 TOOLS.iter().any(|t| &t.name == name),

--- a/mcp/servers/mmcg/src/queries.rs
+++ b/mcp/servers/mmcg/src/queries.rs
@@ -2275,6 +2275,69 @@ pub fn project_map(
     project_map_with_options(store, path, depth, top, false)
 }
 
+/// Empty head-side projection for consumers that still need to explain a
+/// fully deleted scope. The ordinary `map` command keeps its explicit
+/// no-files error; Lens uses this only when Git impact proves the deletion.
+pub(crate) fn empty_project_map(
+    path: &str,
+    depth: u8,
+    production_only: bool,
+) -> Result<ProjectMapResponse, String> {
+    let normalized = normalize_map_path(path)?;
+    Ok(ProjectMapResponse {
+        schema_version: 1,
+        scope: MapScope {
+            path: if normalized.is_empty() {
+                ".".into()
+            } else {
+                normalized
+            },
+            kind: if path.is_empty() || path == "." {
+                "root".into()
+            } else {
+                "directory".into()
+            },
+            depth: depth.clamp(1, 6),
+            aggregation_paths_truncated: false,
+            production_only,
+        },
+        files: MapCount {
+            total: Some(0),
+            returned: 0,
+            truncated: false,
+            truncation_reason: None,
+        },
+        languages: empty_map_section(),
+        components: empty_map_section(),
+        entry_points: empty_map_section(),
+        hotspots: empty_map_section(),
+        cycles: empty_map_section(),
+        limits: MapLimits {
+            paths: MAP_PATH_LIMIT as u32,
+            languages: MAP_LANGUAGE_LIMIT as u32,
+            components: MAP_COMPONENT_LIMIT as u32,
+            boundaries_per_component: MAP_BOUNDARY_LIMIT as u32,
+            boundaries_global: MAP_BOUNDARY_GLOBAL_LIMIT as u32,
+            entry_points: MAP_ENTRY_LIMIT as u32,
+            hotspots: 100,
+            cycle_edges: MAP_CYCLE_EDGE_LIMIT as u32,
+            cycles: MAP_CYCLE_LIMIT as u32,
+            cycle_memberships: MAP_CYCLE_MEMBERSHIP_LIMIT as u32,
+        },
+        precision_notes: Vec::new(),
+    })
+}
+
+fn empty_map_section<T>() -> MapSection<T> {
+    MapSection {
+        total: Some(0),
+        returned: 0,
+        truncated: false,
+        truncation_reason: None,
+        items: Vec::new(),
+    }
+}
+
 pub fn project_map_with_options(
     store: &Store,
     path: &str,

--- a/mcp/servers/mmcg/src/setup.rs
+++ b/mcp/servers/mmcg/src/setup.rs
@@ -2470,6 +2470,10 @@ mod tests {
 
     #[test]
     fn continue_removes_only_owned_shape_and_force_backs_up_customized_content() {
+        let _canonical_entry = TestCanonicalEntryGuard::new(json!({
+            "command": "/bin/mmcg",
+            "args": ["serve"],
+        }));
         let root = tmp("continue-owned");
         let home = root.join("home");
         fs::create_dir_all(&home).unwrap();

--- a/mcp/servers/mmcg/src/store.rs
+++ b/mcp/servers/mmcg/src/store.rs
@@ -396,7 +396,7 @@ struct SourceFileState {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct IndexFileState {
+pub(crate) struct IndexFileState {
     database: SourceFileState,
     wal: Option<SourceFileState>,
 }
@@ -733,6 +733,66 @@ impl Store {
         Ok(Self::from_connection(conn, db_path, snapshot_dir))
     }
 
+    /// Clone the exact connection snapshot into a private writable database.
+    ///
+    /// Temporal analysis uses this to rewind changed files to a Git baseline
+    /// without checking out files or mutating the repository index. `VACUUM
+    /// INTO` reads through this connection, so rows that came from an active
+    /// WAL snapshot are retained. The only writes land under a temporary
+    /// directory owned by the returned [`Store`].
+    pub(crate) fn private_writable_snapshot(&self) -> SqlResult<Self> {
+        let state = index_file_state(&self.db_path)?;
+        let source_bytes = state
+            .database
+            .len
+            .checked_add(state.wal.as_ref().map_or(0, |wal| wal.len))
+            .ok_or_else(sqlite_snapshot_too_large)?;
+        if source_bytes > READ_ONLY_SNAPSHOT_MAX_BYTES {
+            return Err(sqlite_snapshot_too_large());
+        }
+        let snapshot_dir = tempfile::Builder::new()
+            .prefix("mastermind-temporal-index-")
+            .tempdir()
+            .map_err(|error| sqlite_io_error("create temporal index snapshot", error))?;
+        let snapshot_path = snapshot_dir.path().join("mmcg.db");
+        let query_only = self
+            .conn
+            .query_row("PRAGMA query_only", [], |row| row.get::<_, i64>(0))?
+            != 0;
+        if query_only {
+            self.conn.execute_batch("PRAGMA query_only = OFF;")?;
+        }
+        let vacuum = self.conn.execute(
+            "VACUUM INTO ?1",
+            params![snapshot_path.to_string_lossy().as_ref()],
+        );
+        let restore = if query_only {
+            self.conn.execute_batch("PRAGMA query_only = ON;")
+        } else {
+            Ok(())
+        };
+        vacuum?;
+        restore?;
+
+        let conn = Connection::open(&snapshot_path)?;
+        conn.execute_batch(
+            r#"
+            PRAGMA foreign_keys = ON;
+            PRAGMA journal_mode = WAL;
+            PRAGMA synchronous = NORMAL;
+            PRAGMA busy_timeout = 5000;
+            PRAGMA cache_size = -65536;
+            "#,
+        )?;
+        let mut snapshot = Self::from_connection(conn, snapshot_path, Some(snapshot_dir));
+        snapshot.interrupt_source = Arc::clone(&self.interrupt_source);
+        snapshot.set_default_work_budget(self.default_work_budget());
+        if !snapshot.schema_current()? {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+        Ok(snapshot)
+    }
+
     pub fn schema_current(&self) -> SqlResult<bool> {
         Ok(self.meta_value("schema_version")?.as_deref() == Some(SCHEMA_VERSION))
     }
@@ -759,6 +819,48 @@ impl Store {
     /// override it once at startup from `MMCG_QUERY_BUDGET_MS`.
     pub fn default_work_budget(&self) -> WorkBudget {
         self.default_budget.get()
+    }
+
+    /// Remaining effective budget of the innermost active guard. Separate
+    /// private SQLite snapshots use this to preserve the parent request's
+    /// deadline and operation cap instead of starting a fresh allowance.
+    pub(crate) fn remaining_work_budget(&self) -> WorkBudget {
+        let stack = self.guard_stack.borrow();
+        let Some(frame) = stack.last() else {
+            return self.default_work_budget();
+        };
+        let now = Instant::now();
+        WorkBudget {
+            deadline: frame
+                .deadline
+                .map(|deadline| deadline.saturating_duration_since(now)),
+            op_ticks: frame.op_cap.map(|cap| {
+                let used = self
+                    .ops_counter
+                    .load(Ordering::Relaxed)
+                    .saturating_sub(frame.ops_baseline);
+                cap.saturating_sub(used)
+            }),
+        }
+    }
+
+    /// Cooperative check for non-SQL phases inside a guarded graph request.
+    /// It shares the same cancel/budget marker used by SQLite so transports
+    /// keep returning `cancelled` and `work_limit_exceeded` consistently.
+    pub(crate) fn work_interrupted(&self) -> bool {
+        if self.interrupt_source.load(Ordering::SeqCst) == INTERRUPT_CANCEL {
+            return true;
+        }
+        let expired = self
+            .guard_stack
+            .borrow()
+            .last()
+            .is_some_and(|frame| frame.expired(&self.ops_counter));
+        if expired {
+            self.interrupt_source
+                .store(INTERRUPT_BUDGET, Ordering::SeqCst);
+        }
+        expired
     }
 
     /// Override the default work budget directly — used by tests that need an
@@ -820,7 +922,7 @@ impl Store {
         stack.push(frame);
         drop(stack);
         self.install_progress_handler();
-        if expired {
+        if expired && self.interrupt_source.load(Ordering::SeqCst) != INTERRUPT_CANCEL {
             self.interrupt_source
                 .store(INTERRUPT_BUDGET, Ordering::SeqCst);
         }
@@ -849,7 +951,9 @@ impl Store {
             1_000,
             Some(move || {
                 ops_counter.fetch_add(1, Ordering::Relaxed);
-                if frame.expired(&ops_counter) {
+                if interrupt_source.load(Ordering::SeqCst) == INTERRUPT_CANCEL {
+                    true
+                } else if frame.expired(&ops_counter) {
                     interrupt_source.store(INTERRUPT_BUDGET, Ordering::SeqCst);
                     true
                 } else {
@@ -1742,6 +1846,13 @@ impl Store {
                 Box::new(error),
             )
         })
+    }
+
+    /// Metadata token for the canonical source database and active WAL, used
+    /// by long read-only analyses to reject a result assembled while an
+    /// external watcher advanced the index.
+    pub(crate) fn source_index_state(&self) -> SqlResult<IndexFileState> {
+        index_file_state(&self.db_path)
     }
 
     pub fn begin_read_snapshot(&self) -> SqlResult<()> {
@@ -3624,6 +3735,32 @@ mod tests {
             .is_err());
         assert_eq!(read_only.symbol_count().unwrap(), 1);
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn private_writable_snapshot_isolated_from_read_only_source() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("index.db");
+        {
+            let source = Store::open(&path).unwrap();
+            source.set_meta("temporal_probe", "source").unwrap();
+        }
+        let before = directory_bytes(directory.path());
+        let source = Store::open_read_only(&path).unwrap();
+
+        let snapshot = source.private_writable_snapshot().unwrap();
+        snapshot.set_meta("temporal_probe", "snapshot").unwrap();
+
+        assert_eq!(
+            source.meta_value("temporal_probe").unwrap().as_deref(),
+            Some("source")
+        );
+        assert_eq!(
+            snapshot.meta_value("temporal_probe").unwrap().as_deref(),
+            Some("snapshot")
+        );
+        assert!(!snapshot.db_path().starts_with(directory.path()));
+        assert_eq!(directory_bytes(directory.path()), before);
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/temporal.rs
+++ b/mcp/servers/mmcg/src/temporal.rs
@@ -1,0 +1,2102 @@
+//! Bounded architecture deltas between a Git baseline and the indexed worktree.
+//!
+//! The current codegraph remains the source of truth. Temporal analysis clones
+//! that exact SQLite snapshot into a private temporary database, rewinds only
+//! the Git-changed source files to the resolved baseline blobs, and runs the
+//! existing project-map engine over both stores. No checkout, worktree, or
+//! repository-index write is required.
+
+use crate::diff::{self, WorkingTreeChangedFile, WorkingTreeDiffError};
+use crate::indexer::{extractor_for_path, is_binary_content, parse_blob, MAX_INDEXABLE_FILE_SIZE};
+use crate::queries::{
+    self, ChangeImpactError, ChangeImpactResponse, MapComponent, MapHotspot, ProjectMapResponse,
+    SymbolHit,
+};
+use crate::store::Store;
+use aho_corasick::AhoCorasick;
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+#[cfg(test)]
+use std::cell::RefCell;
+
+const COMPONENT_DELTA_LIMIT: usize = 100;
+const BOUNDARY_DELTA_LIMIT: usize = 500;
+const CYCLE_DELTA_LIMIT: usize = 100;
+const CENTRALITY_DELTA_LIMIT: usize = 200;
+const OWNERSHIP_PATH_LIMIT: usize = 500;
+const HISTORY_CANDIDATE_LIMIT: usize = 500;
+const HISTORY_ARTIFACT_LIMIT: usize = 5_000;
+const HISTORY_BYTE_LIMIT: usize = 32 * 1024 * 1024;
+const DIAGNOSTIC_LIMIT: usize = 100;
+
+#[derive(Debug, Clone)]
+pub struct TemporalOptions {
+    pub since: String,
+    pub path: String,
+    pub depth: u8,
+    pub top: u32,
+    pub production_only: bool,
+    pub codeowners: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalCollection<T> {
+    pub total: u32,
+    pub returned: u32,
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation_reason: Option<&'static str>,
+    pub items: Vec<T>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalBaseline {
+    pub requested_ref: String,
+    pub baseline_oid: String,
+    pub head_oid: String,
+    pub includes_worktree: bool,
+    pub includes_untracked: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalScope {
+    pub path: String,
+    pub depth: u8,
+    pub production_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalComponent {
+    pub path: String,
+    pub file_count: u32,
+    pub languages: Vec<TemporalLanguage>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TemporalLanguage {
+    pub language: String,
+    pub file_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalComponentDrift {
+    pub path: String,
+    pub base_file_count: u32,
+    pub head_file_count: u32,
+    pub base_languages: Vec<TemporalLanguage>,
+    pub head_languages: Vec<TemporalLanguage>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TemporalBoundary {
+    pub component: String,
+    pub file: String,
+    pub name: String,
+    pub kind: String,
+    pub line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalBoundaryDrift {
+    pub component: String,
+    pub file: String,
+    pub name: String,
+    pub kind: String,
+    pub base_line: u32,
+    pub head_line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_signature: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_signature: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalBoundaryDelta {
+    pub added: TemporalCollection<TemporalBoundary>,
+    pub removed: TemporalCollection<TemporalBoundary>,
+    pub changed: TemporalCollection<TemporalBoundaryDrift>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TemporalHotspot {
+    pub file: String,
+    pub name: String,
+    pub kind: String,
+    pub line: u32,
+    pub rank: u32,
+    pub in_degree: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalCentralityDrift {
+    pub file: String,
+    pub name: String,
+    pub kind: String,
+    pub base_rank: u32,
+    pub head_rank: u32,
+    pub base_in_degree: u32,
+    pub head_in_degree: u32,
+    pub in_degree_delta: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalHotspotDrift {
+    pub entered: TemporalCollection<TemporalHotspot>,
+    pub exited: TemporalCollection<TemporalHotspot>,
+    pub moved: TemporalCollection<TemporalCentralityDrift>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalCycleDrift {
+    pub base_cycles: Vec<Vec<String>>,
+    pub head_cycles: Vec<Vec<String>>,
+    pub added_members: Vec<String>,
+    pub removed_members: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalCycleDelta {
+    pub added: TemporalCollection<Vec<String>>,
+    pub removed: TemporalCollection<Vec<String>>,
+    pub changed: TemporalCollection<TemporalCycleDrift>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalOwnershipChange {
+    pub path: String,
+    pub base_owners: Vec<String>,
+    pub head_owners: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalOwnership {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_source: Option<String>,
+    pub changes: TemporalCollection<TemporalOwnershipChange>,
+    #[serde(skip)]
+    diagnostics_truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalHistoryCandidate {
+    pub artifact_path: String,
+    pub kind: String,
+    pub title: String,
+    pub referenced_path: String,
+    pub trigger: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalComponents {
+    pub added: TemporalCollection<TemporalComponent>,
+    pub removed: TemporalCollection<TemporalComponent>,
+    pub changed: TemporalCollection<TemporalComponentDrift>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalSummary {
+    pub architecture_changed: bool,
+    pub components_added: u32,
+    pub components_removed: u32,
+    pub boundaries_added: u32,
+    pub boundaries_removed: u32,
+    pub boundaries_changed: u32,
+    pub cycles_introduced: u32,
+    pub cycles_resolved: u32,
+    pub cycles_changed: u32,
+    pub centrality_increases: u32,
+    pub hotspot_entries: u32,
+    pub hotspot_exits: u32,
+    pub ownership_changes: u32,
+    pub history_review_candidates: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalProvenance {
+    pub baseline_graph: &'static str,
+    pub head_graph: &'static str,
+    pub graph_edges: &'static str,
+    pub ownership: &'static str,
+    pub history: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalLimits {
+    pub changed_files: u32,
+    pub components_per_direction: u32,
+    pub boundaries_per_direction: u32,
+    pub cycles_per_direction: u32,
+    pub centrality_rows: u32,
+    pub ownership_paths: u32,
+    pub history_candidates: u32,
+    pub history_artifacts: u32,
+    pub history_bytes: u64,
+    pub diagnostics: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalDiagnostic {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalResponse {
+    pub schema_version: u32,
+    pub baseline: TemporalBaseline,
+    pub scope: TemporalScope,
+    pub summary: TemporalSummary,
+    pub components: TemporalComponents,
+    pub boundaries: TemporalBoundaryDelta,
+    pub cycles: TemporalCycleDelta,
+    pub centrality: TemporalCollection<TemporalCentralityDrift>,
+    pub hotspots: TemporalHotspotDrift,
+    /// Cross-component boundary symbols are Mastermind's observable public API.
+    pub public_api: TemporalBoundaryDelta,
+    pub ownership: TemporalOwnership,
+    pub history_review_candidates: TemporalCollection<TemporalHistoryCandidate>,
+    pub provenance: TemporalProvenance,
+    pub limits: TemporalLimits,
+    pub partial: bool,
+    pub diagnostics_truncated: bool,
+    pub diagnostics: Vec<TemporalDiagnostic>,
+}
+
+#[derive(Debug, Clone)]
+pub enum TemporalError {
+    Impact(ChangeImpactError),
+    MapUnavailable(String),
+    SnapshotUnavailable,
+    BaselineRewind(String),
+    ChangeSetTruncated,
+    SnapshotChanged,
+}
+
+impl TemporalError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Impact(error) => error.code(),
+            Self::MapUnavailable(_) => "map_unavailable",
+            Self::SnapshotUnavailable => "snapshot_unavailable",
+            Self::BaselineRewind(_) => "baseline_rewind_failed",
+            Self::ChangeSetTruncated => "change_set_too_large",
+            Self::SnapshotChanged => "snapshot_changed",
+        }
+    }
+}
+
+impl std::fmt::Display for TemporalError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Impact(error) => write!(formatter, "{}: {error}", self.code()),
+            Self::MapUnavailable(message) | Self::BaselineRewind(message) => {
+                write!(formatter, "{}: {message}", self.code())
+            }
+            _ => formatter.write_str(self.code()),
+        }
+    }
+}
+
+impl std::error::Error for TemporalError {}
+
+impl From<ChangeImpactError> for TemporalError {
+    fn from(error: ChangeImpactError) -> Self {
+        Self::Impact(error)
+    }
+}
+
+impl From<WorkingTreeDiffError> for TemporalError {
+    fn from(error: WorkingTreeDiffError) -> Self {
+        match error {
+            WorkingTreeDiffError::SnapshotChanged => Self::SnapshotChanged,
+            WorkingTreeDiffError::InvalidRef
+            | WorkingTreeDiffError::GitUnavailable
+            | WorkingTreeDiffError::GitTimeout
+            | WorkingTreeDiffError::GitOutputLimit
+            | WorkingTreeDiffError::IndexStale => Self::Impact(error.into()),
+        }
+    }
+}
+
+#[derive(Default)]
+struct ArchitectureProjection {
+    components: BTreeMap<String, TemporalComponent>,
+    boundaries: BTreeMap<BoundaryKey, TemporalBoundary>,
+    cycles: BTreeSet<Vec<String>>,
+    hotspots: BTreeMap<HotspotKey, TemporalHotspot>,
+    partial: bool,
+}
+
+type BoundaryKey = (String, String, String, String);
+type HotspotKey = (String, String, String);
+
+#[cfg(test)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TemporalTestStage {
+    AfterImpact,
+}
+
+#[cfg(test)]
+type TemporalTestHook = (TemporalTestStage, Box<dyn FnOnce()>);
+
+#[cfg(test)]
+thread_local! {
+    static TEMPORAL_TEST_HOOK: RefCell<Option<TemporalTestHook>> = RefCell::new(None);
+}
+
+#[cfg(test)]
+pub(crate) struct TemporalTestHookGuard;
+
+#[cfg(test)]
+impl Drop for TemporalTestHookGuard {
+    fn drop(&mut self) {
+        TEMPORAL_TEST_HOOK.with(|hook| hook.borrow_mut().take());
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn install_temporal_test_hook(
+    stage: TemporalTestStage,
+    hook: impl FnOnce() + 'static,
+) -> TemporalTestHookGuard {
+    TEMPORAL_TEST_HOOK.with(|slot| *slot.borrow_mut() = Some((stage, Box::new(hook))));
+    TemporalTestHookGuard
+}
+
+#[cfg(test)]
+fn run_temporal_test_hook(stage: TemporalTestStage) {
+    let hook = TEMPORAL_TEST_HOOK.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if slot
+            .as_ref()
+            .is_some_and(|(candidate, _)| *candidate == stage)
+        {
+            slot.take().map(|(_, hook)| hook)
+        } else {
+            None
+        }
+    });
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
+/// Full temporal analysis for CLI and MCP surfaces.
+pub fn analyze(
+    store: &Store,
+    root: &Path,
+    options: &TemporalOptions,
+) -> Result<TemporalResponse, TemporalError> {
+    let root = root
+        .canonicalize()
+        .map_err(|_| TemporalError::Impact(ChangeImpactError::RootMismatch))?;
+    crate::lens::validate_index_snapshot(store, &root, None).map_err(|error| match error {
+        crate::lens::LensError::ImpactUnavailable(error) => TemporalError::Impact(error),
+        crate::lens::LensError::AnalysisTimeout
+        | crate::lens::LensError::SnapshotTimeout
+        | crate::lens::LensError::SnapshotTooLarge => TemporalError::SnapshotUnavailable,
+        _ => TemporalError::Impact(ChangeImpactError::IndexStale),
+    })?;
+    let source_index_state = store
+        .source_index_state()
+        .map_err(|_| TemporalError::SnapshotChanged)?;
+    let index_version = store
+        .data_version()
+        .map_err(|_| TemporalError::SnapshotChanged)?;
+    let impact = queries::change_impact(
+        store,
+        &root,
+        &options.since,
+        u32::from(options.depth.clamp(1, 5)),
+        options.top.clamp(1, 100) as usize,
+    )?;
+    #[cfg(test)]
+    run_temporal_test_hook(TemporalTestStage::AfterImpact);
+    let head_map = match queries::project_map_with_options(
+        store,
+        &options.path,
+        options.depth,
+        options.top,
+        options.production_only,
+    ) {
+        Ok(map) => Some(map),
+        Err(error)
+            if error.contains("scope has no indexed files")
+                && scope_has_deleted_file(&impact, &options.path)
+                    .map_err(TemporalError::MapUnavailable)? =>
+        {
+            None
+        }
+        Err(error) => return Err(TemporalError::MapUnavailable(error)),
+    };
+    let response = analyze_with_impact(store, &root, options, &impact, head_map.as_ref())?;
+    if store
+        .data_version()
+        .map_err(|_| TemporalError::SnapshotChanged)?
+        != index_version
+        || store
+            .source_index_state()
+            .map_err(|_| TemporalError::SnapshotChanged)?
+            != source_index_state
+    {
+        return Err(TemporalError::SnapshotChanged);
+    }
+    Ok(response)
+}
+
+/// Reuse Lens's already-validated impact and map snapshots.
+pub(crate) fn analyze_with_impact(
+    store: &Store,
+    root: &Path,
+    options: &TemporalOptions,
+    impact: &ChangeImpactResponse,
+    head_map: Option<&ProjectMapResponse>,
+) -> Result<TemporalResponse, TemporalError> {
+    if impact.changes.files.truncated {
+        return Err(TemporalError::ChangeSetTruncated);
+    }
+    let root = root
+        .canonicalize()
+        .map_err(|_| TemporalError::Impact(ChangeImpactError::RootMismatch))?;
+    let changed_files = impact
+        .changes
+        .files
+        .items
+        .iter()
+        .map(|file| WorkingTreeChangedFile {
+            path: file.path.clone(),
+            status: file.status.clone(),
+        })
+        .collect::<Vec<_>>();
+    let changed_paths = changed_files
+        .iter()
+        .map(|file| file.path.clone())
+        .collect::<Vec<_>>();
+    let work_deadline = store
+        .remaining_work_budget()
+        .deadline
+        .map(|remaining| Instant::now() + remaining);
+    let interrupted = || store.work_interrupted();
+    let baseline_blobs = diff::baseline_blobs_for_paths_controlled(
+        &root,
+        &impact.baseline.baseline_oid,
+        &changed_paths,
+        work_deadline,
+        Some(&interrupted),
+    )?;
+    let mut baseline_store = store
+        .private_writable_snapshot()
+        .map_err(|_| TemporalError::SnapshotUnavailable)?;
+    let exhausted = baseline_store.push_work_budget(store.remaining_work_budget());
+    if exhausted {
+        baseline_store.pop_work_budget();
+        return Err(TemporalError::SnapshotUnavailable);
+    }
+    let mut diagnostics = Vec::new();
+    let head_ownership_paths = ownership_scope_paths(store, options)?;
+    let baseline_projection = (|| {
+        rewind_changed_files(
+            &mut baseline_store,
+            &changed_paths,
+            &baseline_blobs,
+            &mut diagnostics,
+        )?;
+        let map = match queries::project_map_with_options(
+            &baseline_store,
+            &options.path,
+            options.depth,
+            options.top,
+            options.production_only,
+        ) {
+            Ok(map) => Some(map),
+            Err(error) if error.contains("scope has no indexed files") => {
+                diagnostics.push(diagnostic(
+                    "baseline_scope_empty",
+                    "The selected scope did not contain indexed source files at the baseline.",
+                ));
+                None
+            }
+            Err(error) => return Err(TemporalError::MapUnavailable(error)),
+        };
+        let ownership_paths = ownership_scope_paths(&baseline_store, options)?;
+        Ok((map, ownership_paths))
+    })();
+    baseline_store.pop_work_budget();
+    let (baseline_map, baseline_ownership_paths) = baseline_projection?;
+    let head_scope_empty = head_map.is_none_or(|map| map.files.total == Some(0));
+    if head_scope_empty && baseline_map.is_none() {
+        return Err(TemporalError::MapUnavailable(if options.production_only {
+            "map production scope has no indexed files".to_string()
+        } else {
+            "map scope has no indexed files".to_string()
+        }));
+    }
+
+    let base = baseline_map
+        .as_ref()
+        .map(ArchitectureProjection::from_map)
+        .unwrap_or_default();
+    let head = head_map
+        .map(ArchitectureProjection::from_map)
+        .unwrap_or_default();
+    let components = component_delta(&base, &head);
+    let boundaries = boundary_delta(&base, &head);
+    let cycles = cycle_delta(&base, &head);
+    let (centrality, hotspots) = centrality_delta(&base, &head);
+    let public_api = boundaries.clone();
+    let ownership = ownership_delta(
+        OwnershipInput {
+            store,
+            root: &root,
+            override_path: options.codeowners.as_deref(),
+            baseline_oid: &impact.baseline.baseline_oid,
+            changed_files: &changed_files,
+            baseline_blobs: &baseline_blobs,
+            scope_paths: baseline_ownership_paths
+                .into_iter()
+                .chain(head_ownership_paths)
+                .collect(),
+            boundaries: &boundaries,
+        },
+        &mut diagnostics,
+    )?;
+    let history_review_candidates = history_review_candidates(
+        store,
+        &changed_files,
+        &components,
+        &boundaries,
+        &mut diagnostics,
+    )?;
+
+    let validation_deadline = store
+        .remaining_work_budget()
+        .deadline
+        .map(|remaining| Instant::now() + remaining);
+    let interrupted = || store.work_interrupted();
+    diff::validate_working_tree_snapshot_controlled(
+        &root,
+        &impact.baseline.baseline_oid,
+        &impact.baseline.head_oid,
+        &changed_files,
+        &impact.snapshot_token,
+        validation_deadline,
+        Some(&interrupted),
+    )?;
+
+    let centrality_increases = centrality
+        .items
+        .iter()
+        .filter(|item| item.in_degree_delta > 0)
+        .count() as u32;
+    let summary = TemporalSummary {
+        architecture_changed: architecture_changed(
+            &components,
+            &boundaries,
+            &cycles,
+            &centrality,
+            &hotspots,
+            &ownership,
+        ),
+        components_added: components.added.total,
+        components_removed: components.removed.total,
+        boundaries_added: boundaries.added.total,
+        boundaries_removed: boundaries.removed.total,
+        boundaries_changed: boundaries.changed.total,
+        cycles_introduced: cycles.added.total,
+        cycles_resolved: cycles.removed.total,
+        cycles_changed: cycles.changed.total,
+        centrality_increases,
+        hotspot_entries: hotspots.entered.total,
+        hotspot_exits: hotspots.exited.total,
+        ownership_changes: ownership.changes.total,
+        history_review_candidates: history_review_candidates.total,
+    };
+    let mut partial = base.partial
+        || head.partial
+        || components.added.truncated
+        || components.removed.truncated
+        || components.changed.truncated
+        || boundaries.added.truncated
+        || boundaries.removed.truncated
+        || boundaries.changed.truncated
+        || cycles.added.truncated
+        || cycles.removed.truncated
+        || cycles.changed.truncated
+        || centrality.truncated
+        || hotspots.entered.truncated
+        || hotspots.exited.truncated
+        || hotspots.moved.truncated
+        || ownership.changes.truncated
+        || history_review_candidates.truncated;
+    if base.partial || head.partial {
+        diagnostics.push(diagnostic(
+            "bounded_map_projection",
+            "At least one base/head map section was truncated; deltas describe only the returned deterministic projection.",
+        ));
+    }
+    diagnostics
+        .sort_by(|left, right| (&left.code, &left.message).cmp(&(&right.code, &right.message)));
+    diagnostics.dedup_by(|left, right| left.code == right.code && left.message == right.message);
+    let mut diagnostics_truncated = ownership.diagnostics_truncated;
+    if diagnostics.len() > DIAGNOSTIC_LIMIT {
+        diagnostics.truncate(DIAGNOSTIC_LIMIT.saturating_sub(1));
+        diagnostics.push(diagnostic(
+            "diagnostic_limit",
+            "Additional temporal diagnostics were omitted by the response limit.",
+        ));
+        diagnostics_truncated = true;
+    }
+    if diagnostics_truncated {
+        partial = true;
+    }
+
+    Ok(TemporalResponse {
+        schema_version: 1,
+        baseline: TemporalBaseline {
+            requested_ref: impact.baseline.requested_ref.clone(),
+            baseline_oid: impact.baseline.baseline_oid.clone(),
+            head_oid: impact.baseline.head_oid.clone(),
+            includes_worktree: impact.baseline.includes_worktree,
+            includes_untracked: impact.baseline.includes_untracked,
+        },
+        scope: TemporalScope {
+            path: if options.path.is_empty() || options.path == "." {
+                ".".to_string()
+            } else {
+                queries::normalize_map_path(&options.path).map_err(TemporalError::MapUnavailable)?
+            },
+            depth: options.depth.clamp(1, 5),
+            production_only: options.production_only,
+        },
+        summary,
+        components,
+        boundaries,
+        cycles,
+        centrality,
+        hotspots,
+        public_api,
+        ownership,
+        history_review_candidates,
+        provenance: TemporalProvenance {
+            baseline_graph: "git_blob_rewind_private_sqlite_snapshot",
+            head_graph: "indexed_worktree_snapshot",
+            graph_edges: "tree_sitter_syntactic_medium_confidence",
+            ownership: "base_and_head_codeowners_last_match",
+            history: "exact_path_mentions_review_candidates_only",
+        },
+        limits: TemporalLimits {
+            changed_files: diff::CHANGE_FILE_LIMIT as u32,
+            components_per_direction: COMPONENT_DELTA_LIMIT as u32,
+            boundaries_per_direction: BOUNDARY_DELTA_LIMIT as u32,
+            cycles_per_direction: CYCLE_DELTA_LIMIT as u32,
+            centrality_rows: CENTRALITY_DELTA_LIMIT as u32,
+            ownership_paths: OWNERSHIP_PATH_LIMIT as u32,
+            history_candidates: HISTORY_CANDIDATE_LIMIT as u32,
+            history_artifacts: HISTORY_ARTIFACT_LIMIT as u32,
+            history_bytes: HISTORY_BYTE_LIMIT as u64,
+            diagnostics: DIAGNOSTIC_LIMIT as u32,
+        },
+        partial,
+        diagnostics_truncated,
+        diagnostics,
+    })
+}
+
+pub(crate) fn scope_has_deleted_file(
+    impact: &ChangeImpactResponse,
+    path: &str,
+) -> Result<bool, String> {
+    let normalized = queries::normalize_map_path(path)?;
+    let directory_prefix = (!normalized.is_empty()).then(|| format!("{normalized}/"));
+    Ok(impact.changes.files.items.iter().any(|file| {
+        file.status == "deleted"
+            && crate::indexer::extractor_for_path(Path::new(&file.path)).is_some()
+            && (normalized.is_empty()
+                || file.path == normalized
+                || directory_prefix
+                    .as_deref()
+                    .is_some_and(|prefix| file.path.starts_with(prefix)))
+    }))
+}
+
+fn architecture_changed(
+    components: &TemporalComponents,
+    boundaries: &TemporalBoundaryDelta,
+    cycles: &TemporalCycleDelta,
+    centrality: &TemporalCollection<TemporalCentralityDrift>,
+    hotspots: &TemporalHotspotDrift,
+    ownership: &TemporalOwnership,
+) -> bool {
+    components.added.total > 0
+        || components.removed.total > 0
+        || components.changed.total > 0
+        || boundaries.added.total > 0
+        || boundaries.removed.total > 0
+        || boundaries.changed.total > 0
+        || cycles.added.total > 0
+        || cycles.removed.total > 0
+        || cycles.changed.total > 0
+        || centrality.total > 0
+        || hotspots.entered.total > 0
+        || hotspots.exited.total > 0
+        || ownership.changes.total > 0
+}
+
+fn ownership_scope_paths(
+    store: &Store,
+    options: &TemporalOptions,
+) -> Result<Vec<String>, TemporalError> {
+    let normalized =
+        queries::normalize_map_path(&options.path).map_err(TemporalError::MapUnavailable)?;
+    let kind = if normalized.is_empty() {
+        "root"
+    } else if store
+        .file_mtime(&normalized)
+        .map_err(|error| TemporalError::BaselineRewind(error.to_string()))?
+        .is_some()
+    {
+        "file"
+    } else {
+        "directory"
+    };
+    store
+        .map_paths_filtered(
+            &normalized,
+            kind,
+            OWNERSHIP_PATH_LIMIT.saturating_add(1),
+            options.production_only,
+        )
+        .map_err(|error| TemporalError::BaselineRewind(error.to_string()))
+}
+
+fn rewind_changed_files(
+    store: &mut Store,
+    paths: &[String],
+    blobs: &BTreeMap<String, Option<Vec<u8>>>,
+    diagnostics: &mut Vec<TemporalDiagnostic>,
+) -> Result<(), TemporalError> {
+    for path in paths {
+        if store.work_interrupted() {
+            return Err(TemporalError::SnapshotUnavailable);
+        }
+        let Some(extractor) = extractor_for_path(Path::new(path)) else {
+            continue;
+        };
+        let Some(bytes) = blobs.get(path).and_then(|value| value.as_deref()) else {
+            store
+                .purge_file(path)
+                .map_err(|error| TemporalError::BaselineRewind(error.to_string()))?;
+            continue;
+        };
+        if bytes.len() as u64 > MAX_INDEXABLE_FILE_SIZE || is_binary_content(bytes) {
+            store
+                .purge_file(path)
+                .map_err(|error| TemporalError::BaselineRewind(error.to_string()))?;
+            diagnostics.push(diagnostic(
+                "baseline_source_skipped",
+                format!("Baseline source `{path}` exceeded source admission limits."),
+            ));
+            continue;
+        }
+        let pending = parse_blob(path, bytes, 0, extractor.as_ref())
+            .map_err(|error| TemporalError::BaselineRewind(format!("{path}: {error:?}")))?;
+        store
+            .commit_file(pending)
+            .map_err(|error| TemporalError::BaselineRewind(format!("{path}: {error}")))?;
+    }
+    Ok(())
+}
+
+impl ArchitectureProjection {
+    fn from_map(map: &ProjectMapResponse) -> Self {
+        let mut components = BTreeMap::new();
+        let mut boundaries = BTreeMap::new();
+        for component in &map.components.items {
+            let item = temporal_component(component);
+            for boundary in &component.boundaries.items {
+                let boundary = temporal_boundary(&component.path, boundary);
+                boundaries.insert(boundary_key(&boundary), boundary);
+            }
+            components.insert(item.path.clone(), item);
+        }
+        let cycles = map
+            .cycles
+            .items
+            .iter()
+            .map(|cycle| {
+                let mut cycle = cycle.clone();
+                cycle.sort();
+                cycle
+            })
+            .collect();
+        let hotspots = map
+            .hotspots
+            .items
+            .iter()
+            .enumerate()
+            .map(|(index, hotspot)| {
+                let hotspot = temporal_hotspot(hotspot, index as u32 + 1);
+                (hotspot_key(&hotspot), hotspot)
+            })
+            .collect();
+        let partial = map.files.truncated
+            || map.languages.truncated
+            || map.components.truncated
+            || map
+                .components
+                .items
+                .iter()
+                .any(|item| item.boundaries.truncated)
+            || map.entry_points.truncated
+            || map.hotspots.truncated
+            || map.cycles.truncated
+            || map.scope.aggregation_paths_truncated;
+        Self {
+            components,
+            boundaries,
+            cycles,
+            hotspots,
+            partial,
+        }
+    }
+}
+
+fn temporal_component(component: &MapComponent) -> TemporalComponent {
+    TemporalComponent {
+        path: component.path.clone(),
+        file_count: component.file_count,
+        languages: component
+            .languages
+            .iter()
+            .map(|language| TemporalLanguage {
+                language: language.language.clone(),
+                file_count: language.file_count,
+            })
+            .collect(),
+    }
+}
+
+fn temporal_boundary(component: &str, symbol: &SymbolHit) -> TemporalBoundary {
+    TemporalBoundary {
+        component: component.to_string(),
+        file: symbol.file.clone(),
+        name: symbol.name.clone(),
+        kind: symbol.kind.clone(),
+        line: symbol.line,
+        signature: symbol.signature.clone(),
+    }
+}
+
+fn temporal_hotspot(hotspot: &MapHotspot, rank: u32) -> TemporalHotspot {
+    TemporalHotspot {
+        file: hotspot.file.clone(),
+        name: hotspot.name.clone(),
+        kind: hotspot.kind.clone(),
+        line: hotspot.line,
+        rank,
+        in_degree: hotspot.in_degree,
+    }
+}
+
+fn component_delta(
+    base: &ArchitectureProjection,
+    head: &ArchitectureProjection,
+) -> TemporalComponents {
+    let base_keys = base.components.keys().cloned().collect::<BTreeSet<_>>();
+    let head_keys = head.components.keys().cloned().collect::<BTreeSet<_>>();
+    let added = head_keys
+        .difference(&base_keys)
+        .filter_map(|key| head.components.get(key).cloned())
+        .collect();
+    let removed = base_keys
+        .difference(&head_keys)
+        .filter_map(|key| base.components.get(key).cloned())
+        .collect();
+    let changed = base_keys
+        .intersection(&head_keys)
+        .filter_map(|key| {
+            let base = base.components.get(key)?;
+            let head = head.components.get(key)?;
+            (base.file_count != head.file_count || base.languages != head.languages).then(|| {
+                TemporalComponentDrift {
+                    path: key.clone(),
+                    base_file_count: base.file_count,
+                    head_file_count: head.file_count,
+                    base_languages: base.languages.clone(),
+                    head_languages: head.languages.clone(),
+                }
+            })
+        })
+        .collect();
+    TemporalComponents {
+        added: bounded(added, COMPONENT_DELTA_LIMIT),
+        removed: bounded(removed, COMPONENT_DELTA_LIMIT),
+        changed: bounded(changed, COMPONENT_DELTA_LIMIT),
+    }
+}
+
+fn boundary_delta(
+    base: &ArchitectureProjection,
+    head: &ArchitectureProjection,
+) -> TemporalBoundaryDelta {
+    let base_keys = base.boundaries.keys().cloned().collect::<BTreeSet<_>>();
+    let head_keys = head.boundaries.keys().cloned().collect::<BTreeSet<_>>();
+    let added = head_keys
+        .difference(&base_keys)
+        .filter_map(|key| head.boundaries.get(key).cloned())
+        .collect();
+    let removed = base_keys
+        .difference(&head_keys)
+        .filter_map(|key| base.boundaries.get(key).cloned())
+        .collect();
+    let changed = base_keys
+        .intersection(&head_keys)
+        .filter_map(|key| {
+            let base = base.boundaries.get(key)?;
+            let head = head.boundaries.get(key)?;
+            (base.signature != head.signature).then(|| TemporalBoundaryDrift {
+                component: key.0.clone(),
+                file: key.1.clone(),
+                name: key.2.clone(),
+                kind: key.3.clone(),
+                base_line: base.line,
+                head_line: head.line,
+                base_signature: base.signature.clone(),
+                head_signature: head.signature.clone(),
+            })
+        })
+        .collect();
+    TemporalBoundaryDelta {
+        added: bounded(added, BOUNDARY_DELTA_LIMIT),
+        removed: bounded(removed, BOUNDARY_DELTA_LIMIT),
+        changed: bounded(changed, BOUNDARY_DELTA_LIMIT),
+    }
+}
+
+fn cycle_delta(base: &ArchitectureProjection, head: &ArchitectureProjection) -> TemporalCycleDelta {
+    let exact = base
+        .cycles
+        .intersection(&head.cycles)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let base_remaining = base.cycles.difference(&exact).cloned().collect::<Vec<_>>();
+    let head_remaining = head.cycles.difference(&exact).cloned().collect::<Vec<_>>();
+    let mut base_edges = vec![Vec::new(); base_remaining.len()];
+    let mut head_edges = vec![Vec::new(); head_remaining.len()];
+    for (base_index, base_cycle) in base_remaining.iter().enumerate() {
+        let base_members = base_cycle.iter().collect::<BTreeSet<_>>();
+        for (head_index, head_cycle) in head_remaining.iter().enumerate() {
+            if head_cycle
+                .iter()
+                .any(|member| base_members.contains(member))
+            {
+                base_edges[base_index].push(head_index);
+                head_edges[head_index].push(base_index);
+            }
+        }
+    }
+    let mut used_base = vec![false; base_remaining.len()];
+    let mut used_head = vec![false; head_remaining.len()];
+    let mut changed = Vec::new();
+    for start in 0..base_remaining.len() {
+        if used_base[start] || base_edges[start].is_empty() {
+            continue;
+        }
+        let mut queue = VecDeque::from([(true, start)]);
+        let mut base_indices = BTreeSet::new();
+        let mut head_indices = BTreeSet::new();
+        while let Some((is_base, index)) = queue.pop_front() {
+            if is_base {
+                if used_base[index] {
+                    continue;
+                }
+                used_base[index] = true;
+                base_indices.insert(index);
+                queue.extend(base_edges[index].iter().map(|next| (false, *next)));
+            } else {
+                if used_head[index] {
+                    continue;
+                }
+                used_head[index] = true;
+                head_indices.insert(index);
+                queue.extend(head_edges[index].iter().map(|next| (true, *next)));
+            }
+        }
+        let base_cycles = base_indices
+            .iter()
+            .map(|index| base_remaining[*index].clone())
+            .collect::<Vec<_>>();
+        let head_cycles = head_indices
+            .iter()
+            .map(|index| head_remaining[*index].clone())
+            .collect::<Vec<_>>();
+        let base_members = base_cycles
+            .iter()
+            .flatten()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let head_members = head_cycles
+            .iter()
+            .flatten()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        changed.push(TemporalCycleDrift {
+            base_cycles,
+            head_cycles,
+            added_members: head_members.difference(&base_members).cloned().collect(),
+            removed_members: base_members.difference(&head_members).cloned().collect(),
+        });
+    }
+    changed.sort_by(|left, right| {
+        left.head_cycles
+            .cmp(&right.head_cycles)
+            .then_with(|| left.base_cycles.cmp(&right.base_cycles))
+    });
+    let added = head_remaining
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, cycle)| (!used_head[index]).then_some(cycle))
+        .collect();
+    let removed = base_remaining
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, cycle)| (!used_base[index]).then_some(cycle))
+        .collect();
+    TemporalCycleDelta {
+        added: bounded(added, CYCLE_DELTA_LIMIT),
+        removed: bounded(removed, CYCLE_DELTA_LIMIT),
+        changed: bounded(changed, CYCLE_DELTA_LIMIT),
+    }
+}
+
+fn centrality_delta(
+    base: &ArchitectureProjection,
+    head: &ArchitectureProjection,
+) -> (
+    TemporalCollection<TemporalCentralityDrift>,
+    TemporalHotspotDrift,
+) {
+    let base_keys = base.hotspots.keys().cloned().collect::<BTreeSet<_>>();
+    let head_keys = head.hotspots.keys().cloned().collect::<BTreeSet<_>>();
+    let entered = head_keys
+        .difference(&base_keys)
+        .filter_map(|key| head.hotspots.get(key).cloned())
+        .collect();
+    let exited = base_keys
+        .difference(&head_keys)
+        .filter_map(|key| base.hotspots.get(key).cloned())
+        .collect();
+    let mut drift = base_keys
+        .intersection(&head_keys)
+        .filter_map(|key| {
+            let base = base.hotspots.get(key)?;
+            let head = head.hotspots.get(key)?;
+            (base.in_degree != head.in_degree || base.rank != head.rank).then(|| {
+                TemporalCentralityDrift {
+                    file: key.0.clone(),
+                    name: key.1.clone(),
+                    kind: key.2.clone(),
+                    base_rank: base.rank,
+                    head_rank: head.rank,
+                    base_in_degree: base.in_degree,
+                    head_in_degree: head.in_degree,
+                    in_degree_delta: i64::from(head.in_degree) - i64::from(base.in_degree),
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    drift.sort_by(|left, right| {
+        right
+            .in_degree_delta
+            .cmp(&left.in_degree_delta)
+            .then_with(|| {
+                (&left.file, &left.name, &left.kind).cmp(&(&right.file, &right.name, &right.kind))
+            })
+    });
+    let centrality = bounded(drift.clone(), CENTRALITY_DELTA_LIMIT);
+    let moved = bounded(drift, CENTRALITY_DELTA_LIMIT);
+    (
+        centrality,
+        TemporalHotspotDrift {
+            entered: bounded(entered, CENTRALITY_DELTA_LIMIT),
+            exited: bounded(exited, CENTRALITY_DELTA_LIMIT),
+            moved,
+        },
+    )
+}
+
+struct OwnershipInput<'a> {
+    store: &'a Store,
+    root: &'a Path,
+    override_path: Option<&'a Path>,
+    baseline_oid: &'a str,
+    changed_files: &'a [WorkingTreeChangedFile],
+    baseline_blobs: &'a BTreeMap<String, Option<Vec<u8>>>,
+    scope_paths: Vec<String>,
+    boundaries: &'a TemporalBoundaryDelta,
+}
+
+fn ownership_delta(
+    input: OwnershipInput<'_>,
+    diagnostics: &mut Vec<TemporalDiagnostic>,
+) -> Result<TemporalOwnership, TemporalError> {
+    let OwnershipInput {
+        store,
+        root,
+        override_path,
+        baseline_oid,
+        changed_files,
+        baseline_blobs,
+        scope_paths,
+        boundaries,
+    } = input;
+    let mut candidates = scope_paths
+        .into_iter()
+        .chain(changed_files.iter().map(|file| file.path.clone()))
+        .chain(boundaries.added.items.iter().map(|item| item.file.clone()))
+        .chain(
+            boundaries
+                .removed
+                .items
+                .iter()
+                .map(|item| item.file.clone()),
+        )
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let paths_truncated = candidates.len() > OWNERSHIP_PATH_LIMIT;
+    candidates.truncate(OWNERSHIP_PATH_LIMIT);
+
+    let requested_head_path = override_path
+        .map(|path| {
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                root.join(path)
+            }
+        })
+        .or_else(|| crate::evidence::discover_codeowners(root));
+    let head_path = requested_head_path
+        .as_deref()
+        .and_then(|path| path.canonicalize().ok());
+    let head_source = head_path
+        .as_deref()
+        .and_then(|path| path.strip_prefix(root).ok())
+        .map(|path| path.to_string_lossy().replace('\\', "/"));
+    if override_path.is_some() && head_source.is_none() {
+        diagnostics.push(diagnostic(
+            "external_codeowners_baseline_unavailable",
+            "An unavailable or external CODEOWNERS override has no Git-baseline counterpart; ownership drift was omitted.",
+        ));
+        return Ok(TemporalOwnership {
+            base_source: None,
+            head_source: requested_head_path.map(|path| path.to_string_lossy().to_string()),
+            changes: TemporalCollection {
+                total: 0,
+                returned: 0,
+                truncated: true,
+                truncation_reason: Some("baseline_unavailable"),
+                items: Vec::new(),
+            },
+            diagnostics_truncated: false,
+        });
+    }
+
+    let baseline_candidates = if override_path.is_some() {
+        head_source.iter().cloned().collect()
+    } else {
+        vec![
+            ".github/CODEOWNERS".to_string(),
+            "CODEOWNERS".to_string(),
+            "docs/CODEOWNERS".to_string(),
+        ]
+    };
+    let deadline = store
+        .remaining_work_budget()
+        .deadline
+        .map(|remaining| Instant::now() + remaining);
+    let interrupted = || store.work_interrupted();
+    let baseline_owner_blobs = diff::baseline_blobs_for_paths_controlled(
+        root,
+        baseline_oid,
+        &baseline_candidates,
+        deadline,
+        Some(&interrupted),
+    )?;
+    let (base_source, base_bytes) = baseline_candidates
+        .iter()
+        .find_map(|path| {
+            baseline_owner_blobs
+                .get(path)
+                .and_then(|bytes| bytes.as_ref())
+                .map(|bytes| (Some(path.clone()), Some(bytes.as_slice())))
+        })
+        .unwrap_or((None, None));
+    let head_bytes = match head_path.as_deref() {
+        Some(path) => match read_stable_codeowners(path, store) {
+            Ok(bytes) => Some(bytes),
+            Err("work_interrupted") => return Err(TemporalError::SnapshotUnavailable),
+            Err(code) => {
+                diagnostics.push(diagnostic(
+                    code,
+                    "Head CODEOWNERS could not be read safely.",
+                ));
+                None
+            }
+        },
+        None => None,
+    };
+
+    let base_resolution = base_bytes.and_then(|bytes| {
+        match crate::evidence::resolve_codeowners_bytes_controlled(bytes, &candidates, &interrupted)
+        {
+            Ok(resolution) => Some(resolution),
+            Err("work_interrupted") => None,
+            Err(code) => {
+                diagnostics.push(diagnostic(
+                    code,
+                    "Baseline CODEOWNERS could not be resolved.",
+                ));
+                None
+            }
+        }
+    });
+    let head_resolution = head_bytes.as_deref().and_then(|bytes| {
+        match crate::evidence::resolve_codeowners_bytes_controlled(bytes, &candidates, &interrupted)
+        {
+            Ok(resolution) => Some(resolution),
+            Err("work_interrupted") => None,
+            Err(code) => {
+                diagnostics.push(diagnostic(code, "Head CODEOWNERS could not be resolved."));
+                None
+            }
+        }
+    });
+    if store.work_interrupted() {
+        return Err(TemporalError::SnapshotUnavailable);
+    }
+    for resolution in [base_resolution.as_ref(), head_resolution.as_ref()]
+        .into_iter()
+        .flatten()
+    {
+        for code in &resolution.diagnostics {
+            diagnostics.push(diagnostic(code, "CODEOWNERS resolution was partial."));
+        }
+    }
+    let parser_diagnostics_truncated = base_resolution
+        .as_ref()
+        .is_some_and(|resolution| resolution.diagnostics_truncated)
+        || head_resolution
+            .as_ref()
+            .is_some_and(|resolution| resolution.diagnostics_truncated);
+    if (base_bytes.is_some() && base_resolution.is_none())
+        || (head_path.is_some() && head_resolution.is_none())
+    {
+        return Ok(TemporalOwnership {
+            base_source,
+            head_source,
+            changes: TemporalCollection {
+                total: 0,
+                returned: 0,
+                truncated: true,
+                truncation_reason: Some("source_unavailable"),
+                items: Vec::new(),
+            },
+            diagnostics_truncated: parser_diagnostics_truncated,
+        });
+    }
+    let changed_by_path = changed_files
+        .iter()
+        .map(|file| (file.path.as_str(), file.status.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    let mut changes = Vec::new();
+    for path in &candidates {
+        if store.work_interrupted() {
+            return Err(TemporalError::SnapshotUnavailable);
+        }
+        let existed_at_base = baseline_blobs.get(path).is_none_or(|value| value.is_some());
+        let exists_at_head = changed_by_path.get(path.as_str()) != Some(&"deleted");
+        let base_owners = if existed_at_base {
+            base_resolution
+                .as_ref()
+                .and_then(|value| value.owners_by_path.get(path))
+                .cloned()
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let head_owners = if exists_at_head {
+            head_resolution
+                .as_ref()
+                .and_then(|value| value.owners_by_path.get(path))
+                .cloned()
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        if base_owners != head_owners {
+            changes.push(TemporalOwnershipChange {
+                path: path.clone(),
+                base_owners,
+                head_owners,
+            });
+        }
+    }
+    let parser_partial = base_resolution.as_ref().is_some_and(|value| value.partial)
+        || head_resolution.as_ref().is_some_and(|value| value.partial);
+    let mut changes = bounded(changes, OWNERSHIP_PATH_LIMIT);
+    if paths_truncated || parser_partial {
+        changes.truncated = true;
+        changes.truncation_reason = Some(if paths_truncated {
+            "path_limit"
+        } else {
+            "codeowners_work_limit"
+        });
+    }
+    Ok(TemporalOwnership {
+        base_source,
+        head_source,
+        changes,
+        diagnostics_truncated: parser_diagnostics_truncated,
+    })
+}
+
+fn read_stable_codeowners(path: &Path, store: &Store) -> Result<Vec<u8>, &'static str> {
+    const MAX_BYTES: u64 = 3 * 1024 * 1024;
+    let mut file = std::fs::File::open(path).map_err(|_| "codeowners_unavailable")?;
+    let before = file.metadata().map_err(|_| "codeowners_unavailable")?;
+    if !before.is_file() {
+        return Err("codeowners_unavailable");
+    }
+    if before.len() >= MAX_BYTES {
+        return Err("codeowners_too_large");
+    }
+    let mut bytes = Vec::with_capacity(usize::try_from(before.len()).unwrap_or(0));
+    let mut input = file.by_ref().take(MAX_BYTES + 1);
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        if store.work_interrupted() {
+            return Err("work_interrupted");
+        }
+        let count = input
+            .read(&mut buffer)
+            .map_err(|_| "codeowners_unavailable")?;
+        if count == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buffer[..count]);
+    }
+    if bytes.len() as u64 >= MAX_BYTES {
+        return Err("codeowners_too_large");
+    }
+    let after = file.metadata().map_err(|_| "codeowners_changed")?;
+    if before.len() != after.len() || before.modified().ok() != after.modified().ok() {
+        return Err("codeowners_changed");
+    }
+    Ok(bytes)
+}
+
+fn history_review_candidates(
+    store: &Store,
+    changed_files: &[WorkingTreeChangedFile],
+    components: &TemporalComponents,
+    boundaries: &TemporalBoundaryDelta,
+    diagnostics: &mut Vec<TemporalDiagnostic>,
+) -> Result<TemporalCollection<TemporalHistoryCandidate>, TemporalError> {
+    let mut triggers = BTreeMap::new();
+    for file in changed_files.iter().filter(|file| file.status == "deleted") {
+        triggers.insert(file.path.clone(), "path_deleted".to_string());
+    }
+    for component in &components.removed.items {
+        if component.path != "." && !component.path.is_empty() {
+            triggers
+                .entry(component.path.clone())
+                .or_insert_with(|| "component_removed".to_string());
+        }
+    }
+    for boundary in &boundaries.removed.items {
+        triggers
+            .entry(boundary.file.clone())
+            .or_insert_with(|| "public_api_removed".to_string());
+    }
+    for boundary in &boundaries.changed.items {
+        triggers
+            .entry(boundary.file.clone())
+            .or_insert_with(|| "public_api_changed".to_string());
+    }
+    if triggers.is_empty() {
+        return Ok(bounded(Vec::new(), HISTORY_CANDIDATE_LIMIT));
+    }
+    let paths = triggers.keys().cloned().collect::<Vec<_>>();
+    let matcher = AhoCorasick::new(&paths)
+        .map_err(|error| TemporalError::BaselineRewind(error.to_string()))?;
+    let (entries, history_truncated) = store
+        .project_history_entries_bounded(HISTORY_ARTIFACT_LIMIT, HISTORY_BYTE_LIMIT)
+        .map_err(|error| TemporalError::BaselineRewind(error.to_string()))?;
+    let mut candidates = BTreeSet::new();
+    let mut overflow = false;
+    'entries: for entry in entries {
+        if store.work_interrupted() {
+            return Err(TemporalError::SnapshotUnavailable);
+        }
+        for matched in matcher.find_overlapping_iter(entry.body.as_bytes()) {
+            if store.work_interrupted() {
+                return Err(TemporalError::SnapshotUnavailable);
+            }
+            if !exact_path_boundaries(&entry.body, matched.start(), matched.end()) {
+                continue;
+            }
+            let referenced_path = paths[matched.pattern().as_usize()].clone();
+            candidates.insert((
+                entry.path.clone(),
+                entry.kind.clone(),
+                entry.title.clone(),
+                referenced_path.clone(),
+                triggers
+                    .get(&referenced_path)
+                    .cloned()
+                    .unwrap_or_else(|| "architecture_changed".to_string()),
+            ));
+            if candidates.len() > HISTORY_CANDIDATE_LIMIT {
+                overflow = true;
+                break 'entries;
+            }
+        }
+    }
+    if history_truncated {
+        diagnostics.push(diagnostic(
+            "history_snapshot_truncated",
+            "The derived history corpus was truncated before temporal correlation.",
+        ));
+    }
+    let mut response = bounded(
+        candidates
+            .into_iter()
+            .map(|(artifact_path, kind, title, referenced_path, trigger)| {
+                TemporalHistoryCandidate {
+                    artifact_path,
+                    kind,
+                    title,
+                    referenced_path,
+                    trigger,
+                }
+            })
+            .collect(),
+        HISTORY_CANDIDATE_LIMIT,
+    );
+    if history_truncated || overflow {
+        response.truncated = true;
+        response.truncation_reason = Some(if overflow {
+            "candidate_limit"
+        } else {
+            "history_snapshot_limit"
+        });
+    }
+    Ok(response)
+}
+
+fn exact_path_boundaries(body: &str, start: usize, end: usize) -> bool {
+    let bytes = body.as_bytes();
+    let before = start.checked_sub(1).and_then(|index| bytes.get(index));
+    let after = bytes.get(end);
+    let is_path_byte = |byte: u8| {
+        byte >= 0x80
+            || byte.is_ascii_alphanumeric()
+            || matches!(byte, b'_' | b'-' | b'.' | b'/' | b'\\')
+    };
+    let after_is_boundary = match after {
+        Some(b'.') => bytes
+            .get(end.saturating_add(1))
+            .is_none_or(|byte| !is_path_byte(*byte)),
+        Some(byte) => !is_path_byte(*byte),
+        None => true,
+    };
+    before.is_none_or(|byte| !is_path_byte(*byte)) && after_is_boundary
+}
+
+fn boundary_key(boundary: &TemporalBoundary) -> BoundaryKey {
+    (
+        boundary.component.clone(),
+        boundary.file.clone(),
+        boundary.name.clone(),
+        boundary.kind.clone(),
+    )
+}
+
+fn hotspot_key(hotspot: &TemporalHotspot) -> HotspotKey {
+    (
+        hotspot.file.clone(),
+        hotspot.name.clone(),
+        hotspot.kind.clone(),
+    )
+}
+
+fn bounded<T>(mut items: Vec<T>, limit: usize) -> TemporalCollection<T> {
+    let total = items.len();
+    let truncated = total > limit;
+    items.truncate(limit);
+    TemporalCollection {
+        total: total as u32,
+        returned: items.len() as u32,
+        truncated,
+        truncation_reason: truncated.then_some("output_limit"),
+        items,
+    }
+}
+
+fn diagnostic(code: impl Into<String>, message: impl Into<String>) -> TemporalDiagnostic {
+    TemporalDiagnostic {
+        code: code.into(),
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexer::Indexer;
+    use std::fs;
+    use std::process::Command;
+
+    fn set_delta(base: BTreeSet<String>, head: BTreeSet<String>) -> (Vec<String>, Vec<String>) {
+        (
+            head.difference(&base).cloned().collect(),
+            base.difference(&head).cloned().collect(),
+        )
+    }
+
+    #[test]
+    fn temporal_projection_reports_additions_and_removals() {
+        let base = BTreeSet::from(["services/legacy".to_string(), "services/shared".to_string()]);
+        let head = BTreeSet::from([
+            "services/payment".to_string(),
+            "services/shared".to_string(),
+        ]);
+
+        let (added, removed) = set_delta(base, head);
+
+        assert_eq!(added, ["services/payment"]);
+        assert_eq!(removed, ["services/legacy"]);
+    }
+
+    #[test]
+    fn temporal_projection_covers_cycles_centrality_and_public_api() {
+        let boundary = |signature: &str| TemporalBoundary {
+            component: "payment".to_string(),
+            file: "payment/api.py".to_string(),
+            name: "charge".to_string(),
+            kind: "function".to_string(),
+            line: 1,
+            signature: Some(signature.to_string()),
+        };
+        let hotspot = |rank, in_degree| TemporalHotspot {
+            file: "payment/api.py".to_string(),
+            name: "charge".to_string(),
+            kind: "function".to_string(),
+            line: 1,
+            rank,
+            in_degree,
+        };
+        let mut base = ArchitectureProjection::default();
+        base.boundaries.insert(
+            boundary_key(&boundary("charge(total)")),
+            boundary("charge(total)"),
+        );
+        base.cycles
+            .insert(vec!["a.py".to_string(), "b.py".to_string()]);
+        base.hotspots
+            .insert(hotspot_key(&hotspot(2, 3)), hotspot(2, 3));
+        let mut head = ArchitectureProjection::default();
+        head.boundaries.insert(
+            boundary_key(&boundary("charge(total, currency)")),
+            boundary("charge(total, currency)"),
+        );
+        head.cycles
+            .insert(vec!["a.py".to_string(), "b.py".to_string()]);
+        head.cycles
+            .insert(vec!["c.py".to_string(), "d.py".to_string()]);
+        head.hotspots
+            .insert(hotspot_key(&hotspot(1, 8)), hotspot(1, 8));
+
+        let api = boundary_delta(&base, &head);
+        let cycles = cycle_delta(&base, &head);
+        let (centrality, hotspots) = centrality_delta(&base, &head);
+
+        assert_eq!(api.changed.total, 1);
+        assert_eq!(cycles.added.items, [vec!["c.py", "d.py"]]);
+        assert_eq!(centrality.items[0].in_degree_delta, 5);
+        assert_eq!(hotspots.moved.items[0].base_rank, 2);
+        assert_eq!(hotspots.moved.items[0].head_rank, 1);
+    }
+
+    #[test]
+    fn temporal_projection_distinguishes_cycle_growth_and_line_movement() {
+        let mut base = ArchitectureProjection::default();
+        let mut head = ArchitectureProjection::default();
+        base.cycles
+            .insert(vec!["a.py".to_string(), "b.py".to_string()]);
+        head.cycles.insert(vec![
+            "a.py".to_string(),
+            "b.py".to_string(),
+            "c.py".to_string(),
+        ]);
+        let base_boundary = TemporalBoundary {
+            component: "api".to_string(),
+            file: "api.py".to_string(),
+            name: "serve".to_string(),
+            kind: "function".to_string(),
+            line: 5,
+            signature: Some("serve(request)".to_string()),
+        };
+        let mut moved_boundary = base_boundary.clone();
+        moved_boundary.line = 50;
+        base.boundaries
+            .insert(boundary_key(&base_boundary), base_boundary);
+        head.boundaries
+            .insert(boundary_key(&moved_boundary), moved_boundary);
+
+        let cycles = cycle_delta(&base, &head);
+        let api = boundary_delta(&base, &head);
+
+        assert_eq!(cycles.added.total, 0);
+        assert_eq!(cycles.removed.total, 0);
+        assert_eq!(cycles.changed.total, 1);
+        assert_eq!(cycles.changed.items[0].added_members, ["c.py"]);
+        assert!(cycles.changed.items[0].removed_members.is_empty());
+        assert_eq!(api.changed.total, 0, "line motion is not API drift");
+    }
+
+    #[test]
+    fn hotspot_window_entry_alone_marks_architecture_changed() {
+        let empty = ArchitectureProjection::default();
+        let components = component_delta(&empty, &empty);
+        let boundaries = boundary_delta(&empty, &empty);
+        let cycles = cycle_delta(&empty, &empty);
+        let centrality = bounded(Vec::new(), CENTRALITY_DELTA_LIMIT);
+        let hotspots = TemporalHotspotDrift {
+            entered: bounded(
+                vec![TemporalHotspot {
+                    file: "src/gravity.rs".to_string(),
+                    name: "gravity".to_string(),
+                    kind: "function".to_string(),
+                    line: 1,
+                    rank: 1,
+                    in_degree: 8,
+                }],
+                CENTRALITY_DELTA_LIMIT,
+            ),
+            exited: bounded(Vec::new(), CENTRALITY_DELTA_LIMIT),
+            moved: bounded(Vec::new(), CENTRALITY_DELTA_LIMIT),
+        };
+        let ownership = TemporalOwnership {
+            base_source: None,
+            head_source: None,
+            changes: bounded(Vec::new(), OWNERSHIP_PATH_LIMIT),
+            diagnostics_truncated: false,
+        };
+
+        assert!(architecture_changed(
+            &components,
+            &boundaries,
+            &cycles,
+            &centrality,
+            &hotspots,
+            &ownership,
+        ));
+    }
+
+    fn git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn write(root: &Path, path: &str, body: &str) {
+        let target = root.join(path);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(target, body).unwrap();
+    }
+
+    #[test]
+    fn temporal_analysis_rewinds_components_ownership_and_history() {
+        let root = tempfile::tempdir().unwrap();
+        git(root.path(), &["init", "-q"]);
+        git(
+            root.path(),
+            &["config", "user.email", "temporal@example.com"],
+        );
+        git(root.path(), &["config", "user.name", "Temporal Test"]);
+        write(
+            root.path(),
+            ".github/CODEOWNERS",
+            "* @platform\n/legacy/ @legacy\n",
+        );
+        write(
+            root.path(),
+            "legacy/old.py",
+            "def legacy_api():\n    return 1\n",
+        );
+        write(
+            root.path(),
+            "shared/api.py",
+            "def shared_api():\n    return 1\n",
+        );
+        write(
+            root.path(),
+            ".mastermind/tasks/001-history/spec.md",
+            "---\nid: 001-history\ntitle: Legacy boundary\n---\nKeep legacy/old.py behind the compatibility boundary.\n",
+        );
+        git(root.path(), &["add", "."]);
+        git(root.path(), &["commit", "-qm", "baseline"]);
+
+        fs::remove_file(root.path().join("legacy/old.py")).unwrap();
+        write(
+            root.path(),
+            "payment/new.py",
+            "def payment_api():\n    return 2\n",
+        );
+        write(
+            root.path(),
+            ".github/CODEOWNERS",
+            "* @platform\n/payment/ @payments\n",
+        );
+
+        let db = root.path().join(".mastermind/mmcg.db");
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(root.path())
+            .index_all(&mut store, true)
+            .unwrap();
+        let canonical_root = root.path().canonicalize().unwrap();
+        let freshness = crate::lens::validate_index_snapshot(&store, &canonical_root, None);
+        assert!(freshness.is_ok(), "freshness: {freshness:?}");
+        assert!(store.project_history_count().unwrap() > 0);
+        let (history_entries, _) = store
+            .project_history_entries_bounded(HISTORY_ARTIFACT_LIMIT, HISTORY_BYTE_LIMIT)
+            .unwrap();
+        assert!(
+            history_entries
+                .iter()
+                .any(|entry| entry.body.contains("legacy/old.py")),
+            "history entries: {history_entries:?}"
+        );
+        let response = analyze(
+            &store,
+            root.path(),
+            &TemporalOptions {
+                since: "HEAD".to_string(),
+                path: ".".to_string(),
+                depth: 1,
+                top: 20,
+                production_only: false,
+                codeowners: None,
+            },
+        )
+        .unwrap();
+
+        assert!(response
+            .components
+            .added
+            .items
+            .iter()
+            .any(|component| component.path == "payment"));
+        assert!(response
+            .components
+            .removed
+            .items
+            .iter()
+            .any(|component| component.path == "legacy"));
+        assert!(response.ownership.changes.items.iter().any(|change| {
+            change.path == "legacy/old.py"
+                && change.base_owners == ["@legacy"]
+                && change.head_owners.is_empty()
+        }));
+        assert!(response.ownership.changes.items.iter().any(|change| {
+            change.path == "payment/new.py"
+                && change.base_owners.is_empty()
+                && change.head_owners == ["@payments"]
+        }));
+        assert!(
+            response
+                .history_review_candidates
+                .items
+                .iter()
+                .any(|candidate| {
+                    candidate.referenced_path == "legacy/old.py"
+                        && candidate.trigger == "path_deleted"
+                }),
+            "history candidates: {:?}",
+            response.history_review_candidates.items
+        );
+        assert!(response.summary.architecture_changed);
+
+        let deleted_scope = analyze(
+            &store,
+            root.path(),
+            &TemporalOptions {
+                since: "HEAD".to_string(),
+                path: "legacy".to_string(),
+                depth: 1,
+                top: 20,
+                production_only: false,
+                codeowners: None,
+            },
+        )
+        .expect("a fully deleted scope must still be reconstructed from the baseline");
+        assert_eq!(deleted_scope.components.removed.total, 1);
+        assert_eq!(deleted_scope.components.removed.items[0].path, ".");
+
+        let error = analyze(
+            &store,
+            root.path(),
+            &TemporalOptions {
+                since: "HEAD".to_string(),
+                path: "typo/never/existed".to_string(),
+                depth: 1,
+                top: 20,
+                production_only: false,
+                codeowners: None,
+            },
+        )
+        .expect_err("a scope absent from both snapshots must not look clean");
+        assert!(matches!(error, TemporalError::MapUnavailable(_)));
+    }
+
+    #[test]
+    fn temporal_analysis_detects_codeowners_only_drift_for_stable_sources() {
+        let root = tempfile::tempdir().unwrap();
+        git(root.path(), &["init", "-q"]);
+        git(
+            root.path(),
+            &["config", "user.email", "temporal@example.com"],
+        );
+        git(root.path(), &["config", "user.name", "Temporal Test"]);
+        write(root.path(), "CODEOWNERS", "* @platform\n");
+        write(root.path(), "src/a.py", "def a():\n    return 1\n");
+        write(root.path(), "src/b.py", "def b():\n    return 2\n");
+        git(root.path(), &["add", "."]);
+        git(root.path(), &["commit", "-qm", "baseline"]);
+        write(root.path(), "CODEOWNERS", "* @architecture\n");
+
+        let db = root.path().join(".mastermind/mmcg.db");
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(root.path())
+            .index_all(&mut store, true)
+            .unwrap();
+        let response = analyze(
+            &store,
+            root.path(),
+            &TemporalOptions {
+                since: "HEAD".to_string(),
+                path: ".".to_string(),
+                depth: 1,
+                top: 20,
+                production_only: false,
+                codeowners: None,
+            },
+        )
+        .unwrap();
+
+        assert!(response.ownership.changes.items.iter().any(|change| {
+            change.path == "src/a.py"
+                && change.base_owners == ["@platform"]
+                && change.head_owners == ["@architecture"]
+        }));
+        assert!(response.ownership.changes.items.iter().any(|change| {
+            change.path == "src/b.py"
+                && change.base_owners == ["@platform"]
+                && change.head_owners == ["@architecture"]
+        }));
+    }
+
+    #[test]
+    fn temporal_analysis_reports_truncated_codeowners_diagnostics() {
+        let root = tempfile::tempdir().unwrap();
+        git(root.path(), &["init", "-q"]);
+        git(
+            root.path(),
+            &["config", "user.email", "temporal@example.com"],
+        );
+        git(root.path(), &["config", "user.name", "Temporal Test"]);
+        write(root.path(), "CODEOWNERS", "* @platform\n");
+        write(root.path(), "src/a.py", "def a():\n    return 1\n");
+        git(root.path(), &["add", "."]);
+        git(root.path(), &["commit", "-qm", "baseline"]);
+        write(root.path(), "CODEOWNERS", &"!\n".repeat(60_000));
+
+        let db = root.path().join(".mastermind/mmcg.db");
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(root.path())
+            .index_all(&mut store, true)
+            .unwrap();
+        let response = analyze(
+            &store,
+            root.path(),
+            &TemporalOptions {
+                since: "HEAD".to_string(),
+                path: ".".to_string(),
+                depth: 1,
+                top: 20,
+                production_only: false,
+                codeowners: None,
+            },
+        )
+        .unwrap();
+
+        assert!(response.partial);
+        assert!(response.diagnostics_truncated);
+        assert!(response
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "codeowner_diagnostic_limit"));
+        assert!(response.diagnostics.len() <= DIAGNOSTIC_LIMIT);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temporal_analysis_rewinds_a_git_path_with_a_newline() {
+        let root = tempfile::tempdir().unwrap();
+        git(root.path(), &["init", "-q"]);
+        git(
+            root.path(),
+            &["config", "user.email", "temporal@example.com"],
+        );
+        git(root.path(), &["config", "user.name", "Temporal Test"]);
+        let path = "src/evil\nname.py";
+        write(root.path(), path, "def value():\n    return 1\n");
+        git(root.path(), &["add", "."]);
+        git(root.path(), &["commit", "-qm", "baseline"]);
+        write(root.path(), path, "def value():\n    return 2\n");
+
+        let db = root.path().join(".mastermind/mmcg.db");
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(root.path())
+            .index_all(&mut store, true)
+            .unwrap();
+        let response = analyze(
+            &store,
+            root.path(),
+            &TemporalOptions {
+                since: "HEAD".to_string(),
+                path: "src".to_string(),
+                depth: 1,
+                top: 20,
+                production_only: false,
+                codeowners: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(response.components.added.total, 0);
+        assert_eq!(response.components.removed.total, 0);
+        assert!(!response
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "baseline_scope_empty"));
+    }
+
+    #[test]
+    fn temporal_analysis_rejects_an_index_revision_race_after_impact() {
+        let root = tempfile::tempdir().unwrap();
+        git(root.path(), &["init", "-q"]);
+        git(
+            root.path(),
+            &["config", "user.email", "temporal@example.com"],
+        );
+        git(root.path(), &["config", "user.name", "Temporal Test"]);
+        write(root.path(), "src/a.py", "def a():\n    return 1\n");
+        git(root.path(), &["add", "."]);
+        git(root.path(), &["commit", "-qm", "baseline"]);
+        write(root.path(), "src/a.py", "def a():\n    return 2\n");
+
+        let db = root.path().join(".mastermind/mmcg.db");
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(root.path())
+            .index_all(&mut store, true)
+            .unwrap();
+        let race_db = db.clone();
+        let _hook = install_temporal_test_hook(TemporalTestStage::AfterImpact, move || {
+            let connection = rusqlite::Connection::open(race_db).unwrap();
+            connection
+                .execute(
+                    "INSERT INTO meta(key, value) VALUES ('temporal_race', '1')",
+                    [],
+                )
+                .unwrap();
+        });
+
+        let error = analyze(
+            &store,
+            root.path(),
+            &TemporalOptions {
+                since: "HEAD".to_string(),
+                path: ".".to_string(),
+                depth: 1,
+                top: 20,
+                production_only: false,
+                codeowners: None,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, TemporalError::SnapshotChanged));
+    }
+
+    #[test]
+    fn signature_drift_marks_exact_history_mentions_for_review() {
+        let path = tempfile::tempdir().unwrap().path().join("history.db");
+        let mut store = Store::open(path).unwrap();
+        store
+            .replace_project_history(&[crate::store::ProjectHistoryEntry {
+                path: ".mastermind/architecture/adr.md".to_string(),
+                kind: "architecture_decision".to_string(),
+                title: "Public payment API".to_string(),
+                body: "The stable boundary is services/payment/api.py.".to_string(),
+            }])
+            .unwrap();
+        let empty = ArchitectureProjection::default();
+        let boundary = TemporalBoundaryDrift {
+            component: "services/payment".to_string(),
+            file: "services/payment/api.py".to_string(),
+            name: "charge".to_string(),
+            kind: "function".to_string(),
+            base_line: 1,
+            head_line: 1,
+            base_signature: Some("charge(total)".to_string()),
+            head_signature: Some("charge(total, currency)".to_string()),
+        };
+        let boundaries = TemporalBoundaryDelta {
+            added: bounded(Vec::new(), BOUNDARY_DELTA_LIMIT),
+            removed: bounded(Vec::new(), BOUNDARY_DELTA_LIMIT),
+            changed: bounded(vec![boundary], BOUNDARY_DELTA_LIMIT),
+        };
+        let mut diagnostics = Vec::new();
+
+        let candidates = history_review_candidates(
+            &store,
+            &[],
+            &component_delta(&empty, &empty),
+            &boundaries,
+            &mut diagnostics,
+        )
+        .unwrap();
+
+        assert_eq!(candidates.total, 1);
+        assert_eq!(candidates.items[0].trigger, "public_api_changed");
+    }
+}

--- a/npm/mastermind/README.md
+++ b/npm/mastermind/README.md
@@ -39,6 +39,7 @@ cd your-project
 mastermind index .
 mastermind map .
 mastermind impact --since main
+mastermind temporal --since main
 mastermind ui --since main
 mastermind miner profile .  # optional personal profile; no init required
 ```
@@ -51,6 +52,7 @@ Small changes can use the codegraph directly without creating a task spec.
 - Architecture maps plus runtime, state, retry, and compatibility reviews
 - Symbol search, callers, imports, cycles, and API surface
 - Changed symbols, affected callers, component crossings, and candidate tests
+- Base-vs-head component, boundary, cycle, centrality, ownership, and API drift
 - A local, read-only diff-first Lens UI backed by the same map and impact engine
 - Direct, verified, and strict task workflows based on change risk
 - Executor reports checked against the real Git diff and codegraph


### PR DESCRIPTION
## What this PR does

Adds a bounded Temporal Graph across the CLI, MCP, and Mastermind Lens. It compares a resolved Git baseline with the indexed worktree and reports component, boundary, public API, cycle, centrality, hotspot, ownership, and history drift without checking out the baseline.

## Type of change

- [x] mmcg (Rust) — indexer / MCP / CLI / miner
- [ ] Workflow artifact — skill / subagent / CLAUDE.md template
- [x] Docs
- [x] Bug fix

## Architecture

```mermaid
flowchart LR
  Base["Git baseline"] --> Rewind["Private SQLite snapshot + blob rewind"]
  Head["Indexed worktree"] --> HeadMap["Shared project map"]
  Rewind --> BaseMap["Shared project map"]
  BaseMap --> Delta["Temporal schema v1"]
  HeadMap --> Delta
  Delta --> CLI["mastermind temporal"]
  Delta --> MCP["mmcg_temporal"]
  Delta --> Lens["Lens: Architecture over time"]
```

The Tree-sitter graph remains the default. Baseline reconstruction uses a private database snapshot, bounded Git blob reads, and the same map engine on both sides.

## Checklist

- [x] `cargo test` + `cargo clippy -- -D warnings` + `cargo fmt --check` pass
- [x] `python3 scripts/validate.py` passes
- [x] Prompt evals are not applicable because no subagent or skill prompt changed
- [x] Change is focused and the commit uses a conventional prefix

## How I tested it

- `just check` — exit 0
  - 498 Rust library tests
  - 51 CLI tests
  - 20 golden tests
  - policy CLI, npm, security, eval, validator, formatting, Clippy, and `cargo-deny` gates passed
- `cargo package --manifest-path mcp/servers/mmcg/Cargo.toml --locked --allow-dirty` — exit 0
  - 75 files packaged
  - 2.3 MiB unpacked, 495.3 KiB compressed
  - package verification build passed
- Clean temporary build with Git 2.33 — exit 0
  - `impact` returned schema v1
  - `temporal` returned schema v1
  - ordinary paths and a tracked source filename containing a newline both worked
  - trace used bounded `ls-tree -z` plus plain path-free `cat-file --batch`, with no Git 2.42-only `-Z`
- Lens DOM/static harness passed, including available, partial, unavailable, hostile-string, and bounded event states
- Independent read-only review passed with no confirmed P0–P3 findings

<details>
<summary>Observed live Temporal smoke</summary>

Command:

```bash
mastermind index --force .
mastermind temporal --since main --format json
```

Relevant observed output:

```json
{
  "schema_version": 1,
  "summary": {
    "architecture_changed": true,
    "cycles_introduced": 0,
    "cycles_changed": 1,
    "ownership_changes": 1
  },
  "partial": true,
  "diagnostics_truncated": false,
  "diagnostics": [
    {"code": "bounded_map_projection"}
  ]
}
```

The new module joined an existing SCC and was reported as cycle membership drift rather than a fake new cycle.

</details>

## Fail-closed regression proof

- A typo or never-existing `--path` exits with `map_unavailable` instead of a false-clean result.
- A fully deleted source scope is reconstructed from the baseline.
- A deleted non-source-only scope is rejected.
- SQLite revision changes and Git snapshot races are rejected.
- Hostile CODEOWNERS diagnostics remain capped and set `diagnostics_truncated` truthfully.
- MCP cancellation reaches non-SQL Temporal phases.

## Rollout and rollback

This is additive and introduces Temporal response schema v1. No database migration, deployment, publish, or release is included.

Rollback is a normal revert of this PR. Existing map, impact, policy, SCIP, and Lens fallback behavior remains available.

## Known validation limits

Windows runtime and large external monorepo workloads were not rerun for this PR. Portable behavior is covered by deterministic tests and the Git 2.33 clean-build smoke.

## Breaking change?

No.
