### PR TITLE
feat(mmcg): export PR evidence packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,27 @@ Lens also renders the same Temporal Graph response below the blast trace. A
 temporal failure is isolated and labelled instead of turning missing evidence
 into a clean architecture verdict; snapshot races still fail the whole refresh.
 
+### Export a PR evidence package
+
+```bash
+mastermind review export --since main --out mastermind-review
+```
+
+The command writes one autonomous `index.html`, a combined
+`mastermind.sarif`, a bounded `summary.md`, a strict `manifest.json`, and a
+ready-to-copy `mastermind-review.yml` GitHub Actions workflow. The HTML embeds
+the same Lens snapshot and runs offline under a hash-only CSP. The manifest
+records baseline/head OIDs, working-tree state, exact SHA-256 digests for every
+payload and external evidence input, plus every returned partial, truncated,
+or unavailable analysis state. Existing output paths are never overwritten.
+
+Use the same repeatable `--sarif`, `--coverage`, `--junit`, and `--otel`
+options as Lens. Exact artifact bytes are always bound to the exported head.
+For producer-to-revision binding, pass a strict v1 attestation with
+`--evidence-attestation`; digest and head mismatches fail the export. See the
+[review-package contract](docs/reference/mmcg.md#pr-evidence-package-mmcg-review-export)
+and [GitHub Actions example](docs/examples/mastermind-review-pr.yml).
+
 ### Understand change and test impact
 
 ```bash

--- a/docs/examples/mastermind-review-pr.yml
+++ b/docs/examples/mastermind-review-pr.yml
@@ -1,0 +1,98 @@
+name: Mastermind review evidence
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out exact pull-request head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Set up Rust for a Mastermind source checkout
+        if: github.repository == 'xcrft/mastermind'
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - name: Resolve pinned Mastermind
+        env:
+          BUILD_MASTERMIND_SOURCE: ${{ github.repository == 'xcrft/mastermind' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$BUILD_MASTERMIND_SOURCE" == "true" ]]; then
+            cargo build --release --locked --manifest-path mcp/servers/mmcg/Cargo.toml
+            mkdir -p "$RUNNER_TEMP/mastermind-bin"
+            install -m 0755 mcp/servers/mmcg/target/release/mmcg "$RUNNER_TEMP/mastermind-bin/mastermind"
+            echo "MASTERMIND_BIN=$RUNNER_TEMP/mastermind-bin/mastermind" >> "$GITHUB_ENV"
+          else
+            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@1.2.1
+            echo "MASTERMIND_BIN=mastermind" >> "$GITHUB_ENV"
+          fi
+
+      - name: Verify review-export capability
+        shell: bash
+        run: '"$MASTERMIND_BIN" review export --help >/dev/null'
+
+      - name: Build read-only review package
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          INDEX_PATH="$RUNNER_TEMP/mastermind-review.db"
+          "$MASTERMIND_BIN" --index "$INDEX_PATH" index .
+          "$MASTERMIND_BIN" --index "$INDEX_PATH" review export --since "$BASE_SHA" --out mastermind-review
+
+      - name: Upload autonomous review package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mastermind-review-${{ github.event.pull_request.head.sha }}
+          path: mastermind-review
+          if-no-files-found: error
+          include-hidden-files: false
+          compression-level: 6
+          retention-days: 14
+
+  sarif:
+    needs: review
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out the exact analyzed source without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Download the exact review artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mastermind-review-${{ github.event.pull_request.head.sha }}
+          path: mastermind-review
+
+      - name: Upload architecture risks to GitHub code scanning
+        uses: github/codeql-action/upload-sarif@c54b30b7df092240050e69945842bc67aee0f0f4 # v4.37.3
+        with:
+          sarif_file: mastermind-review/mastermind.sarif
+          category: mastermind-review
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          sha: ${{ github.event.pull_request.head.sha }}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,7 +103,12 @@ Analyze the current worktree against a baseline:
 ```bash
 mastermind impact --since main
 mastermind temporal --since main
+mastermind review export --since main --out mastermind-review
 ```
+
+The review export is a portable PR artifact: open `mastermind-review/index.html`
+without a server, upload `mastermind-review/mastermind.sarif` to code scanning,
+or copy its pinned `mastermind-review.yml` into `.github/workflows/`.
 
 ## Build a personal style profile without project initialization
 

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -423,8 +423,11 @@ Repository-relative artifact paths match exactly. Reports produced under a
 different absolute build root may use a unique repository-path suffix match;
 this relocation and the maximum-hit merge used for duplicate coverage lines
 are reported as precision notes. Artifact labels preserve provenance, but Lens
-cannot prove that a SARIF, coverage, JUnit, or OTLP report was produced from the current Git
-revision. CODEOWNERS matching uses the working-tree file,
+alone cannot prove that a SARIF, coverage, JUnit, or OTLP report was produced
+from the current Git revision. A PR evidence package binds the exact report
+bytes a reviewer saw to its resolved HEAD, while an optional producer
+attestation records the stronger revision claim described below. CODEOWNERS
+matching uses the working-tree file,
 including last-match-wins and explicit no-owner rules; it does not verify GitHub
 account/team existence or write permission, and GitHub review assignment still
 uses the base-branch file. Git history is pinned to the impact snapshot's HEAD
@@ -441,6 +444,72 @@ artifacts and Git history are parsed in memory. Project knowledge is read from
 the derived SQLite history corpus; Markdown remains authoritative and must be
 re-indexed after changes. Lens writes none of this evidence to source files or
 SQLite.
+
+### PR evidence package (`mmcg review export`)
+
+`mmcg review export --since REF --out DIR` captures the same fail-closed Lens
+snapshot without starting an HTTP server. `DIR` must not already exist. The
+export is assembled in a private sibling temporary directory and renamed only
+after every payload is synced, so a failed run does not publish a half-package.
+
+The package contains:
+
+- `index.html`: one autonomous Lens document with the snapshot, CSS, and JS
+  embedded under a hash-only CSP. It has no fetch, CDN, telemetry, or write
+  path;
+- `mastermind.sarif`: the project-map and change-impact SARIF projections as
+  two independently identified runs;
+- `summary.md`: a short, bounded reviewer summary with links to the HTML and
+  SARIF payloads;
+- `manifest.json`: strict schema-v1 repository, scope, evidence, payload digest,
+  and partial/truncation state bindings;
+- `mastermind-review.yml`: the pinned
+  [GitHub Actions example](../examples/mastermind-review-pr.yml) for artifact
+  and SARIF upload.
+
+The workflow builds the checked-out binary when it runs in the Mastermind
+source repository, so a command introduced by the pull request is exercised
+before release. In consuming repositories it installs the exact npm version
+recorded in the template and verifies `review export` before indexing.
+Compilation and analysis run with a read-only token; a separate action-only job
+receives `security-events: write` and uploads the already-produced SARIF
+artifact.
+
+The export accepts the same `--path`, `--depth`, `--top`,
+`--production-only`, `--sarif`, `--coverage`, `--junit`, `--otel`,
+`--codeowners`, `--git-commits`, and `--no-project-knowledge` inputs as Lens.
+It rechecks external files after analysis and fails if their exact bytes change.
+The manifest records their SHA-256 digests next to the resolved head OID. This
+is a **digest binding at export time**: it proves exactly which report bytes a
+reviewer saw at that revision, not that Semgrep, CodeQL, a test runner, or an
+OTel collector produced those bytes from that revision.
+
+For the stronger producer claim, create a strict JSON attestation and pass
+`--evidence-attestation PATH`:
+
+```json
+{
+  "schema_version": 1,
+  "head_oid": "0123456789abcdef0123456789abcdef01234567",
+  "artifacts": [
+    {
+      "kind": "sarif",
+      "path": "reports/semgrep.sarif",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}
+```
+
+Every path must be canonical and repository-relative; every listed digest must
+match a requested evidence input and `head_oid` must match the Lens snapshot.
+Unknown or duplicate JSON fields, digest drift, and revision drift fail closed.
+This v1 attestation is explicitly recorded as unsigned CI evidence. A signed
+workflow, artifact attestation, or other trust anchor may authenticate its
+producer separately. The formal contracts are
+[`mastermind-review-manifest-v1.schema.json`](../../schemas/mastermind-review-manifest-v1.schema.json)
+and
+[`mastermind-evidence-attestation-v1.schema.json`](../../schemas/mastermind-evidence-attestation-v1.schema.json).
 
 ### SARIF export
 

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -97,7 +97,7 @@ See the [client integration guides](https://github.com/xcrft/mastermind/tree/mai
 | Semantic overlay | Optional SCIP definitions, references, implementations, and provenance |
 | Architecture | Project map, temporal drift, centrality, dependency cycles, unreferenced candidates |
 | Change analysis | Git-aware symbol changes, blast radius, component crossings |
-| Local review UI | Read-only diff-first Lens with bounded SARIF, coverage, JUnit, OTLP, project-knowledge, ownership, and churn overlays |
+| Review evidence | Read-only diff-first Lens plus autonomous HTML/SARIF/summary packages with revision and evidence digests |
 | Test selection | Direct, transitive, and heuristic candidates with evidence |
 | Workflow gates | `verify-spec`, `audit-spec`, and `run-task` |
 | Local coordination | Bounded additive scratchpad and indexed project history |

--- a/mcp/servers/mmcg/assets/lens/app.js
+++ b/mcp/servers/mmcg/assets/lens/app.js
@@ -993,23 +993,32 @@
     }
 
     try {
-      const response = await fetch("/api/lens", {
-        method: "GET",
-        headers: { Accept: "application/json" },
-        cache: "no-store",
-      });
+      const embedded = document.getElementById("lens-snapshot");
       let payload;
-      try {
-        payload = await response.json();
-      } catch (error) {
-        throw new LensRequestError("invalid_json", "The local server returned an unreadable snapshot.");
-      }
-      const apiError = record(record(payload).error);
-      if (!response.ok || Object.keys(apiError).length > 0) {
-        throw new LensRequestError(
-          text(apiError.code, "http_" + response.status),
-          text(apiError.message, "The local Lens endpoint could not produce a snapshot.")
-        );
+      if (embedded) {
+        try {
+          payload = JSON.parse(embedded.textContent);
+        } catch (error) {
+          throw new LensRequestError("invalid_json", "The review package contains an unreadable snapshot.");
+        }
+      } else {
+        const response = await fetch("/api/lens", {
+          method: "GET",
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        });
+        try {
+          payload = await response.json();
+        } catch (error) {
+          throw new LensRequestError("invalid_json", "The local server returned an unreadable snapshot.");
+        }
+        const apiError = record(record(payload).error);
+        if (!response.ok || Object.keys(apiError).length > 0) {
+          throw new LensRequestError(
+            text(apiError.code, "http_" + response.status),
+            text(apiError.message, "The local Lens endpoint could not produce a snapshot.")
+          );
+        }
       }
 
       state.raw = payload;
@@ -1045,7 +1054,7 @@
     } finally {
       state.refreshing = false;
       document.body.classList.remove("is-refreshing");
-      elements.refresh.disabled = false;
+      elements.refresh.disabled = Boolean(document.getElementById("lens-snapshot"));
       elements.graphFrame.setAttribute("aria-busy", "false");
       updateSnapshotAge();
     }

--- a/mcp/servers/mmcg/assets/lens/app.test.cjs
+++ b/mcp/servers/mmcg/assets/lens/app.test.cjs
@@ -473,8 +473,15 @@ function fixture() {
   };
 }
 
-async function renderFixture(payload) {
+async function renderFixture(payload, options) {
   const harness = createDocument();
+  const settings = options || {};
+  if (settings.embedded) {
+    const embedded = new MockElement("script");
+    embedded.textContent = JSON.stringify(payload || fixture());
+    harness.nodes.set("lens-snapshot", embedded);
+  }
+  let fetchCalls = 0;
   const window = {
     setTimeout(handler) {
       handler();
@@ -492,7 +499,13 @@ async function renderFixture(payload) {
     document: harness.document,
     window: window,
     ResizeObserver: window.ResizeObserver,
-    fetch: async () => ({ ok: true, status: 200, json: async () => payload || fixture() }),
+    fetch: async () => {
+      fetchCalls += 1;
+      if (settings.rejectFetch) {
+        throw new Error("standalone package attempted a network request");
+      }
+      return { ok: true, status: 200, json: async () => payload || fixture() };
+    },
     Intl: Intl,
     Date: Date,
     Map: Map,
@@ -507,6 +520,7 @@ async function renderFixture(payload) {
   }, { filename: "app.js" });
   await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setImmediate(resolve));
+  harness.fetchCalls = fetchCalls;
   return harness;
 }
 
@@ -540,6 +554,10 @@ async function main() {
   assert.match(harness.nodes.get("temporal-events").textContent, /Hotspot exited/i);
   assert.match(harness.nodes.get("temporal-events").textContent, /charge<\/span>/i);
   assert.match(harness.nodes.get("temporal-events").textContent, /History needs review/i);
+
+  const standaloneHarness = await renderFixture(fixture(), { embedded: true, rejectFetch: true });
+  assert.equal(standaloneHarness.fetchCalls, 0, "Standalone Lens must render embedded JSON without fetching");
+  assert.match(standaloneHarness.nodes.get("repository-name").textContent, /example/i);
 
   const unavailable = fixture();
   unavailable.temporal = {

--- a/mcp/servers/mmcg/assets/mastermind-review-pr.yml
+++ b/mcp/servers/mmcg/assets/mastermind-review-pr.yml
@@ -1,0 +1,98 @@
+name: Mastermind review evidence
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out exact pull-request head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Set up Rust for a Mastermind source checkout
+        if: github.repository == 'xcrft/mastermind'
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - name: Resolve pinned Mastermind
+        env:
+          BUILD_MASTERMIND_SOURCE: ${{ github.repository == 'xcrft/mastermind' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$BUILD_MASTERMIND_SOURCE" == "true" ]]; then
+            cargo build --release --locked --manifest-path mcp/servers/mmcg/Cargo.toml
+            mkdir -p "$RUNNER_TEMP/mastermind-bin"
+            install -m 0755 mcp/servers/mmcg/target/release/mmcg "$RUNNER_TEMP/mastermind-bin/mastermind"
+            echo "MASTERMIND_BIN=$RUNNER_TEMP/mastermind-bin/mastermind" >> "$GITHUB_ENV"
+          else
+            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@1.2.1
+            echo "MASTERMIND_BIN=mastermind" >> "$GITHUB_ENV"
+          fi
+
+      - name: Verify review-export capability
+        shell: bash
+        run: '"$MASTERMIND_BIN" review export --help >/dev/null'
+
+      - name: Build read-only review package
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          INDEX_PATH="$RUNNER_TEMP/mastermind-review.db"
+          "$MASTERMIND_BIN" --index "$INDEX_PATH" index .
+          "$MASTERMIND_BIN" --index "$INDEX_PATH" review export --since "$BASE_SHA" --out mastermind-review
+
+      - name: Upload autonomous review package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mastermind-review-${{ github.event.pull_request.head.sha }}
+          path: mastermind-review
+          if-no-files-found: error
+          include-hidden-files: false
+          compression-level: 6
+          retention-days: 14
+
+  sarif:
+    needs: review
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out the exact analyzed source without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Download the exact review artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mastermind-review-${{ github.event.pull_request.head.sha }}
+          path: mastermind-review
+
+      - name: Upload architecture risks to GitHub code scanning
+        uses: github/codeql-action/upload-sarif@c54b30b7df092240050e69945842bc67aee0f0f4 # v4.37.3
+        with:
+          sarif_file: mastermind-review/mastermind.sarif
+          category: mastermind-review
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          sha: ${{ github.event.pull_request.head.sha }}

--- a/mcp/servers/mmcg/src/audit_bundle.rs
+++ b/mcp/servers/mmcg/src/audit_bundle.rs
@@ -1236,7 +1236,9 @@ fn read_key(path: &Path, private: bool) -> Result<[u8; 32], BundleError> {
         .map_err(|_| BundleError::Crypto("Ed25519 key must be 32 bytes".into()))
 }
 
-fn from_json_strict<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, BundleError> {
+pub(crate) fn from_json_strict<T: for<'de> Deserialize<'de>>(
+    bytes: &[u8],
+) -> Result<T, BundleError> {
     let mut deserializer = serde_json::Deserializer::from_slice(bytes);
     let value = NoDuplicates
         .deserialize(&mut deserializer)

--- a/mcp/servers/mmcg/src/evidence.rs
+++ b/mcp/servers/mmcg/src/evidence.rs
@@ -16,6 +16,7 @@ use quick_xml::events::Event;
 use quick_xml::Reader;
 use serde::Serialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fs::File;
@@ -23,9 +24,9 @@ use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::time::{Instant, SystemTime};
 
-const MAX_ARTIFACT_BYTES: u64 = 32 * 1024 * 1024;
-const MAX_CODEOWNERS_BYTES: u64 = 3 * 1024 * 1024;
-const MAX_ARTIFACT_SOURCES: usize = 64;
+pub(crate) const MAX_ARTIFACT_BYTES: u64 = 32 * 1024 * 1024;
+pub(crate) const MAX_CODEOWNERS_BYTES: u64 = 3 * 1024 * 1024;
+pub(crate) const MAX_ARTIFACT_SOURCES: usize = 64;
 const MAX_RELEVANT_FILES: usize = 1_000;
 const MAX_FINDINGS: usize = 5_000;
 const MAX_FINDINGS_PER_FILE: usize = 100;
@@ -94,6 +95,10 @@ pub struct EvidenceSource {
     pub facts_total: Option<u32>,
     pub facts_returned: u32,
     pub files_matched: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_bytes: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -320,6 +325,7 @@ struct Collector<'a> {
     runtime_edges_truncated: bool,
     knowledge_match_count: usize,
     deadline: Option<Instant>,
+    artifact_identities: HashMap<String, (String, u64)>,
 }
 
 #[derive(Default)]
@@ -459,6 +465,7 @@ fn collect_internal(
         runtime_edges_truncated: false,
         knowledge_match_count: 0,
         deadline,
+        artifact_identities: HashMap::new(),
     };
 
     if !options.sarif.is_empty()
@@ -675,6 +682,7 @@ impl Collector<'_> {
         failure: SourceFailure,
     ) {
         self.diagnostic(id.clone(), failure.code(), failure.message());
+        let artifact = self.artifact_identities.remove(&id);
         self.sources.push(EvidenceSource {
             id,
             kind,
@@ -683,11 +691,14 @@ impl Collector<'_> {
             facts_total: None,
             facts_returned: 0,
             files_matched: 0,
+            artifact_sha256: artifact.as_ref().map(|value| value.0.clone()),
+            artifact_bytes: artifact.map(|value| value.1),
         });
     }
 
     fn source_done(&mut self, id: String, kind: &'static str, label: String, stats: SourceStats) {
         self.partial |= stats.partial;
+        let artifact = self.artifact_identities.remove(&id);
         self.sources.push(EvidenceSource {
             id,
             kind,
@@ -696,7 +707,19 @@ impl Collector<'_> {
             facts_total: (!stats.partial).then(|| saturating_u32(stats.facts_total)),
             facts_returned: saturating_u32(stats.facts_returned),
             files_matched: saturating_u32(stats.files.len()),
+            artifact_sha256: artifact.as_ref().map(|value| value.0.clone()),
+            artifact_bytes: artifact.map(|value| value.1),
         });
+    }
+
+    fn register_artifact(&mut self, id: &str, input: &SourceInput) {
+        self.artifact_identities.insert(
+            id.to_string(),
+            (
+                crate::hex::encode(&Sha256::digest(&input.bytes)),
+                input.bytes.len() as u64,
+            ),
+        );
     }
 
     fn read_source(&self, path: &Path) -> Result<SourceInput, SourceFailure> {
@@ -897,6 +920,7 @@ impl Collector<'_> {
             Ok(input) => input,
             Err(error) => return self.source_error(id, "sarif", fallback, error),
         };
+        self.register_artifact(&id, &input);
         let label = input.label;
         let value: Value = match serde_json::from_slice(strip_utf8_bom(&input.bytes)) {
             Ok(value) => value,
@@ -1059,6 +1083,7 @@ impl Collector<'_> {
             Ok(input) => input,
             Err(error) => return self.source_error(id, "coverage", fallback, error),
         };
+        self.register_artifact(&id, &input);
         let label = input.label;
         let coverage_bytes = strip_utf8_bom(&input.bytes);
         let first = coverage_bytes
@@ -1120,6 +1145,7 @@ impl Collector<'_> {
             Ok(input) => input,
             Err(error) => return self.source_error(id, "junit", fallback, error),
         };
+        self.register_artifact(&id, &input);
         let label = input.label;
         let parsed = match junit::parse(strip_utf8_bom(&input.bytes), self.deadline) {
             Ok(parsed) => parsed,
@@ -1195,6 +1221,7 @@ impl Collector<'_> {
             Ok(input) => input,
             Err(error) => return self.source_error(id, "otel", fallback, error),
         };
+        self.register_artifact(&id, &input);
         let label = input.label;
         let parsed = match otel::parse(strip_utf8_bom(&input.bytes), self.deadline) {
             Ok(parsed) => parsed,
@@ -1424,6 +1451,7 @@ impl Collector<'_> {
             Ok(input) => input,
             Err(error) => return self.source_error(id, "codeowners", fallback, error),
         };
+        self.register_artifact(&id, &input);
         let label = input.label;
         if input.bytes.len() as u64 >= MAX_CODEOWNERS_BYTES {
             return self.source_error(id, "codeowners", label, SourceFailure::CodeownersTooLarge);
@@ -2525,6 +2553,7 @@ mod tests {
             root,
             relevant: paths.iter().map(|path| (*path).to_string()).collect(),
             sources: Vec::new(),
+            artifact_identities: HashMap::new(),
             files: BTreeMap::new(),
             diagnostics: Vec::new(),
             notes: Vec::new(),
@@ -2601,6 +2630,16 @@ mod tests {
         let snapshot = collector.finish(0);
 
         assert!(!snapshot.partial);
+        let artifact = fs::read(root.path().join("findings.sarif")).unwrap();
+        let artifact_digest = crate::hex::encode(&Sha256::digest(&artifact));
+        assert_eq!(
+            snapshot.sources.items[0].artifact_sha256.as_deref(),
+            Some(artifact_digest.as_str())
+        );
+        assert_eq!(
+            snapshot.sources.items[0].artifact_bytes,
+            Some(artifact.len() as u64)
+        );
         assert_eq!(snapshot.sources.items[0].facts_total, Some(2));
         assert_eq!(snapshot.sources.items[0].facts_returned, 1);
         assert_eq!(snapshot.files.items.len(), 1);

--- a/mcp/servers/mmcg/src/lens.rs
+++ b/mcp/servers/mmcg/src/lens.rs
@@ -1163,7 +1163,7 @@ mod tests {
 
     #[test]
     fn standalone_html_accepts_crlf_checkout_assets() {
-        let crlf_template = INDEX_HTML.replace('\n', "\r\n");
+        let crlf_template = INDEX_HTML.replace("\r\n", "\n").replace('\n', "\r\n");
 
         let html = standalone_html_from_template("{}", &crlf_template).unwrap();
         let html = String::from_utf8(html).unwrap();

--- a/mcp/servers/mmcg/src/lens.rs
+++ b/mcp/servers/mmcg/src/lens.rs
@@ -280,6 +280,13 @@ pub(crate) fn standalone_html(snapshot: &LensSnapshot) -> Result<Vec<u8>, LensEr
 }
 
 fn standalone_html_from_json(snapshot_json: &str) -> Result<Vec<u8>, LensError> {
+    standalone_html_from_template(snapshot_json, INDEX_HTML)
+}
+
+fn standalone_html_from_template(
+    snapshot_json: &str,
+    template: &str,
+) -> Result<Vec<u8>, LensError> {
     let escaped_json = snapshot_json
         .replace('&', "\\u0026")
         .replace('<', "\\u003c")
@@ -291,11 +298,12 @@ fn standalone_html_from_json(snapshot_json: &str) -> Result<Vec<u8>, LensError> 
         "default-src 'none'; script-src '{script_hash}' '{snapshot_hash}'; style-src '{style_hash}'; img-src data:; connect-src 'none'; font-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
     );
     let served_csp = "    <meta\n      http-equiv=\"Content-Security-Policy\"\n      content=\"default-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'; img-src 'self'; object-src 'none'; base-uri 'none'; form-action 'none'\"\n    >\n";
-    let mut html = INDEX_HTML.replace(
+    let template = template.replace("\r\n", "\n");
+    let mut html = template.replace(
         served_csp,
         &format!("    <meta http-equiv=\"Content-Security-Policy\" content=\"{csp}\">\n"),
     );
-    if html == INDEX_HTML {
+    if html == template {
         return Err(LensError::Serialization);
     }
     html = html.replace(
@@ -1151,6 +1159,19 @@ mod tests {
         assert!(html.contains("connect-src 'none'"));
         assert!(html.contains("sha256-"));
         assert!(html.contains("Offline package"));
+    }
+
+    #[test]
+    fn standalone_html_accepts_crlf_checkout_assets() {
+        let crlf_template = INDEX_HTML.replace('\n', "\r\n");
+
+        let html = standalone_html_from_template("{}", &crlf_template).unwrap();
+        let html = String::from_utf8(html).unwrap();
+
+        assert!(html.contains("id=\"lens-snapshot\""));
+        assert!(html.contains("connect-src 'none'"));
+        assert!(!html.contains("href=\"styles.css\""));
+        assert!(!html.contains("src=\"app.js\""));
     }
 
     fn directory_snapshot(path: &Path) -> Vec<(String, Vec<u8>)> {

--- a/mcp/servers/mmcg/src/lens.rs
+++ b/mcp/servers/mmcg/src/lens.rs
@@ -7,6 +7,8 @@
 
 use crate::queries::{self, ChangeImpactError, ChangeImpactResponse, ProjectMapResponse};
 use crate::store::{query_budget_ms_from_env, Store, WorkBudget, DEFAULT_CLI_BUDGET_MS};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -218,6 +220,113 @@ pub fn build_snapshot_with_evidence_extensions(
         extensions,
         request_deadline(),
     )
+}
+
+/// Build one fail-closed Lens snapshot from an existing index without serving
+/// HTTP. Review-package export uses this entry point so CLI, MCP, and Lens keep
+/// the same freshness, WAL, and bounded-analysis semantics.
+pub(crate) fn snapshot_from_paths_with_evidence_extensions(
+    root: &Path,
+    index_path: &Path,
+    options: &LensOptions,
+    evidence: &crate::evidence::EvidenceOptions,
+    extensions: &crate::evidence::EvidenceExtensionOptions,
+) -> Result<LensSnapshot, LensError> {
+    snapshot_from_paths_until(
+        root,
+        index_path,
+        options,
+        evidence,
+        extensions,
+        request_deadline(),
+    )
+}
+
+fn snapshot_from_paths_until(
+    root: &Path,
+    index_path: &Path,
+    options: &LensOptions,
+    evidence: &crate::evidence::EvidenceOptions,
+    extensions: &crate::evidence::EvidenceExtensionOptions,
+    deadline: Option<Instant>,
+) -> Result<LensSnapshot, LensError> {
+    let root = root
+        .canonicalize()
+        .map_err(|_| LensError::RootUnavailable)?;
+    let index_path = index_path
+        .canonicalize()
+        .map_err(|_| LensError::IndexUnavailable)?;
+    if !index_path.is_file() {
+        return Err(LensError::IndexUnavailable);
+    }
+    let before = index_source_state(&index_path)?;
+    let store =
+        Store::open_read_only_with_deadline(&index_path, deadline).map_err(read_only_open_error)?;
+    let snapshot = build_snapshot_until(&store, &root, options, evidence, extensions, deadline)?;
+    if index_source_state(&index_path)? != before {
+        return Err(LensError::ImpactUnavailable(
+            ChangeImpactError::SnapshotChanged,
+        ));
+    }
+    Ok(snapshot)
+}
+
+/// Render a single-file, offline Lens application. The snapshot, stylesheet,
+/// and application code are embedded under content hashes; the resulting CSP
+/// disables all network connections and external resources.
+pub(crate) fn standalone_html(snapshot: &LensSnapshot) -> Result<Vec<u8>, LensError> {
+    let snapshot_json = serde_json::to_string(snapshot).map_err(|_| LensError::Serialization)?;
+    standalone_html_from_json(&snapshot_json)
+}
+
+fn standalone_html_from_json(snapshot_json: &str) -> Result<Vec<u8>, LensError> {
+    let escaped_json = snapshot_json
+        .replace('&', "\\u0026")
+        .replace('<', "\\u003c")
+        .replace('>', "\\u003e");
+    let script_hash = inline_hash(APP_JS.as_bytes());
+    let snapshot_hash = inline_hash(escaped_json.as_bytes());
+    let style_hash = inline_hash(STYLES_CSS.as_bytes());
+    let csp = format!(
+        "default-src 'none'; script-src '{script_hash}' '{snapshot_hash}'; style-src '{style_hash}'; img-src data:; connect-src 'none'; font-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+    );
+    let served_csp = "    <meta\n      http-equiv=\"Content-Security-Policy\"\n      content=\"default-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'; img-src 'self'; object-src 'none'; base-uri 'none'; form-action 'none'\"\n    >\n";
+    let mut html = INDEX_HTML.replace(
+        served_csp,
+        &format!("    <meta http-equiv=\"Content-Security-Policy\" content=\"{csp}\">\n"),
+    );
+    if html == INDEX_HTML {
+        return Err(LensError::Serialization);
+    }
+    html = html.replace(
+        "    <link rel=\"stylesheet\" href=\"styles.css\">",
+        &format!("    <style>{STYLES_CSS}</style>"),
+    );
+    html = html.replace("    <script src=\"app.js\" defer></script>\n", "");
+    html = html.replace("<span>Local</span>", "<span>Offline package</span>");
+    html = html.replace(
+        "aria-label=\"Refresh Lens snapshot\"",
+        "aria-label=\"Static Lens snapshot\"",
+    );
+    html = html.replace(
+        "<span>Refresh snapshot</span>",
+        "<span>Static snapshot</span>",
+    );
+    let scripts = format!(
+        "    <script type=\"application/json\" id=\"lens-snapshot\">{escaped_json}</script>\n    <script>{APP_JS}</script>\n  </body>"
+    );
+    html = html.replace("  </body>", &scripts);
+    if html.contains("href=\"styles.css\"")
+        || html.contains("src=\"app.js\"")
+        || !html.contains("id=\"lens-snapshot\"")
+    {
+        return Err(LensError::Serialization);
+    }
+    Ok(html.into_bytes())
+}
+
+fn inline_hash(bytes: &[u8]) -> String {
+    format!("sha256-{}", BASE64.encode(Sha256::digest(bytes)))
 }
 
 fn request_deadline() -> Option<Instant> {
@@ -885,26 +994,14 @@ fn route(path: &str, state: &ServerState) -> HttpResponse {
 
 fn api_response(state: &ServerState) -> HttpResponse {
     let deadline = request_deadline();
-    let result = index_source_state(&state.index_path).and_then(|before| {
-        let snapshot = Store::open_read_only_with_deadline(&state.index_path, deadline)
-            .map_err(read_only_open_error)
-            .and_then(|store| {
-                build_snapshot_until(
-                    &store,
-                    &state.root,
-                    &state.options,
-                    &state.evidence,
-                    &state.extensions,
-                    deadline,
-                )
-            })?;
-        if index_source_state(&state.index_path)? != before {
-            return Err(LensError::ImpactUnavailable(
-                ChangeImpactError::SnapshotChanged,
-            ));
-        }
-        Ok(snapshot)
-    });
+    let result = snapshot_from_paths_until(
+        &state.root,
+        &state.index_path,
+        &state.options,
+        &state.evidence,
+        &state.extensions,
+        deadline,
+    );
     match result {
         Ok(snapshot) => match serde_json::to_vec(&snapshot) {
             Ok(body) => HttpResponse::json(200, "OK", body),
@@ -1036,6 +1133,24 @@ mod tests {
             top: 100,
             production_only: false,
         }
+    }
+
+    #[test]
+    fn standalone_html_is_single_file_offline_and_script_safe() {
+        let html = standalone_html_from_json(
+            r#"{"repository":{"name":"</script><img src=x onerror=alert(1)>"}}"#,
+        )
+        .unwrap();
+        let html = String::from_utf8(html).unwrap();
+
+        assert!(html.contains("id=\"lens-snapshot\""));
+        assert!(html.contains("\\u003c/script\\u003e"));
+        assert!(!html.contains("</script><img"));
+        assert!(!html.contains("href=\"styles.css\""));
+        assert!(!html.contains("src=\"app.js\""));
+        assert!(html.contains("connect-src 'none'"));
+        assert!(html.contains("sha256-"));
+        assert!(html.contains("Offline package"));
     }
 
     fn directory_snapshot(path: &Path) -> Vec<(String, Vec<u8>)> {

--- a/mcp/servers/mmcg/src/lib.rs
+++ b/mcp/servers/mmcg/src/lib.rs
@@ -25,6 +25,7 @@ pub mod mcp;
 pub mod miner;
 pub mod policy;
 pub mod queries;
+pub mod review_package;
 pub mod run_task;
 pub mod sarif_export;
 pub mod scip_overlay;

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -7,6 +7,7 @@
 //!   mastermind enrich --scip  — add optional compiler-resolved evidence
 //!   mastermind temporal       — compare architecture at a Git baseline
 //!   mastermind ui --since REF — open the local diff-first Lens UI
+//!   mastermind review export  — write an autonomous PR evidence package
 //!   mastermind serve          — run as MCP stdio server
 //!   mastermind doctor         — health-check the setup
 //!   mastermind query <kind>   — one-shot query from the CLI (handy for debugging)
@@ -182,6 +183,9 @@ enum Cmd {
     /// Evaluate repository-owned architecture rules over bounded change evidence.
     #[command(subcommand)]
     Policy(PolicyCmd),
+    /// Build portable review evidence from the same bounded Lens snapshot.
+    #[command(subcommand)]
+    Review(ReviewCmd),
     /// Serve Mastermind Lens: a local, read-only, diff-first change review UI.
     Ui {
         /// Git ref used as the change-impact baseline.
@@ -547,6 +551,56 @@ enum PolicyCmd {
         /// Maximum returned impacted symbols. Incomplete evidence fails closed.
         #[arg(long, default_value_t = 500, value_parser = clap::value_parser!(u32).range(1..=500))]
         top: u32,
+    },
+}
+
+#[derive(Subcommand)]
+enum ReviewCmd {
+    /// Export one autonomous HTML/SARIF/Markdown package plus its revision manifest and CI workflow.
+    Export {
+        /// Git ref used as the change-impact baseline.
+        #[arg(long)]
+        since: String,
+        /// New output directory. Export refuses to overwrite an existing path.
+        #[arg(long, value_name = "DIR")]
+        out: PathBuf,
+        /// Project root. Defaults to cwd.
+        #[arg(long, default_value = ".")]
+        root: PathBuf,
+        /// Repository-relative map scope. Defaults to the repository root.
+        #[arg(long, default_value = ".")]
+        path: String,
+        #[arg(long, default_value_t = 3, value_parser = clap::value_parser!(u8).range(1..=5))]
+        depth: u8,
+        #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u32).range(1..=100))]
+        top: u32,
+        /// Exclude conventional tests, fixtures, examples, generated, and vendor paths from the architecture map.
+        #[arg(long)]
+        production_only: bool,
+        /// Import a SARIF 2.1 report as read-only evidence. Repeatable.
+        #[arg(long = "sarif", value_name = "PATH")]
+        sarif: Vec<PathBuf>,
+        /// Import an LCOV tracefile or Cobertura XML report. Repeatable.
+        #[arg(long = "coverage", value_name = "PATH")]
+        coverage: Vec<PathBuf>,
+        /// Import a JUnit XML test report. Repeatable.
+        #[arg(long = "junit", value_name = "PATH")]
+        junit: Vec<PathBuf>,
+        /// Import an OpenTelemetry OTLP JSON trace export. Repeatable.
+        #[arg(long = "otel", value_name = "PATH")]
+        otel: Vec<PathBuf>,
+        /// Override the repository CODEOWNERS file used by Lens.
+        #[arg(long, value_name = "PATH")]
+        codeowners: Option<PathBuf>,
+        /// Do not correlate exact changed-file mentions from indexed specs, ADRs, audits, and lessons.
+        #[arg(long)]
+        no_project_knowledge: bool,
+        /// Bound read-only Git churn and contributor evidence. Zero disables it.
+        #[arg(long, default_value_t = 200, value_parser = clap::value_parser!(u16).range(0..=1000))]
+        git_commits: u16,
+        /// Optional strict v1 producer manifest binding repository-relative evidence digests to the same head OID.
+        #[arg(long, value_name = "PATH")]
+        evidence_attestation: Option<PathBuf>,
     },
 }
 
@@ -1066,6 +1120,66 @@ fn run_cli_inner(
             if !report.passed {
                 std::process::exit(1);
             }
+        }
+        Cmd::Review(ReviewCmd::Export {
+            since,
+            out,
+            root,
+            path,
+            depth,
+            top,
+            production_only,
+            sarif,
+            coverage,
+            junit,
+            otel,
+            codeowners,
+            no_project_knowledge,
+            git_commits,
+            evidence_attestation,
+        }) => {
+            let root = root
+                .canonicalize()
+                .map_err(|_| mmcg::lens::LensError::RootUnavailable)?;
+            let index_path = index_path_for_root(index_override.as_deref(), &root);
+            let result =
+                mmcg::review_package::export(&mmcg::review_package::ReviewExportOptions {
+                    root,
+                    index_path,
+                    out,
+                    lens: mmcg::lens::LensOptions {
+                        since,
+                        path,
+                        depth,
+                        top,
+                        production_only,
+                    },
+                    evidence: mmcg::evidence::EvidenceOptions {
+                        sarif,
+                        coverage,
+                        discover_codeowners: codeowners.is_none(),
+                        codeowners,
+                        git_commits,
+                    },
+                    extensions: mmcg::evidence::EvidenceExtensionOptions {
+                        junit,
+                        otel,
+                        project_knowledge: !no_project_knowledge,
+                    },
+                    evidence_attestation,
+                })?;
+            println!(
+                "review package: {} | head {} | {} | {} files | evidence {}",
+                result.output_dir.display(),
+                result.head_oid,
+                if result.partial {
+                    "partial"
+                } else {
+                    "complete"
+                },
+                result.artifacts,
+                result.evidence_binding,
+            );
         }
         Cmd::Ui {
             since,
@@ -1863,6 +1977,75 @@ mod tests {
             "main",
             "--git-commits",
             "1001",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn review_export_matches_lens_bounds_and_revision_inputs() {
+        assert!(
+            Cli::try_parse_from(["mastermind", "review", "export", "--since", "main"]).is_err()
+        );
+        let cli = Cli::try_parse_from([
+            "mastermind",
+            "review",
+            "export",
+            "--since",
+            "origin/main",
+            "--out",
+            "mastermind-review",
+            "--path",
+            "services/payment",
+            "--production-only",
+            "--sarif",
+            "semgrep.sarif",
+            "--coverage",
+            "lcov.info",
+            "--junit",
+            "junit.xml",
+            "--otel",
+            "traces.json",
+            "--evidence-attestation",
+            "evidence-attestation.json",
+            "--git-commits",
+            "25",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.cmd,
+            Cmd::Review(ReviewCmd::Export {
+                since,
+                out,
+                path,
+                depth: 3,
+                top: 100,
+                production_only: true,
+                sarif,
+                coverage,
+                junit,
+                otel,
+                git_commits: 25,
+                evidence_attestation: Some(attestation),
+                ..
+            }) if since == "origin/main"
+                && out.as_path() == std::path::Path::new("mastermind-review")
+                && path == "services/payment"
+                && sarif == [PathBuf::from("semgrep.sarif")]
+                && coverage == [PathBuf::from("lcov.info")]
+                && junit == [PathBuf::from("junit.xml")]
+                && otel == [PathBuf::from("traces.json")]
+                && attestation.as_path() == std::path::Path::new("evidence-attestation.json")
+        ));
+        assert!(Cli::try_parse_from([
+            "mastermind",
+            "review",
+            "export",
+            "--since",
+            "main",
+            "--out",
+            "review",
+            "--depth",
+            "6",
         ])
         .is_err());
     }

--- a/mcp/servers/mmcg/src/review_package.rs
+++ b/mcp/servers/mmcg/src/review_package.rs
@@ -985,8 +985,15 @@ fn rename_package_noclobber(source: &Path, target: &Path) -> std::io::Result<()>
 #[cfg(windows)]
 fn rename_package_noclobber(source: &Path, target: &Path) -> std::io::Result<()> {
     // MoveFileEx without MOVEFILE_REPLACE_EXISTING is the behavior used by
-    // std::fs::rename on Windows, so an existing destination fails.
-    std::fs::rename(source, target)
+    // std::fs::rename on Windows, so an existing destination fails. Windows
+    // reports a non-empty destination directory as ERROR_DIR_NOT_EMPTY; map it
+    // to the cross-platform no-clobber contract consumed by write_package.
+    match std::fs::rename(source, target) {
+        Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => Err(
+            std::io::Error::new(std::io::ErrorKind::AlreadyExists, error),
+        ),
+        result => result,
+    }
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux", windows)))]

--- a/mcp/servers/mmcg/src/review_package.rs
+++ b/mcp/servers/mmcg/src/review_package.rs
@@ -1,0 +1,1464 @@
+//! Deterministic, offline PR evidence packages built from the shared Lens snapshot.
+//!
+//! Export is fail-closed for stale repository/index state and for evidence that
+//! changes while it is being packaged. External reports remain read-only. The
+//! package manifest binds their exact bytes to the reviewed Git head; an
+//! optional producer-side attestation can additionally bind those digests to
+//! the same revision without changing the codegraph database.
+
+use crate::evidence::{EvidenceExtensionOptions, EvidenceOptions, EvidencePrecisionNote};
+use crate::lens::{LensError, LensOptions, LensSnapshot};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::time::SystemTime;
+
+pub const REVIEW_PACKAGE_SCHEMA: u32 = 1;
+pub const EVIDENCE_ATTESTATION_SCHEMA: u32 = 1;
+const MAX_ATTESTATION_BYTES: u64 = 1024 * 1024;
+
+const WORKFLOW_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/assets/mastermind-review-pr.yml"
+));
+
+#[derive(Debug, Clone)]
+pub struct ReviewExportOptions {
+    pub root: PathBuf,
+    pub index_path: PathBuf,
+    pub out: PathBuf,
+    pub lens: LensOptions,
+    pub evidence: EvidenceOptions,
+    pub extensions: EvidenceExtensionOptions,
+    pub evidence_attestation: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReviewExportResult {
+    pub output_dir: PathBuf,
+    pub head_oid: String,
+    pub partial: bool,
+    pub artifacts: u32,
+    pub evidence_binding: String,
+}
+
+#[derive(Debug)]
+pub enum ReviewPackageError {
+    Lens(LensError),
+    OutputExists,
+    OutputParentUnavailable,
+    UnsafeOutput,
+    EvidenceUnavailable(String),
+    EvidenceTooLarge(String),
+    EvidenceChanged(String),
+    EvidenceBinding(String),
+    InvalidAttestation(String),
+    Serialization(String),
+    Io(String),
+}
+
+impl fmt::Display for ReviewPackageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Lens(error) => write!(formatter, "review snapshot failed: {error}"),
+            Self::OutputExists => formatter.write_str(
+                "review output already exists; choose a new --out path or remove it explicitly",
+            ),
+            Self::OutputParentUnavailable => {
+                formatter.write_str("review output parent must be an existing real directory")
+            }
+            Self::UnsafeOutput => formatter.write_str("review output path is unsafe"),
+            Self::EvidenceUnavailable(label) => {
+                write!(formatter, "review evidence is unavailable: {label}")
+            }
+            Self::EvidenceTooLarge(label) => {
+                write!(formatter, "review evidence exceeds its read limit: {label}")
+            }
+            Self::EvidenceChanged(label) => {
+                write!(formatter, "review evidence changed during export: {label}")
+            }
+            Self::EvidenceBinding(label) => {
+                write!(formatter, "review evidence digest binding failed: {label}")
+            }
+            Self::InvalidAttestation(message) => {
+                write!(formatter, "invalid review evidence attestation: {message}")
+            }
+            Self::Serialization(message) => {
+                write!(formatter, "review package serialization failed: {message}")
+            }
+            Self::Io(message) => write!(formatter, "review package I/O failed: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ReviewPackageError {}
+
+impl From<LensError> for ReviewPackageError {
+    fn from(error: LensError) -> Self {
+        Self::Lens(error)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SourceRequest {
+    id: String,
+    kind: &'static str,
+    path: PathBuf,
+    maximum_bytes: u64,
+    retain_body: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SourceIdentity {
+    id: String,
+    kind: String,
+    label: String,
+    resolved: PathBuf,
+    repository_relative: bool,
+    sha256: String,
+    bytes: u64,
+    modified: Option<SystemTime>,
+    body: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceAttestation {
+    schema_version: u32,
+    head_oid: String,
+    artifacts: Vec<AttestedArtifact>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AttestedArtifact {
+    kind: String,
+    path: String,
+    sha256: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ReviewManifest {
+    schema_version: u32,
+    package_format: &'static str,
+    generator: GeneratorBinding,
+    repository: RepositoryBinding,
+    scope: ScopeBinding,
+    analysis: AnalysisBinding,
+    evidence_binding: EvidenceBinding,
+    artifacts: Vec<ArtifactBinding>,
+    content_sha256: String,
+}
+
+#[derive(Debug, Serialize)]
+struct GeneratorBinding {
+    name: &'static str,
+    version: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct RepositoryBinding {
+    name: String,
+    root_label: String,
+    requested_ref: String,
+    baseline_oid: String,
+    head_oid: String,
+    includes_worktree: bool,
+    includes_untracked: bool,
+    snapshot_token_sha256: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ScopeBinding {
+    path: String,
+    depth: u8,
+    top: u32,
+    production_only: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct AnalysisBinding {
+    partial: bool,
+    temporal_status: &'static str,
+    semantic_available: bool,
+    evidence_partial: bool,
+    states: Vec<AnalysisState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+struct AnalysisState {
+    path: String,
+    state: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct EvidenceBinding {
+    status: String,
+    head_oid: String,
+    sources: Vec<EvidenceSourceBinding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    attestation: Option<AttestationBinding>,
+}
+
+#[derive(Debug, Serialize)]
+struct EvidenceSourceBinding {
+    id: String,
+    kind: String,
+    label: String,
+    repository_relative: bool,
+    sha256: String,
+    bytes: u64,
+    analysis_status: &'static str,
+    revision_binding: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct AttestationBinding {
+    label: String,
+    sha256: String,
+    head_oid: String,
+    artifacts: u32,
+    trust: &'static str,
+}
+
+#[derive(Default)]
+struct AttestationValidation {
+    artifacts: BTreeSet<(String, String, String)>,
+    binding: Option<AttestationBinding>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ArtifactBinding {
+    path: &'static str,
+    media_type: &'static str,
+    sha256: String,
+    bytes: u64,
+}
+
+struct PackageDocument {
+    path: &'static str,
+    media_type: &'static str,
+    body: Vec<u8>,
+}
+
+pub fn export(options: &ReviewExportOptions) -> Result<ReviewExportResult, ReviewPackageError> {
+    let root = options
+        .root
+        .canonicalize()
+        .map_err(|_| ReviewPackageError::Lens(LensError::RootUnavailable))?;
+    let output_dir = output_target(&options.out)?;
+    let requests = evidence_requests(&root, &options.evidence, &options.extensions);
+    let before_sources = read_sources(&root, &requests)?;
+    let before_attestation = options
+        .evidence_attestation
+        .as_ref()
+        .map(|path| {
+            read_source(
+                &root,
+                &SourceRequest {
+                    id: "attestation".into(),
+                    kind: "attestation",
+                    path: path.clone(),
+                    maximum_bytes: MAX_ATTESTATION_BYTES,
+                    retain_body: true,
+                },
+            )
+        })
+        .transpose()?;
+
+    let mut snapshot = crate::lens::snapshot_from_paths_with_evidence_extensions(
+        &root,
+        &options.index_path,
+        &options.lens,
+        &options.evidence,
+        &options.extensions,
+    )?;
+
+    let after_sources = read_sources(&root, &requests)?;
+    ensure_sources_unchanged(&before_sources, &after_sources)?;
+    let after_attestation = options
+        .evidence_attestation
+        .as_ref()
+        .map(|path| {
+            read_source(
+                &root,
+                &SourceRequest {
+                    id: "attestation".into(),
+                    kind: "attestation",
+                    path: path.clone(),
+                    maximum_bytes: MAX_ATTESTATION_BYTES,
+                    retain_body: true,
+                },
+            )
+        })
+        .transpose()?;
+    match (&before_attestation, &after_attestation) {
+        (Some(before), Some(after)) if before != after => {
+            return Err(ReviewPackageError::EvidenceChanged(before.label.clone()));
+        }
+        (None, None) | (Some(_), Some(_)) => {}
+        _ => return Err(ReviewPackageError::EvidenceChanged("attestation".into())),
+    }
+
+    let head_oid = snapshot.impact.baseline.head_oid.clone();
+    let attestation = validate_attestation(after_attestation.as_ref(), &after_sources, &head_oid)?;
+    if !after_sources.is_empty() {
+        snapshot.evidence.precision_notes.push(EvidencePrecisionNote {
+            source_id: "review-package",
+            code: "artifact_digest_revision_binding",
+            message: format!(
+                "manifest.json binds the exact SHA-256 digest of every packaged external evidence source to Git head {head_oid}; this proves which bytes were reviewed, not when or by whom the report was produced."
+            ),
+        });
+    }
+    if attestation.binding.is_some() {
+        snapshot.evidence.precision_notes.push(EvidencePrecisionNote {
+            source_id: "review-package",
+            code: "producer_revision_attested",
+            message: "A producer-side evidence attestation matched the package Git head and exact artifact digests. The attestation is an unsigned CI fact unless the surrounding workflow supplies a stronger trust anchor.".into(),
+        });
+    }
+    snapshot
+        .evidence
+        .precision_notes
+        .sort_by(|left, right| (left.code, &left.message).cmp(&(right.code, &right.message)));
+
+    let snapshot_value = serde_json::to_value(&snapshot)
+        .map_err(|error| ReviewPackageError::Serialization(error.to_string()))?;
+    let analysis = analysis_binding(&snapshot, &snapshot_value);
+    let evidence_binding = evidence_binding(
+        &snapshot,
+        &after_sources,
+        &attestation.artifacts,
+        attestation.binding,
+        &head_oid,
+    )?;
+    let html = crate::lens::standalone_html(&snapshot)?;
+    let sarif = pretty_json(&crate::sarif_export::review_package(
+        &snapshot.map,
+        &snapshot.impact,
+    ))?;
+    let workflow = WORKFLOW_TEMPLATE.as_bytes().to_vec();
+    let summary = summary_markdown(&snapshot, &analysis, &evidence_binding).into_bytes();
+    let documents = vec![
+        PackageDocument {
+            path: "index.html",
+            media_type: "text/html; charset=utf-8",
+            body: html,
+        },
+        PackageDocument {
+            path: "mastermind.sarif",
+            media_type: "application/sarif+json",
+            body: sarif,
+        },
+        PackageDocument {
+            path: "summary.md",
+            media_type: "text/markdown; charset=utf-8",
+            body: summary,
+        },
+        PackageDocument {
+            path: "mastermind-review.yml",
+            media_type: "application/yaml",
+            body: workflow,
+        },
+    ];
+    let artifacts = documents
+        .iter()
+        .map(|document| ArtifactBinding {
+            path: document.path,
+            media_type: document.media_type,
+            sha256: sha256_hex(&document.body),
+            bytes: document.body.len() as u64,
+        })
+        .collect::<Vec<_>>();
+    let content_sha256 = sha256_hex(
+        &serde_json::to_vec(&artifacts)
+            .map_err(|error| ReviewPackageError::Serialization(error.to_string()))?,
+    );
+    let manifest = ReviewManifest {
+        schema_version: REVIEW_PACKAGE_SCHEMA,
+        package_format: "mastermind-review",
+        generator: GeneratorBinding {
+            name: "Mastermind",
+            version: env!("CARGO_PKG_VERSION"),
+        },
+        repository: RepositoryBinding {
+            name: snapshot.repository.name.clone(),
+            root_label: snapshot.repository.root_label.clone(),
+            requested_ref: snapshot.impact.baseline.requested_ref.clone(),
+            baseline_oid: snapshot.impact.baseline.baseline_oid.clone(),
+            head_oid: head_oid.clone(),
+            includes_worktree: snapshot.impact.baseline.includes_worktree,
+            includes_untracked: snapshot.impact.baseline.includes_untracked,
+            snapshot_token_sha256: sha256_hex(snapshot.impact.snapshot_token.as_bytes()),
+        },
+        scope: ScopeBinding {
+            path: snapshot.options.path.clone(),
+            depth: snapshot.options.depth,
+            top: snapshot.options.top,
+            production_only: snapshot.options.production_only,
+        },
+        analysis,
+        evidence_binding,
+        artifacts,
+        content_sha256,
+    };
+    let manifest_body = pretty_json(
+        &serde_json::to_value(&manifest)
+            .map_err(|error| ReviewPackageError::Serialization(error.to_string()))?,
+    )?;
+    write_package(&output_dir, documents, &manifest_body)?;
+
+    Ok(ReviewExportResult {
+        output_dir,
+        head_oid,
+        partial: manifest.analysis.partial,
+        artifacts: manifest.artifacts.len() as u32 + 1,
+        evidence_binding: manifest.evidence_binding.status,
+    })
+}
+
+fn evidence_requests(
+    root: &Path,
+    evidence: &EvidenceOptions,
+    extensions: &EvidenceExtensionOptions,
+) -> Vec<SourceRequest> {
+    let mut requests = Vec::new();
+    let mut artifact_count = 0_usize;
+    for (kind, paths) in [
+        ("sarif", evidence.sarif.as_slice()),
+        ("coverage", evidence.coverage.as_slice()),
+        ("junit", extensions.junit.as_slice()),
+        ("otel", extensions.otel.as_slice()),
+    ] {
+        for (index, path) in paths.iter().enumerate() {
+            if artifact_count >= crate::evidence::MAX_ARTIFACT_SOURCES {
+                break;
+            }
+            requests.push(SourceRequest {
+                id: format!("{kind}:{index}"),
+                kind,
+                path: path.clone(),
+                maximum_bytes: crate::evidence::MAX_ARTIFACT_BYTES,
+                retain_body: false,
+            });
+            artifact_count += 1;
+        }
+    }
+    let codeowners = evidence.codeowners.clone().or_else(|| {
+        evidence
+            .discover_codeowners
+            .then(|| crate::evidence::discover_codeowners(root))
+            .flatten()
+    });
+    if let Some(path) = codeowners {
+        requests.push(SourceRequest {
+            id: "codeowners".into(),
+            kind: "codeowners",
+            path,
+            maximum_bytes: crate::evidence::MAX_CODEOWNERS_BYTES,
+            retain_body: false,
+        });
+    }
+    requests
+}
+
+fn read_sources(
+    root: &Path,
+    requests: &[SourceRequest],
+) -> Result<Vec<SourceIdentity>, ReviewPackageError> {
+    requests
+        .iter()
+        .map(|request| read_source(root, request))
+        .collect()
+}
+
+fn read_source(root: &Path, request: &SourceRequest) -> Result<SourceIdentity, ReviewPackageError> {
+    let requested = if request.path.is_absolute() {
+        request.path.clone()
+    } else {
+        root.join(&request.path)
+    };
+    let fallback_label = display_path(&request.path);
+    let resolved = requested
+        .canonicalize()
+        .map_err(|_| ReviewPackageError::EvidenceUnavailable(fallback_label.clone()))?;
+    let initial = std::fs::metadata(&resolved)
+        .map_err(|_| ReviewPackageError::EvidenceUnavailable(fallback_label.clone()))?;
+    if !initial.is_file() {
+        return Err(ReviewPackageError::EvidenceUnavailable(fallback_label));
+    }
+    if initial.len() > request.maximum_bytes {
+        return Err(ReviewPackageError::EvidenceTooLarge(fallback_label));
+    }
+    let mut file = File::open(&resolved)
+        .map_err(|_| ReviewPackageError::EvidenceUnavailable(fallback_label.clone()))?;
+    let before = file
+        .metadata()
+        .map_err(|_| ReviewPackageError::EvidenceUnavailable(fallback_label.clone()))?;
+    if !before.is_file() || before.len() != initial.len() || modified(&before) != modified(&initial)
+    {
+        return Err(ReviewPackageError::EvidenceChanged(fallback_label));
+    }
+    let mut body = Vec::with_capacity(usize::try_from(before.len()).unwrap_or(0));
+    Read::by_ref(&mut file)
+        .take(request.maximum_bytes + 1)
+        .read_to_end(&mut body)
+        .map_err(|_| ReviewPackageError::EvidenceUnavailable(fallback_label.clone()))?;
+    if body.len() as u64 > request.maximum_bytes {
+        return Err(ReviewPackageError::EvidenceTooLarge(fallback_label));
+    }
+    let after = file
+        .metadata()
+        .map_err(|_| ReviewPackageError::EvidenceChanged(fallback_label.clone()))?;
+    if after.len() != before.len() || modified(&after) != modified(&before) {
+        return Err(ReviewPackageError::EvidenceChanged(fallback_label));
+    }
+    let (label, repository_relative) = match resolved.strip_prefix(root) {
+        Ok(relative) => (display_path(relative), true),
+        Err(_) => (
+            resolved
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "evidence-artifact".into()),
+            false,
+        ),
+    };
+    let sha256 = sha256_hex(&body);
+    let bytes = body.len() as u64;
+    Ok(SourceIdentity {
+        id: request.id.clone(),
+        kind: request.kind.into(),
+        label,
+        resolved,
+        repository_relative,
+        sha256,
+        bytes,
+        modified: modified(&after),
+        body: if request.retain_body {
+            body
+        } else {
+            Vec::new()
+        },
+    })
+}
+
+fn ensure_sources_unchanged(
+    before: &[SourceIdentity],
+    after: &[SourceIdentity],
+) -> Result<(), ReviewPackageError> {
+    if before.len() != after.len() {
+        return Err(ReviewPackageError::EvidenceChanged(
+            "evidence source set".into(),
+        ));
+    }
+    for (left, right) in before.iter().zip(after) {
+        if left != right {
+            return Err(ReviewPackageError::EvidenceChanged(left.label.clone()));
+        }
+    }
+    Ok(())
+}
+
+fn validate_attestation(
+    input: Option<&SourceIdentity>,
+    sources: &[SourceIdentity],
+    head_oid: &str,
+) -> Result<AttestationValidation, ReviewPackageError> {
+    let Some(input) = input else {
+        return Ok(AttestationValidation::default());
+    };
+    let attestation: EvidenceAttestation = crate::audit_bundle::from_json_strict(&input.body)
+        .map_err(|error| ReviewPackageError::InvalidAttestation(error.to_string()))?;
+    if attestation.schema_version != EVIDENCE_ATTESTATION_SCHEMA {
+        return Err(ReviewPackageError::InvalidAttestation(
+            "unsupported schema_version".into(),
+        ));
+    }
+    if !full_oid(&attestation.head_oid) || attestation.head_oid != head_oid {
+        return Err(ReviewPackageError::InvalidAttestation(
+            "head_oid does not match the review snapshot".into(),
+        ));
+    }
+    if attestation.artifacts.len() > crate::evidence::MAX_ARTIFACT_SOURCES + 1 {
+        return Err(ReviewPackageError::InvalidAttestation(
+            "artifact list exceeds the review source limit".into(),
+        ));
+    }
+    let mut seen = BTreeSet::new();
+    let mut attested = BTreeSet::new();
+    for artifact in &attestation.artifacts {
+        if !matches!(
+            artifact.kind.as_str(),
+            "sarif" | "coverage" | "junit" | "otel" | "codeowners"
+        ) {
+            return Err(ReviewPackageError::InvalidAttestation(format!(
+                "unsupported artifact kind {}",
+                artifact.kind
+            )));
+        }
+        let normalized = normalize_relative(&artifact.path).ok_or_else(|| {
+            ReviewPackageError::InvalidAttestation(
+                "artifact path must be canonical and repository-relative".into(),
+            )
+        })?;
+        if normalized != artifact.path || !sha256_digest(&artifact.sha256) {
+            return Err(ReviewPackageError::InvalidAttestation(
+                "artifact path or sha256 is not canonical".into(),
+            ));
+        }
+        if !seen.insert((artifact.kind.clone(), artifact.path.clone())) {
+            return Err(ReviewPackageError::InvalidAttestation(
+                "duplicate artifact identity".into(),
+            ));
+        }
+        let matches = sources
+            .iter()
+            .filter(|source| {
+                source.repository_relative
+                    && source.kind == artifact.kind
+                    && source.label == artifact.path
+            })
+            .collect::<Vec<_>>();
+        if matches.is_empty()
+            || matches
+                .iter()
+                .any(|source| source.sha256 != artifact.sha256)
+        {
+            return Err(ReviewPackageError::InvalidAttestation(format!(
+                "artifact digest does not match {}:{}",
+                artifact.kind, artifact.path
+            )));
+        }
+        attested.insert((
+            artifact.kind.clone(),
+            artifact.path.clone(),
+            artifact.sha256.clone(),
+        ));
+    }
+    Ok(AttestationValidation {
+        artifacts: attested,
+        binding: Some(AttestationBinding {
+            label: input.label.clone(),
+            sha256: input.sha256.clone(),
+            head_oid: attestation.head_oid,
+            artifacts: attestation.artifacts.len() as u32,
+            trust: "unsigned-digest-attestation",
+        }),
+    })
+}
+
+fn evidence_binding(
+    snapshot: &LensSnapshot,
+    sources: &[SourceIdentity],
+    attested: &BTreeSet<(String, String, String)>,
+    attestation: Option<AttestationBinding>,
+    head_oid: &str,
+) -> Result<EvidenceBinding, ReviewPackageError> {
+    let bound_sources = sources
+        .iter()
+        .map(|source| {
+            let observed = snapshot
+                .evidence
+                .sources
+                .items
+                .iter()
+                .find(|candidate| candidate.id == source.id)
+                .ok_or_else(|| ReviewPackageError::EvidenceBinding(source.id.clone()))?;
+            if observed.kind != source.kind {
+                return Err(ReviewPackageError::EvidenceBinding(source.id.clone()));
+            }
+            match observed.artifact_sha256.as_deref() {
+                Some(digest)
+                    if digest == source.sha256 && observed.artifact_bytes == Some(source.bytes) => {
+                }
+                None if observed.status == "error" => {}
+                _ => return Err(ReviewPackageError::EvidenceBinding(source.id.clone())),
+            }
+            let producer_attested = attested.contains(&(
+                source.kind.clone(),
+                source.label.clone(),
+                source.sha256.clone(),
+            ));
+            Ok(EvidenceSourceBinding {
+                id: source.id.clone(),
+                kind: source.kind.clone(),
+                label: source.label.clone(),
+                repository_relative: source.repository_relative,
+                sha256: source.sha256.clone(),
+                bytes: source.bytes,
+                analysis_status: observed.status,
+                revision_binding: if producer_attested {
+                    "producer-attested"
+                } else {
+                    "digest-bound-at-export"
+                },
+            })
+        })
+        .collect::<Result<Vec<_>, ReviewPackageError>>()?;
+    let attested_count = bound_sources
+        .iter()
+        .filter(|source| source.revision_binding == "producer-attested")
+        .count();
+    let status = if bound_sources.is_empty() {
+        "not-applicable"
+    } else if attested_count == bound_sources.len() {
+        "producer-attested"
+    } else if attested_count > 0 {
+        "partially-producer-attested"
+    } else {
+        "digest-bound-at-export"
+    };
+    Ok(EvidenceBinding {
+        status: status.into(),
+        head_oid: head_oid.into(),
+        sources: bound_sources,
+        attestation,
+    })
+}
+
+fn analysis_binding(snapshot: &LensSnapshot, value: &Value) -> AnalysisBinding {
+    let mut states = BTreeSet::new();
+    collect_analysis_states(value, "$", &mut states);
+    if snapshot.temporal.status != "available" {
+        states.insert(AnalysisState {
+            path: "$.temporal".into(),
+            state: "unavailable",
+            reason: snapshot
+                .temporal
+                .diagnostic
+                .as_ref()
+                .map(|diagnostic| diagnostic.code.into()),
+        });
+    }
+    let states = states.into_iter().collect::<Vec<_>>();
+    AnalysisBinding {
+        partial: !states.is_empty(),
+        temporal_status: snapshot.temporal.status,
+        semantic_available: snapshot.semantic.available,
+        evidence_partial: snapshot.evidence.partial,
+        states,
+    }
+}
+
+fn collect_analysis_states(value: &Value, path: &str, states: &mut BTreeSet<AnalysisState>) {
+    match value {
+        Value::Object(object) => {
+            let reason = object
+                .get("truncation_reason")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            for (key, child) in object {
+                let state = if key == "partial" {
+                    Some("partial")
+                } else if key == "truncated" || key.ends_with("_truncated") {
+                    Some("truncated")
+                } else {
+                    None
+                };
+                if child.as_bool() == Some(true) {
+                    let Some(state) = state else {
+                        continue;
+                    };
+                    states.insert(AnalysisState {
+                        path: path.into(),
+                        state,
+                        reason: match key.as_str() {
+                            "partial" => None,
+                            "truncated" => reason.clone().or_else(|| Some("truncated".to_string())),
+                            _ => Some(key.to_string()),
+                        },
+                    });
+                }
+            }
+            for (key, child) in object {
+                collect_analysis_states(child, &format!("{path}.{key}"), states);
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                collect_analysis_states(child, &format!("{path}[{index}]"), states);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn summary_markdown(
+    snapshot: &LensSnapshot,
+    analysis: &AnalysisBinding,
+    evidence: &EvidenceBinding,
+) -> String {
+    let impact = &snapshot.impact;
+    let map = &snapshot.map;
+    let revision_kind = if impact.baseline.includes_worktree || impact.baseline.includes_untracked {
+        "commit plus working-tree state"
+    } else {
+        "clean commit"
+    };
+    let mut output = format!(
+        "# Mastermind review\n\n[Open the autonomous Lens report](index.html) · [SARIF results](mastermind.sarif)\n\n- Repository: {}\n- Baseline: `{}` (`{}`)\n- Head: `{}` ({revision_kind})\n- Scope: `{}` · depth {} · top {}\n- Analysis: **{}**\n- Evidence binding: `{}`\n\n## Change summary\n\n- Changed files: {}\n- Changed symbols: {}\n- Impacted symbols: {}\n- Cross-component impacts: {}\n- Candidate tests: {}\n\n## Architecture snapshot\n\n- Indexed files in scope: {}\n- Components: {}\n- Dependency cycles: {}\n- Hotspots: {}\n",
+        markdown_text(&snapshot.repository.name),
+        markdown_text(&impact.baseline.requested_ref),
+        short_oid(&impact.baseline.baseline_oid),
+        short_oid(&impact.baseline.head_oid),
+        markdown_text(&snapshot.options.path),
+        snapshot.options.depth,
+        snapshot.options.top,
+        if analysis.partial { "partial" } else { "complete" },
+        evidence.status,
+        count_label(impact.changes.files.total, impact.changes.files.returned),
+        count_label(impact.changes.symbols.total, impact.changes.symbols.returned),
+        count_label(impact.impact.total, impact.impact.returned),
+        count_label(impact.api_crossings.total, impact.api_crossings.returned),
+        count_label(impact.tests.total, impact.tests.returned),
+        count_label(map.files.total, map.files.returned),
+        count_label(map.components.total, map.components.returned),
+        count_label(map.cycles.total, map.cycles.returned),
+        count_label(map.hotspots.total, map.hotspots.returned),
+    );
+    if let Some(temporal) = snapshot.temporal.data.as_ref() {
+        let summary = &temporal.summary;
+        output.push_str(&format!(
+            "\n## Architecture drift\n\n- Components: +{} / -{}\n- Public boundaries: +{} / -{} / ~{}\n- Cycles: +{} / -{} / ~{}\n- Ownership changes: {}\n- History review candidates: {}\n",
+            summary.components_added,
+            summary.components_removed,
+            summary.boundaries_added,
+            summary.boundaries_removed,
+            summary.boundaries_changed,
+            summary.cycles_introduced,
+            summary.cycles_resolved,
+            summary.cycles_changed,
+            summary.ownership_changes,
+            summary.history_review_candidates,
+        ));
+    }
+    output.push_str(&format!(
+        "\n## Evidence and limits\n\n- External evidence inputs: {}\n- Lens evidence status: {}\n- Temporal status: `{}`\n- Bounded/partial states: {}\n",
+        evidence.sources.len(),
+        if snapshot.evidence.partial { "partial" } else { "complete" },
+        snapshot.temporal.status,
+        analysis.states.len(),
+    ));
+    for state in analysis.states.iter().take(8) {
+        output.push_str(&format!(
+            "  - `{}`: {}{}\n",
+            markdown_text(&state.path),
+            state.state,
+            state
+                .reason
+                .as_ref()
+                .map(|reason| format!(" ({})", markdown_text(reason)))
+                .unwrap_or_default(),
+        ));
+    }
+    if analysis.states.len() > 8 {
+        output.push_str(&format!(
+            "  - {} additional states are recorded in `manifest.json`.\n",
+            analysis.states.len() - 8
+        ));
+    }
+    output.push_str(
+        "\n`manifest.json` records the exact Git OIDs, package payload digests, external evidence digests, and every returned partial/truncation state.\n",
+    );
+    output
+}
+
+fn output_target(path: &Path) -> Result<PathBuf, ReviewPackageError> {
+    let name = path.file_name().ok_or(ReviewPackageError::UnsafeOutput)?;
+    if name.is_empty() || matches!(path.components().next_back(), Some(Component::ParentDir)) {
+        return Err(ReviewPackageError::UnsafeOutput);
+    }
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let metadata = std::fs::symlink_metadata(parent)
+        .map_err(|_| ReviewPackageError::OutputParentUnavailable)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(ReviewPackageError::OutputParentUnavailable);
+    }
+    let parent = parent
+        .canonicalize()
+        .map_err(|_| ReviewPackageError::OutputParentUnavailable)?;
+    let target = parent.join(name);
+    match std::fs::symlink_metadata(&target) {
+        Ok(_) => Err(ReviewPackageError::OutputExists),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(target),
+        Err(error) => Err(ReviewPackageError::Io(error.to_string())),
+    }
+}
+
+fn write_package(
+    target: &Path,
+    documents: Vec<PackageDocument>,
+    manifest: &[u8],
+) -> Result<(), ReviewPackageError> {
+    let parent = target
+        .parent()
+        .ok_or(ReviewPackageError::OutputParentUnavailable)?;
+    let temporary = tempfile::Builder::new()
+        .prefix(".mastermind-review-")
+        .tempdir_in(parent)
+        .map_err(|error| ReviewPackageError::Io(error.to_string()))?;
+    for document in documents {
+        write_new_file(&temporary.path().join(document.path), &document.body)?;
+    }
+    write_new_file(&temporary.path().join("manifest.json"), manifest)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(temporary.path(), std::fs::Permissions::from_mode(0o755))
+            .map_err(|error| ReviewPackageError::Io(error.to_string()))?;
+        File::open(temporary.path())
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| ReviewPackageError::Io(error.to_string()))?;
+    }
+    match rename_package_noclobber(temporary.path(), target) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Err(ReviewPackageError::OutputExists);
+        }
+        Err(error) => return Err(ReviewPackageError::Io(error.to_string())),
+    }
+    #[cfg(unix)]
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| ReviewPackageError::Io(error.to_string()))?;
+    Ok(())
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn rename_package_noclobber(source: &Path, target: &Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let source = CString::new(source.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in source path"))?;
+    let target = CString::new(target.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in target path"))?;
+    // SAFETY: both arguments are live NUL-terminated path buffers. RENAME_EXCL
+    // gives the directory publication the same no-clobber contract as create_new.
+    let status = unsafe { libc::renamex_np(source.as_ptr(), target.as_ptr(), libc::RENAME_EXCL) };
+    if status == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn rename_package_noclobber(source: &Path, target: &Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let source = CString::new(source.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in source path"))?;
+    let target = CString::new(target.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in target path"))?;
+    // SAFETY: both path pointers remain valid for the syscall. renameat2 with
+    // RENAME_NOREPLACE publishes atomically and never replaces another entry.
+    let status = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            libc::AT_FDCWD,
+            source.as_ptr(),
+            libc::AT_FDCWD,
+            target.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if status == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(windows)]
+fn rename_package_noclobber(source: &Path, target: &Path) -> std::io::Result<()> {
+    // MoveFileEx without MOVEFILE_REPLACE_EXISTING is the behavior used by
+    // std::fs::rename on Windows, so an existing destination fails.
+    std::fs::rename(source, target)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux", windows)))]
+fn rename_package_noclobber(_source: &Path, _target: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "atomic no-clobber directory publication is unavailable on this platform",
+    ))
+}
+
+fn write_new_file(path: &Path, bytes: &[u8]) -> Result<(), ReviewPackageError> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o644);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| ReviewPackageError::Io(error.to_string()))?;
+    file.write_all(bytes)
+        .and_then(|_| file.sync_all())
+        .map_err(|error| ReviewPackageError::Io(error.to_string()))
+}
+
+fn pretty_json(value: &Value) -> Result<Vec<u8>, ReviewPackageError> {
+    let mut body = serde_json::to_vec_pretty(value)
+        .map_err(|error| ReviewPackageError::Serialization(error.to_string()))?;
+    body.push(b'\n');
+    Ok(body)
+}
+
+fn modified(metadata: &std::fs::Metadata) -> Option<SystemTime> {
+    metadata.modified().ok()
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    crate::hex::encode(&Sha256::digest(bytes))
+}
+
+fn sha256_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn full_oid(value: &str) -> bool {
+    matches!(value.len(), 40 | 64)
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn normalize_relative(value: &str) -> Option<String> {
+    let path = Path::new(value);
+    if value.is_empty()
+        || value.contains('\\')
+        || path.is_absolute()
+        || value.as_bytes().get(1) == Some(&b':')
+    {
+        return None;
+    }
+    let mut parts = Vec::new();
+    for component in path.components() {
+        let Component::Normal(part) = component else {
+            return None;
+        };
+        let part = part.to_str()?;
+        if part.is_empty() || part.chars().any(|character| character.is_control()) {
+            return None;
+        }
+        parts.push(part);
+    }
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn short_oid(value: &str) -> &str {
+    value.get(..12).unwrap_or(value)
+}
+
+fn count_label(total: Option<u32>, returned: u32) -> String {
+    match total {
+        Some(total) if total == returned => total.to_string(),
+        Some(total) => format!("{returned} returned / {total} total"),
+        None => format!("{returned} returned / total unknown"),
+    }
+}
+
+fn markdown_text(value: &str) -> String {
+    let mut output = String::new();
+    let mut previous_space = false;
+    for character in value.chars() {
+        if character.is_control() || character.is_whitespace() {
+            if !previous_space {
+                output.push(' ');
+                previous_space = true;
+            }
+        } else {
+            if matches!(character, '`' | '*' | '_' | '[' | ']' | '<' | '>') {
+                output.push('\\');
+            }
+            output.push(character);
+            previous_space = false;
+        }
+    }
+    output.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexer::Indexer;
+    use crate::store::Store;
+    use std::process::Command;
+
+    fn git(root: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().into()
+    }
+
+    fn fixture() -> (tempfile::TempDir, tempfile::TempDir, PathBuf) {
+        let repository = tempfile::tempdir().unwrap();
+        let state = tempfile::tempdir().unwrap();
+        std::fs::create_dir(repository.path().join("src")).unwrap();
+        std::fs::write(
+            repository.path().join("src/lib.rs"),
+            "pub fn charge() -> i32 { 1 }\npub fn checkout() -> i32 { charge() }\n",
+        )
+        .unwrap();
+        git(repository.path(), &["init", "-q"]);
+        git(
+            repository.path(),
+            &["config", "user.email", "review@example.test"],
+        );
+        git(repository.path(), &["config", "user.name", "Review Export"]);
+        git(repository.path(), &["add", "."]);
+        git(repository.path(), &["commit", "-qm", "baseline"]);
+        std::fs::write(
+            repository.path().join("src/lib.rs"),
+            "pub fn charge() -> i32 { 2 }\npub fn checkout() -> i32 { charge() }\n",
+        )
+        .unwrap();
+        let index_path = state.path().join("mmcg.db");
+        let mut store = Store::open(&index_path).unwrap();
+        Indexer::new(repository.path())
+            .index_all(&mut store, false)
+            .unwrap();
+        drop(store);
+        (repository, state, index_path)
+    }
+
+    fn export_options(
+        repository: &Path,
+        index_path: PathBuf,
+        output: PathBuf,
+    ) -> ReviewExportOptions {
+        ReviewExportOptions {
+            root: repository.into(),
+            index_path,
+            out: output,
+            lens: LensOptions {
+                since: "HEAD".into(),
+                path: ".".into(),
+                depth: 3,
+                top: 100,
+                production_only: false,
+            },
+            evidence: EvidenceOptions {
+                git_commits: 0,
+                ..EvidenceOptions::default()
+            },
+            extensions: EvidenceExtensionOptions::default(),
+            evidence_attestation: None,
+        }
+    }
+
+    #[test]
+    fn export_writes_one_atomic_offline_evidence_package() {
+        let (repository, state, index_path) = fixture();
+        let sarif = state.path().join("semgrep.sarif");
+        std::fs::write(
+            &sarif,
+            r#"{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"Semgrep"}},"results":[]}]}"#,
+        )
+        .unwrap();
+        let output = repository.path().join("mastermind-review");
+        let mut options = export_options(repository.path(), index_path, output.clone());
+        options.evidence.sarif.push(sarif);
+
+        let result = export(&options).unwrap();
+
+        assert_eq!(result.output_dir, output.canonicalize().unwrap());
+        assert_eq!(result.artifacts, 5);
+        for name in [
+            "index.html",
+            "mastermind.sarif",
+            "summary.md",
+            "manifest.json",
+            "mastermind-review.yml",
+        ] {
+            assert!(output.join(name).is_file(), "missing {name}");
+        }
+        let html = std::fs::read_to_string(output.join("index.html")).unwrap();
+        assert!(html.contains("id=\"lens-snapshot\""));
+        assert!(html.contains("connect-src 'none'"));
+        assert!(!html.contains("href=\"styles.css\""));
+        assert!(!html.contains("src=\"app.js\""));
+        let manifest: Value =
+            serde_json::from_slice(&std::fs::read(output.join("manifest.json")).unwrap()).unwrap();
+        assert_eq!(manifest["schema_version"], 1);
+        assert_eq!(manifest["package_format"], "mastermind-review");
+        assert_eq!(
+            manifest["repository"]["head_oid"].as_str().unwrap().len(),
+            40
+        );
+        assert_eq!(
+            manifest["evidence_binding"]["status"],
+            "digest-bound-at-export"
+        );
+        assert_eq!(
+            manifest["evidence_binding"]["sources"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        let source = &manifest["evidence_binding"]["sources"][0];
+        assert_eq!(source["id"], "sarif:0");
+        assert_eq!(source["analysis_status"], "loaded");
+        assert_eq!(
+            source["sha256"],
+            sha256_hex(&std::fs::read(state.path().join("semgrep.sarif")).unwrap())
+        );
+        assert_eq!(manifest["artifacts"].as_array().unwrap().len(), 4);
+        let package_sarif: Value =
+            serde_json::from_slice(&std::fs::read(output.join("mastermind.sarif")).unwrap())
+                .unwrap();
+        assert_eq!(package_sarif["runs"].as_array().unwrap().len(), 2);
+        let workflow = std::fs::read_to_string(output.join("mastermind-review.yml")).unwrap();
+        assert!(workflow.contains("github/codeql-action/upload-sarif@c54b30b7"));
+        assert!(workflow.contains("actions/upload-artifact@043fb46d"));
+        assert!(matches!(
+            export(&options),
+            Err(ReviewPackageError::OutputExists)
+        ));
+    }
+
+    #[test]
+    fn invalid_external_report_is_digest_bound_and_explicitly_partial() {
+        let (repository, state, index_path) = fixture();
+        let report = state.path().join("invalid.sarif");
+        std::fs::write(&report, b"not SARIF").unwrap();
+        let output = state.path().join("partial-review");
+        let mut options = export_options(repository.path(), index_path, output.clone());
+        options.evidence.sarif.push(report.clone());
+
+        let result = export(&options).unwrap();
+
+        assert!(result.partial);
+        let manifest: Value =
+            serde_json::from_slice(&std::fs::read(output.join("manifest.json")).unwrap()).unwrap();
+        assert_eq!(
+            manifest["evidence_binding"]["sources"][0]["analysis_status"],
+            "error"
+        );
+        assert_eq!(
+            manifest["evidence_binding"]["sources"][0]["sha256"],
+            sha256_hex(&std::fs::read(report).unwrap())
+        );
+        assert!(manifest["analysis"]["states"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|state| state["path"] == "$.evidence" && state["state"] == "partial"));
+    }
+
+    #[test]
+    fn producer_attestation_requires_exact_head_path_and_digest() {
+        let repository = tempfile::tempdir().unwrap();
+        std::fs::create_dir(repository.path().join("reports")).unwrap();
+        let report = repository.path().join("reports/semgrep.sarif");
+        std::fs::write(&report, b"sarif bytes").unwrap();
+        let root = repository.path().canonicalize().unwrap();
+        let source = read_source(
+            &root,
+            &SourceRequest {
+                id: "sarif:0".into(),
+                kind: "sarif",
+                path: PathBuf::from("reports/semgrep.sarif"),
+                maximum_bytes: crate::evidence::MAX_ARTIFACT_BYTES,
+                retain_body: false,
+            },
+        )
+        .unwrap();
+        assert!(source.body.is_empty());
+        let head = "a".repeat(40);
+        let body = format!(
+            "{{\"schema_version\":1,\"head_oid\":\"{head}\",\"artifacts\":[{{\"kind\":\"sarif\",\"path\":\"reports/semgrep.sarif\",\"sha256\":\"{}\"}}]}}",
+            source.sha256
+        )
+        .into_bytes();
+        let input = SourceIdentity {
+            id: "attestation".into(),
+            kind: "attestation".into(),
+            label: "evidence-attestation.json".into(),
+            resolved: root.join("evidence-attestation.json"),
+            repository_relative: true,
+            sha256: sha256_hex(&body),
+            bytes: body.len() as u64,
+            modified: None,
+            body,
+        };
+        let parsed: EvidenceAttestation =
+            crate::audit_bundle::from_json_strict(&input.body).unwrap();
+        assert_eq!(parsed.artifacts[0].sha256, source.sha256);
+
+        let validation =
+            validate_attestation(Some(&input), std::slice::from_ref(&source), &head).unwrap();
+        assert_eq!(validation.artifacts.len(), 1);
+        assert_eq!(validation.binding.unwrap().artifacts, 1);
+
+        let mut mismatched = input.clone();
+        let text = String::from_utf8(mismatched.body)
+            .unwrap()
+            .replace(&source.sha256, &"0".repeat(64));
+        mismatched.body = text.into_bytes();
+        assert!(matches!(
+            validate_attestation(Some(&mismatched), &[source], &head),
+            Err(ReviewPackageError::InvalidAttestation(_))
+        ));
+    }
+
+    #[test]
+    fn export_records_matching_producer_attestation_end_to_end() {
+        let (repository, state, index_path) = fixture();
+        std::fs::create_dir(repository.path().join("reports")).unwrap();
+        let report = repository.path().join("reports/semgrep.sarif");
+        std::fs::write(
+            &report,
+            r#"{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"Semgrep"}},"results":[]}]}"#,
+        )
+        .unwrap();
+        let digest = sha256_hex(&std::fs::read(&report).unwrap());
+        let head = git(repository.path(), &["rev-parse", "HEAD"]);
+        let attestation = repository.path().join("reports/evidence-attestation.json");
+        std::fs::write(
+            &attestation,
+            serde_json::to_vec(&serde_json::json!({
+                "schema_version": 1,
+                "head_oid": head,
+                "artifacts": [{
+                    "kind": "sarif",
+                    "path": "reports/semgrep.sarif",
+                    "sha256": digest
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let output = state.path().join("attested-review");
+        let mut options = export_options(repository.path(), index_path, output.clone());
+        options
+            .evidence
+            .sarif
+            .push(PathBuf::from("reports/semgrep.sarif"));
+        options.evidence_attestation = Some(PathBuf::from("reports/evidence-attestation.json"));
+
+        let result = export(&options).unwrap();
+
+        assert_eq!(result.evidence_binding, "producer-attested");
+        let manifest: Value =
+            serde_json::from_slice(&std::fs::read(output.join("manifest.json")).unwrap()).unwrap();
+        assert_eq!(manifest["evidence_binding"]["status"], "producer-attested");
+        assert_eq!(
+            manifest["evidence_binding"]["sources"][0]["revision_binding"],
+            "producer-attested"
+        );
+        assert_eq!(
+            manifest["evidence_binding"]["attestation"]["head_oid"],
+            head
+        );
+    }
+
+    #[test]
+    fn strict_attestation_rejects_duplicate_json_keys() {
+        let body = br#"{"schema_version":1,"schema_version":1,"head_oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","artifacts":[]}"#.to_vec();
+        let input = SourceIdentity {
+            id: "attestation".into(),
+            kind: "attestation".into(),
+            label: "attestation.json".into(),
+            resolved: PathBuf::from("attestation.json"),
+            repository_relative: true,
+            sha256: sha256_hex(&body),
+            bytes: body.len() as u64,
+            modified: None,
+            body,
+        };
+        assert!(matches!(
+            validate_attestation(Some(&input), &[], &"a".repeat(40)),
+            Err(ReviewPackageError::InvalidAttestation(_))
+        ));
+    }
+
+    #[test]
+    fn nested_partial_and_truncation_states_are_explicit() {
+        let mut states = BTreeSet::new();
+        collect_analysis_states(
+            &serde_json::json!({
+                "map": {"partial": true},
+                "impact": {"rows": {
+                    "truncated": true,
+                    "truncation_reason": "row_limit",
+                    "names_truncated": true,
+                    "failures_truncated": true,
+                    "contributors_truncated": true
+                }}
+            }),
+            "$",
+            &mut states,
+        );
+        assert!(states
+            .iter()
+            .any(|state| state.path == "$.map" && state.state == "partial"));
+        assert!(states.iter().any(|state| {
+            state.path == "$.impact.rows"
+                && state.state == "truncated"
+                && state.reason.as_deref() == Some("row_limit")
+        }));
+        for reason in [
+            "names_truncated",
+            "failures_truncated",
+            "contributors_truncated",
+        ] {
+            assert!(states.iter().any(|state| {
+                state.path == "$.impact.rows"
+                    && state.state == "truncated"
+                    && state.reason.as_deref() == Some(reason)
+            }));
+        }
+    }
+
+    #[test]
+    fn atomic_publication_never_replaces_an_existing_directory() {
+        let parent = tempfile::tempdir().unwrap();
+        let source = tempfile::Builder::new()
+            .prefix("source-")
+            .tempdir_in(parent.path())
+            .unwrap();
+        std::fs::write(source.path().join("payload"), b"new").unwrap();
+        let target = parent.path().join("review");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("owner"), b"existing").unwrap();
+
+        let error = rename_package_noclobber(source.path(), &target).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(std::fs::read(target.join("owner")).unwrap(), b"existing");
+        assert!(source.path().join("payload").is_file());
+    }
+}

--- a/mcp/servers/mmcg/src/sarif_export.rs
+++ b/mcp/servers/mmcg/src/sarif_export.rs
@@ -165,6 +165,27 @@ pub fn change_impact(response: &ChangeImpactResponse) -> Value {
     )
 }
 
+/// Combine the bounded project-map and change-impact projections into the one
+/// SARIF document shipped by a review package. Each analysis keeps its own run
+/// identity, rule metadata, and partial-state properties.
+pub(crate) fn review_package(map: &ProjectMapResponse, impact: &ChangeImpactResponse) -> Value {
+    merge_documents([project_map(map), change_impact(impact)])
+}
+
+fn merge_documents<const N: usize>(documents: [Value; N]) -> Value {
+    let mut runs = Vec::new();
+    for document in documents {
+        if let Some(items) = document.get("runs").and_then(Value::as_array) {
+            runs.extend(items.iter().cloned());
+        }
+    }
+    json!({
+        "$schema": SARIF_SCHEMA,
+        "version": "2.1.0",
+        "runs": runs
+    })
+}
+
 pub fn architecture_policy(report: &PolicyReport) -> Value {
     let mut rules = report
         .rules
@@ -526,5 +547,18 @@ mod tests {
     fn messages_remove_controls_and_are_bounded() {
         assert_eq!(safe_message_text("auth\n\tboundary", 100), "auth boundary");
         assert_eq!(safe_message_text("abcdef", 3), "abc…");
+    }
+
+    #[test]
+    fn review_package_keeps_each_analysis_as_a_distinct_run() {
+        let merged = merge_documents([
+            json!({"runs": [{"automationDetails": {"id": "map"}}]}),
+            json!({"runs": [{"automationDetails": {"id": "impact"}}]}),
+        ]);
+
+        assert_eq!(merged["version"], "2.1.0");
+        assert_eq!(merged["runs"].as_array().unwrap().len(), 2);
+        assert_eq!(merged["runs"][0]["automationDetails"]["id"], "map");
+        assert_eq!(merged["runs"][1]["automationDetails"]["id"], "impact");
     }
 }

--- a/schemas/mastermind-evidence-attestation-v1.schema.json
+++ b/schemas/mastermind-evidence-attestation-v1.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/xcrft/mastermind/blob/main/schemas/mastermind-evidence-attestation-v1.schema.json",
+  "title": "Mastermind external evidence attestation v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "head_oid", "artifacts"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "head_oid": {
+      "type": "string",
+      "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
+    },
+    "artifacts": {
+      "type": "array",
+      "maxItems": 65,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "path", "sha256"],
+        "properties": {
+          "kind": { "enum": ["sarif", "coverage", "junit", "otel", "codeowners"] },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*//)(?!.*\\/$)[^\\u0000-\\u001f\\u007f-\\u009f\\\\]+$"
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/mastermind-review-manifest-v1.schema.json
+++ b/schemas/mastermind-review-manifest-v1.schema.json
@@ -1,0 +1,199 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/xcrft/mastermind/blob/main/schemas/mastermind-review-manifest-v1.schema.json",
+  "title": "Mastermind review package manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "package_format",
+    "generator",
+    "repository",
+    "scope",
+    "analysis",
+    "evidence_binding",
+    "artifacts",
+    "content_sha256"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "package_format": { "const": "mastermind-review" },
+    "generator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "const": "Mastermind" },
+        "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$" }
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "root_label",
+        "requested_ref",
+        "baseline_oid",
+        "head_oid",
+        "includes_worktree",
+        "includes_untracked",
+        "snapshot_token_sha256"
+      ],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "root_label": { "type": "string" },
+        "requested_ref": { "type": "string", "minLength": 1 },
+        "baseline_oid": { "$ref": "#/$defs/git_oid" },
+        "head_oid": { "$ref": "#/$defs/git_oid" },
+        "includes_worktree": { "type": "boolean" },
+        "includes_untracked": { "type": "boolean" },
+        "snapshot_token_sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "depth", "top", "production_only"],
+      "properties": {
+        "path": { "type": "string" },
+        "depth": { "type": "integer", "minimum": 1, "maximum": 5 },
+        "top": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "production_only": { "type": "boolean" }
+      }
+    },
+    "analysis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["partial", "temporal_status", "semantic_available", "evidence_partial", "states"],
+      "properties": {
+        "partial": { "type": "boolean" },
+        "temporal_status": { "enum": ["available", "unavailable"] },
+        "semantic_available": { "type": "boolean" },
+        "evidence_partial": { "type": "boolean" },
+        "states": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "state"],
+            "properties": {
+              "path": { "type": "string", "pattern": "^\\$(?:$|\\.|\\[)" },
+              "state": { "enum": ["partial", "truncated", "unavailable"] },
+              "reason": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "evidence_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "head_oid", "sources"],
+      "properties": {
+        "status": {
+          "enum": [
+            "not-applicable",
+            "digest-bound-at-export",
+            "partially-producer-attested",
+            "producer-attested"
+          ]
+        },
+        "head_oid": { "$ref": "#/$defs/git_oid" },
+        "sources": {
+          "type": "array",
+          "maxItems": 65,
+          "items": { "$ref": "#/$defs/evidence_source" }
+        },
+        "attestation": { "$ref": "#/$defs/attestation" }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": { "$ref": "#/$defs/package_artifact" },
+      "allOf": [
+        { "$ref": "#/$defs/contains_index_html" },
+        { "$ref": "#/$defs/contains_sarif" },
+        { "$ref": "#/$defs/contains_summary" },
+        { "$ref": "#/$defs/contains_workflow" }
+      ]
+    },
+    "content_sha256": { "$ref": "#/$defs/sha256" }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "git_oid": {
+      "type": "string",
+      "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
+    },
+    "evidence_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "label", "repository_relative", "sha256", "bytes", "analysis_status", "revision_binding"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "kind": { "enum": ["sarif", "coverage", "junit", "otel", "codeowners"] },
+        "label": { "type": "string", "minLength": 1 },
+        "repository_relative": { "type": "boolean" },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "bytes": { "type": "integer", "minimum": 0, "maximum": 33554432 },
+        "analysis_status": { "enum": ["loaded", "partial", "error"] },
+        "revision_binding": { "enum": ["digest-bound-at-export", "producer-attested"] }
+      }
+    },
+    "attestation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "sha256", "head_oid", "artifacts", "trust"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "head_oid": { "$ref": "#/$defs/git_oid" },
+        "artifacts": { "type": "integer", "minimum": 0, "maximum": 65 },
+        "trust": { "const": "unsigned-digest-attestation" }
+      }
+    },
+    "package_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "media_type", "sha256", "bytes"],
+      "properties": {
+        "path": {
+          "enum": ["index.html", "mastermind.sarif", "summary.md", "mastermind-review.yml"]
+        },
+        "media_type": { "type": "string", "minLength": 1 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "bytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "contains_index_html": {
+      "type": "array",
+      "contains": { "type": "object", "required": ["path"], "properties": { "path": { "const": "index.html" } } },
+      "minContains": 1,
+      "maxContains": 1
+    },
+    "contains_sarif": {
+      "type": "array",
+      "contains": { "type": "object", "required": ["path"], "properties": { "path": { "const": "mastermind.sarif" } } },
+      "minContains": 1,
+      "maxContains": 1
+    },
+    "contains_summary": {
+      "type": "array",
+      "contains": { "type": "object", "required": ["path"], "properties": { "path": { "const": "summary.md" } } },
+      "minContains": 1,
+      "maxContains": 1
+    },
+    "contains_workflow": {
+      "type": "array",
+      "contains": { "type": "object", "required": ["path"], "properties": { "path": { "const": "mastermind-review.yml" } } },
+      "minContains": 1,
+      "maxContains": 1
+    }
+  }
+}

--- a/scripts/test_audit_workflow_security.py
+++ b/scripts/test_audit_workflow_security.py
@@ -90,6 +90,41 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertEqual(audit_publication_contract_errors(self.text, self.workflow), [])
         self.assertEqual(audit_pr_contract_errors(self.pr_text, self.pr_workflow), [])
 
+    def test_review_package_workflow_is_pinned_and_fork_safe(self):
+        path = ROOT / "docs/examples/mastermind-review-pr.yml"
+        text = path.read_text(encoding="utf-8")
+        workflow = yaml.safe_load(text)
+        review = workflow["jobs"]["review"]
+        sarif_job = workflow["jobs"]["sarif"]
+        self.assertEqual(review["permissions"], {"contents": "read"})
+        self.assertEqual(
+            sarif_job["permissions"],
+            {"actions": "read", "contents": "read", "security-events": "write"},
+        )
+        self.assertEqual(sarif_job["needs"], "review")
+        uses = [step.get("uses", "") for step in review["steps"]]
+        uses.extend(step.get("uses", "") for step in sarif_job["steps"])
+        self.assertIn("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", uses)
+        self.assertIn("actions/setup-node@820762786026740c76f36085b0efc47a31fe5020", uses)
+        self.assertIn("dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4", uses)
+        self.assertIn("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", uses)
+        self.assertIn("actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", uses)
+        self.assertIn("github/codeql-action/upload-sarif@c54b30b7df092240050e69945842bc67aee0f0f4", uses)
+        self.assertEqual(
+            sarif_job["if"],
+            "github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'",
+        )
+        self.assertFalse(any("run" in step for step in sarif_job["steps"]))
+        sarif = next(step for step in sarif_job["steps"] if "upload-sarif@" in step.get("uses", ""))
+        self.assertEqual(sarif["with"]["ref"], "refs/pull/${{ github.event.pull_request.number }}/head")
+        self.assertEqual(sarif["with"]["sha"], "${{ github.event.pull_request.head.sha }}")
+        self.assertIn("github.repository == 'xcrft/mastermind'", text)
+        self.assertIn("cargo build --release --locked --manifest-path mcp/servers/mmcg/Cargo.toml", text)
+        self.assertIn("review export --help", text)
+        self.assertIn("persist-credentials: false", text)
+        self.assertIn("github.event.pull_request.head.sha", text)
+        self.assertNotIn("pull_request_target", text)
+
     def test_attempt_specific_artifact_identity_is_mandatory(self):
         changed = copy.deepcopy(self.pr_workflow)
         changed["jobs"]["audit"]["steps"][-1]["with"]["name"] = "mastermind-pr-audit"

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -914,6 +914,127 @@ def validate_executor_report_schema_contract() -> list[Issue]:
     return issues
 
 
+# ----- review evidence package -----------------------------------------
+
+def validate_review_package_contract() -> list[Issue]:
+    """Keep review export schemas, Rust implementation, and CI example aligned."""
+    issues: list[Issue] = []
+    manifest_path = REPO_ROOT / "schemas/mastermind-review-manifest-v1.schema.json"
+    attestation_path = REPO_ROOT / "schemas/mastermind-evidence-attestation-v1.schema.json"
+    for path, label, required in (
+        (
+            manifest_path,
+            "review manifest",
+            {
+                "schema_version",
+                "package_format",
+                "generator",
+                "repository",
+                "scope",
+                "analysis",
+                "evidence_binding",
+                "artifacts",
+                "content_sha256",
+            },
+        ),
+        (
+            attestation_path,
+            "evidence attestation",
+            {"schema_version", "head_oid", "artifacts"},
+        ),
+    ):
+        try:
+            schema = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            issues.append(Issue(path, "error", f"invalid {label} schema: {error}"))
+            continue
+        if schema.get("additionalProperties") is not False:
+            issues.append(Issue(path, "error", f"{label} schema must fail closed on unknown fields"))
+        if set(schema.get("required", [])) != required:
+            issues.append(Issue(path, "error", f"{label} schema required fields drifted"))
+        if schema.get("properties", {}).get("schema_version", {}).get("const") != 1:
+            issues.append(Issue(path, "error", f"{label} schema must pin version 1"))
+
+    rust_path = REPO_ROOT / "mcp/servers/mmcg/src/review_package.rs"
+    try:
+        rust = rust_path.read_text(encoding="utf-8")
+    except OSError as error:
+        issues.append(Issue(rust_path, "error", f"cannot read review exporter: {error}"))
+    else:
+        for token in (
+            "REVIEW_PACKAGE_SCHEMA: u32 = 1",
+            "EVIDENCE_ATTESTATION_SCHEMA: u32 = 1",
+            "standalone_html",
+            "mastermind.sarif",
+            "summary.md",
+            "manifest.json",
+            "mastermind-review.yml",
+            "digest-bound-at-export",
+            "producer-attested",
+            "from_json_strict",
+        ):
+            if token not in rust:
+                issues.append(Issue(rust_path, "error", f"review exporter missing {token!r}"))
+
+    workflow_path = REPO_ROOT / "docs/examples/mastermind-review-pr.yml"
+    try:
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        workflow = yaml.safe_load(workflow_text)
+    except (OSError, yaml.YAMLError) as error:
+        issues.append(Issue(workflow_path, "error", f"invalid review workflow: {error}"))
+    else:
+        package_path = REPO_ROOT / "npm/mastermind/package.json"
+        try:
+            package_version = json.loads(package_path.read_text(encoding="utf-8"))["version"]
+        except (OSError, json.JSONDecodeError, KeyError) as error:
+            issues.append(Issue(package_path, "error", f"cannot resolve review workflow version: {error}"))
+        else:
+            if f"@xcraftmind/mastermind@{package_version}" not in workflow_text:
+                issues.append(Issue(workflow_path, "error", "review workflow must pin the current npm version"))
+        for token in (
+            "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+            "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+            "dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4",
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+            "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+            "github/codeql-action/upload-sarif@c54b30b7df092240050e69945842bc67aee0f0f4",
+            "github.event.pull_request.head.sha",
+            "github.event.pull_request.base.sha",
+            "refs/pull/${{ github.event.pull_request.number }}/head",
+            "github.repository == 'xcrft/mastermind'",
+            "persist-credentials: false",
+            "review export --since",
+            "review export --help",
+            "sarif_file: mastermind-review/mastermind.sarif",
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            "github.actor != 'dependabot[bot]'",
+        ):
+            if token not in workflow_text:
+                issues.append(Issue(workflow_path, "error", f"review workflow missing {token!r}"))
+        if "pull_request_target" in workflow_text:
+            issues.append(Issue(workflow_path, "error", "review workflow must never run on pull_request_target"))
+        jobs = workflow.get("jobs", {}) if isinstance(workflow, dict) else {}
+        review = jobs.get("review", {}) if isinstance(jobs, dict) else {}
+        sarif_job = jobs.get("sarif", {}) if isinstance(jobs, dict) else {}
+        review_permissions = review.get("permissions", {}) if isinstance(review, dict) else {}
+        sarif_permissions = sarif_job.get("permissions", {}) if isinstance(sarif_job, dict) else {}
+        if review_permissions != {"contents": "read"}:
+            issues.append(Issue(workflow_path, "error", "review build job permissions must be read-only"))
+        if sarif_permissions != {"actions": "read", "contents": "read", "security-events": "write"}:
+            issues.append(Issue(workflow_path, "error", "SARIF upload job permissions must be exact and minimal"))
+        if sarif_job.get("needs") != "review" or any("run" in step for step in sarif_job.get("steps", [])):
+            issues.append(Issue(workflow_path, "error", "SARIF upload job must consume the review artifact without running pull-request code"))
+        embedded_path = REPO_ROOT / "mcp/servers/mmcg/assets/mastermind-review-pr.yml"
+        try:
+            embedded_text = embedded_path.read_text(encoding="utf-8")
+        except OSError as error:
+            issues.append(Issue(embedded_path, "error", f"cannot read embedded review workflow: {error}"))
+        else:
+            if embedded_text != workflow_text:
+                issues.append(Issue(embedded_path, "error", "embedded review workflow must match the documented example byte-for-byte"))
+    return issues
+
+
 # ----- repository workflow supply-chain contract -----------------------
 
 def validate_repository_workflow_pins() -> list[Issue]:
@@ -1402,6 +1523,7 @@ def main(argv: list[str]) -> int:
     issues.extend(validate_eval_fixture_clues())
     issues.extend(validate_workflow_eval_contract())
     issues.extend(validate_executor_report_schema_contract())
+    issues.extend(validate_review_package_contract())
     issues.extend(validate_repository_workflow_pins())
     issues.extend(validate_audit_action_security())
 


### PR DESCRIPTION
## Summary

Adds one command for producing a self-contained PR review package:

```bash
mastermind review export --since main --out mastermind-review
```

The package contains:

- an autonomous offline Lens `index.html`
- combined architecture and impact `mastermind.sarif`
- bounded reviewer `summary.md`
- strict `manifest.json` with exact revision, evidence and payload digests, plus partial/truncation states
- a pinned GitHub Actions workflow for artifact and SARIF upload

## Evidence revision binding

External SARIF, coverage, JUnit, OTLP and CODEOWNERS inputs are hashed from the exact bytes read and bound to the resolved HEAD in the manifest. Inputs are rechecked before publication and drift fails closed.

An optional strict v1 producer attestation records the stronger claim that an evidence producer generated those bytes for the same revision. The package distinguishes this from export-time digest binding instead of overstating provenance.

## Safety

- export uses the shared read-only, stale-index-safe Lens snapshot
- package publication is atomic and refuses to overwrite an existing path
- standalone HTML has embedded assets, a hash-only CSP, no network fetch and no write path
- GitHub workflow analyzes the exact PR head with read-only permissions
- SARIF upload runs separately with minimal `actions: read`, `contents: read` and `security-events: write` permissions
- forks and Dependabot do not receive the SARIF-write job

## Proof

- `just check` passed
  - 507 Rust library tests
  - 52 CLI tests
  - 20 golden tests
  - policy integration test
  - validator: 39 artifacts, 0 errors, 0 warnings
  - npm: 17 tests
  - workflow security: 37 tests
  - eval harness: 16 tests
  - Lens DOM/offline regression
  - fmt, clippy and cargo-deny
- `cargo package --locked --allow-dirty` passed and verified the packed crate
- real repository export produced all five files
- every payload SHA-256 matched an independent calculation
- generated manifest passed strict Draft 2020 JSON Schema validation
- independent change review passed with no P0-P3 findings

## Limitations

Hosted GitHub Actions and a real GitHub Code Scanning upload can only be proven by this PR run. Linux and Windows atomic-publication branches are covered by compilation/contracts but were not executed locally.

## Rollback

Revert this PR. There are no migrations, releases, remote writes or persistent data changes.