### PR TITLE
feat(mmcg): add declarative fact ingestion SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- A minimal declarative fact-ingestion SDK accepts strict
+  `mastermind-facts/v1` manifests with capability negotiation, exact repository
+  and revision binding, source/provenance digests, bounded atomic replacement,
+  normalized read-only CLI/MCP queries, and Lens evidence projection. Producers
+  cannot execute in-process code, register tools or policies, mutate the
+  codegraph topology, or access SQLite directly.
 - `mastermind temporal --since <ref>` and read-only `mmcg_temporal` compare a
   bounded Git-baseline architecture with the indexed worktree. Schema v1 covers
   component and public-boundary drift, new/resolved/membership-changed cycles, centrality and

--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ Tree-sitter evidence, keeps runtime traces as `observed`, and falls back to the
 syntactic graph when the overlay is absent or stale. Imports are bound to the
 indexed repository through SCIP `project_root` or exact embedded document text.
 
+Community analyzers can add bounded annotations and relationship evidence
+through the declarative [`mastermind-facts/v1` SDK](docs/fact-ingestion-sdk.md):
+
+```bash
+mastermind query facts --top 1          # capability and revision contract
+mastermind enrich --facts facts.json    # validate, then atomically normalize
+mastermind query facts --path src
+```
+
+Producers never run inside Mastermind and never receive SQLite, MCP-handler,
+policy-engine, or graph-mutation access. Lens reads current normalized facts;
+relationships only corroborate an existing exact file-and-line graph edge.
+
 ## Core workflows
 
 ### Map a project
@@ -140,8 +153,8 @@ monorepo review.
 Lens evidence overlays correlate the returned static trace with SARIF findings,
 LCOV/Cobertura line coverage, JUnit results, explicit OpenTelemetry code paths,
 CODEOWNERS, bounded Git churn/contributors, and exact changed-file mentions in
-indexed specs, ADRs, audits, lessons, and context. An imported SCIP overlay is
-loaded automatically and decorates only exact symbol/file endpoint matches.
+indexed specs, ADRs, audits, lessons, and context. Imported SCIP and declarative
+fact overlays are loaded automatically and decorate only exact endpoints.
 The graph topology stays unchanged: overlays add source-labelled marks and
 inspector facts rather than an opaque risk score. Lens auto-discovers
 `.github/CODEOWNERS`, `CODEOWNERS`, or `docs/CODEOWNERS`; use `--codeowners` to
@@ -173,6 +186,8 @@ the same Lens snapshot and runs offline under a hash-only CSP. The manifest
 records baseline/head OIDs, working-tree state, exact SHA-256 digests for every
 payload and external evidence input, plus every returned partial, truncated,
 or unavailable analysis state. Existing output paths are never overwritten.
+Valid declarative fact datasets carry their already-verified manifest and
+provenance digests into this package as producer-attested head bindings.
 
 Use the same repeatable `--sarif`, `--coverage`, `--junit`, and `--otel`
 options as Lens. Exact artifact bytes are always bound to the exported head.

--- a/docs/fact-ingestion-sdk.md
+++ b/docs/fact-ingestion-sdk.md
@@ -1,0 +1,152 @@
+# Declarative fact-ingestion SDK
+
+Mastermind extensions are data producers, not in-process plugins. A producer
+writes a strict, revision-bound JSON manifest; Mastermind validates the entire
+manifest and then atomically normalizes it into private SQLite tables. Lens and
+the fixed read-only `mmcg_facts` MCP tool consume those normalized facts.
+
+The public v1 schema is
+[`schemas/mastermind-facts-v1.schema.json`](../schemas/mastermind-facts-v1.schema.json).
+Its API identifier is `mastermind-facts/v1`, with two capabilities:
+`annotations` and `relationships`.
+
+## Producer flow
+
+Index the repository, then ask Mastermind for the exact contract that the
+manifest must bind:
+
+```bash
+mastermind index .
+mastermind query facts --top 1 > mastermind-facts-contract.json
+```
+
+The response contains `contract.api_version`, `contract.repository.identity`,
+`contract.repository.revision`, and `contract.supported_capabilities`. A
+producer copies the API version and exact repository values into its manifest,
+hashes every referenced source and provenance artifact, and emits facts only.
+
+```json
+{
+  "api_version": "mastermind-facts/v1",
+  "capabilities": ["annotations", "relationships"],
+  "repository": {
+    "identity": "git-remote:sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "revision": "0123456789abcdef0123456789abcdef01234567"
+  },
+  "producer": {
+    "name": "com.example.arch-lint",
+    "version": "1.4.0"
+  },
+  "dataset": "default",
+  "provenance": {
+    "kind": "static-analysis",
+    "artifacts": ["analyzer-output"]
+  },
+  "files": [
+    {
+      "path": "src/payment.rs",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1240
+    },
+    {
+      "path": "src/checkout.rs",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "bytes": 980
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "analyzer-output",
+      "path": "reports/arch-lint.json",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 4312
+    }
+  ],
+  "facts": [
+    {
+      "kind": "annotation",
+      "id": "payment-owner-boundary",
+      "path": "src/payment.rs",
+      "line": 42,
+      "severity": "warning",
+      "category": "architecture.boundary",
+      "title": "Payment ownership boundary crossed",
+      "message": "The changed function crosses the declared payment boundary."
+    },
+    {
+      "kind": "relationship",
+      "id": "checkout-to-payment",
+      "relation": "calls",
+      "from": {"path": "src/checkout.rs", "line": 18},
+      "to": {"path": "src/payment.rs", "line": 42},
+      "confidence": "high",
+      "label": "Producer-resolved checkout to payment call"
+    }
+  ]
+}
+```
+
+Import and inspect the normalized dataset:
+
+```bash
+mastermind enrich --facts mastermind-facts.json
+mastermind query facts --path src --top 400
+```
+
+The MCP equivalent is the built-in, read-only `mmcg_facts` tool with `path`
+and `top` arguments. Its bounded response includes the verified provenance
+artifact paths, sizes, and SHA-256 digests. Lens loads current facts
+automatically and shows the binding manifest digest on the producer card. Annotations appear
+as source-labelled findings; relationships may corroborate an already returned
+codegraph edge only when both file and line endpoints match. Facts never create
+or remove graph topology.
+
+`mastermind review export` carries the same normalized facts into its autonomous
+HTML and records the loaded fact-manifest and provenance-artifact digests as
+an unsigned `producer-attested` claim for the exported Git head. A surrounding
+workflow must supply any stronger identity or signature trust anchor.
+
+## Validation and replacement
+
+Before any database write, Mastermind verifies all of the following:
+
+- the exact API version, declared capability allowlist, required fields, and
+  absence of duplicate or unknown JSON fields;
+- the indexed repository identity and current 40-character Git HEAD;
+- canonical repository-relative paths with no traversal, absolute roots,
+  backslashes, control bytes, or symlinks;
+- regular-file sizes and lowercase SHA-256 digests for every referenced source
+  and provenance artifact;
+- that each source digest also matches the current codegraph index;
+- unique fact IDs, one-based locations, bounded text, supported severities and
+  confidence values, and references only to declared files and artifacts.
+
+The repository identity is a credential-free digest of the canonical origin
+host/path when a supported Git remote exists, or a digest of the canonical
+local worktree path otherwise. The manifest is capped at 16 MiB, referenced
+sources at 10,000 files and 512 MiB total, provenance at 64 artifacts, 32 MiB
+each and 256 MiB total, and facts at 100,000. Query responses expose their own
+smaller limits and explicit partial/truncation states.
+
+A successful import atomically replaces only the dataset identified by
+`producer.name` plus `dataset`. An empty `facts` array therefore clears that
+dataset while preserving its validated provenance record. If validation fails,
+the previous dataset is untouched. If HEAD, repository identity, the codegraph,
+or any bound source later changes, reads omit that source and report it as
+stale; they never silently mix revisions.
+
+## Security boundary
+
+The v1 contract deliberately has no executable extension points:
+
+- no native or in-process plugin loading;
+- no producer-defined MCP handlers;
+- no executable custom policy rules;
+- no direct SQLite access or schema migrations;
+- no native Tree-sitter grammar packs;
+- no network fetches or commands from manifest fields.
+
+Only Mastermind writes its normalized fact tables. The language registry, MCP
+tool table, policy DSL, and Tree-sitter graph remain compiled into Mastermind.
+Future community query packs, framework recognizers, and evidence importers can
+target this ingestion boundary without receiving process or database authority.

--- a/docs/integrations/generic-mcp.md
+++ b/docs/integrations/generic-mcp.md
@@ -9,7 +9,7 @@
 | transport | stdio |
 | command | `mastermind serve` |
 | protocol | MCP 2025-11-25; legacy 2024-11-05 |
-| tools | 26: 25 read-only, 1 additive local write (see below) |
+| tools | 27: 26 read-only, 1 additive local write (see below) |
 | resources | none |
 | prompts | none |
 
@@ -68,7 +68,7 @@ The `--index` flag is global and must come before `serve`.
 - Relationships and architecture: `mmcg_callers`, `mmcg_callees`,
   `mmcg_imports`, `mmcg_imported_by`, `mmcg_impact`, `mmcg_api_surface`,
   `mmcg_centrality`, `mmcg_dependency_cycles`, `mmcg_unreferenced`,
-  `mmcg_semantic`, `mmcg_map`, `mmcg_temporal`.
+  `mmcg_semantic`, `mmcg_facts`, `mmcg_map`, `mmcg_temporal`.
 - Change analysis: `mmcg_symbols_changed_since`, `mmcg_change_class`,
   `mmcg_change_impact`, `mmcg_test_impact`, `mmcg_recent_changes`.
 - Workflow state: `mmcg_tasks`, `mmcg_history`, `mmcg_status`, `mmcg_scratchpad_read`, and the

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -2,7 +2,7 @@
 
 This is the exhaustive technical reference for the mmcg engine. For the shortest path to a working installation, start with [Getting started](../getting-started.md); for the product overview, return to the [Mastermind README](../../README.md).
 
-A small Rust binary that builds a structural index of a codebase (Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, C/C++). It serves the graph over **MCP** (25 read-only tools plus one additive local scratchpad write), but MCP is only one surface. The same binary provides spec gates (`verify-spec` / `audit-spec`), project setup (`init` / `doctor`), and the user-global style miner.
+A small Rust binary that builds a structural index of a codebase (Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, C/C++). It serves the graph over **MCP** (26 read-only tools plus one additive local scratchpad write), but MCP is only one surface. The same binary provides spec gates (`verify-spec` / `audit-spec`), project setup (`init` / `doctor`), and the user-global style miner.
 
 > Installed via npm (`@xcraftmind/mastermind`)? The command is **`mastermind`** — the same binary. The `mmcg` name used throughout this doc is the cargo-installed alias (`cargo install mmcg`).
 
@@ -69,7 +69,7 @@ The Mastermind workflow needs structural queries every few seconds (planner deci
 
 mmcg is intentionally narrow:
 - Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++ — extend by adding a parser, not by depending on multi-language toolchains
-- 26 MCP tools: 25 read-only structural/semantic tools plus `mmcg_scratchpad_append`, which makes an additive write to the gitignored local index
+- 27 MCP tools: 26 read-only structural/semantic/evidence tools plus `mmcg_scratchpad_append`, which makes an additive write to the gitignored local index
 
 ## Performance model
 
@@ -112,6 +112,9 @@ mmcg index --force
 # Optionally add compiler-resolved SCIP evidence without replacing the graph.
 mmcg enrich --scip index.scip
 mmcg query semantic "scip-clang . my-package . PaymentService#charge()." --top 100
+mmcg query facts --top 1
+mmcg enrich --facts facts.json
+mmcg query facts --path src --top 400
 
 # Watch a directory and re-index on file changes (long-running, also incremental)
 mmcg watch
@@ -310,6 +313,38 @@ overlay automatically, shows its producer and precision diagnostics, and only
 decorates exact returned endpoint and display-name pairs. `mmcg map`, callers,
 impact, and all existing tools continue to work unchanged without SCIP.
 
+## Declarative fact-ingestion SDK
+
+`mmcg enrich --facts MANIFEST` accepts the public strict
+[`mastermind-facts/v1` schema](../../schemas/mastermind-facts-v1.schema.json).
+First run `mmcg query facts --top 1` to obtain the current API version,
+capability list, repository identity, and exact Git revision. Producers may
+declare bounded `annotations` and `relationships`; they must bind every source
+and provenance artifact to a canonical repository-relative path, byte size,
+and SHA-256 digest.
+
+Mastermind validates the complete manifest before an atomic per-producer,
+per-dataset replacement. Unknown/duplicate fields, unsupported capabilities,
+path traversal, symlinks, digest/size mismatch, repository/revision mismatch,
+or stale codegraph files fail before the previous dataset is touched. Later
+source or revision drift makes the source explicitly stale and suppresses its
+facts. Import is capped at 16 MiB per manifest, 10,000 referenced files and 512
+MiB of source bytes, 64 provenance artifacts and 256 MiB of artifact bytes, and
+100,000 facts.
+
+`mmcg query facts --path PATH --top N` and the fixed read-only `mmcg_facts` MCP
+tool expose the same normalized snapshot, bounded provenance-artifact digests,
+and explicit limits. Lens projects
+annotations as source-labelled findings. A relationship may decorate an
+existing returned codegraph edge only when both file and line endpoints match;
+it cannot create topology.
+
+The manifest is data only. It cannot load native code, register MCP handlers,
+define executable policy rules, modify the language registry or graph, install
+a Tree-sitter grammar, execute a command, or access SQLite. Only Mastermind
+writes the private normalized tables. See the complete
+[producer guide and security model](../fact-ingestion-sdk.md).
+
 ## Temporal Graph (`mmcg temporal`)
 
 `mmcg temporal --since REF` compares the indexed working copy with a resolved
@@ -404,6 +439,9 @@ evidence:
   configurable with `--git-commits 0..1000` (`0` disables Git history).
 - the repository's persisted SCIP overlay, when present and fresh. It is not a
   UI flag or report path; import it first with `mmcg enrich --scip index.scip`.
+- current normalized declarative facts, when present. Import them first with
+  `mmcg enrich --facts MANIFEST`; stale repository, revision, or source bindings
+  are omitted with a diagnostic.
 
 Evidence is matched only to files already returned by the bounded change,
 impact, and candidate-test trace. The versioned `evidence` response includes
@@ -434,7 +472,8 @@ uses the base-branch file. Git history is pinned to the impact snapshot's HEAD
 and does not follow renames.
 
 The UI renders redundant text and visual marks for SARIF, coverage, JUnit,
-SCIP, runtime spans, project knowledge, ownership, and churn. Exact SCIP
+SCIP, normalized declarative facts, runtime spans, project knowledge,
+ownership, and churn. Exact SCIP
 symbol/file endpoint pairs supersede Tree-sitter as static provenance without
 changing the returned graph. Runtime parent-child
 file pairs may decorate an already returned static edge in either direction,
@@ -483,6 +522,16 @@ The manifest records their SHA-256 digests next to the resolved head OID. This
 is a **digest binding at export time**: it proves exactly which report bytes a
 reviewer saw at that revision, not that Semgrep, CodeQL, a test runner, or an
 OTel collector produced those bytes from that revision.
+
+Loaded `mastermind-facts/v1` datasets need no second sidecar attestation: their
+ingestion contract already verified exact repository identity, Git head, source
+digests, and provenance-artifact digests before Mastermind wrote normalized
+facts. The package therefore records the fact-manifest and returned provenance
+digests as unsigned `producer-attested` bindings and embeds the same normalized
+facts in the autonomous Lens HTML. A surrounding workflow must supply any
+stronger identity or signature trust anchor. A stale or truncated fact source
+remains an explicit partial state and is never promoted to a revision-bound
+claim.
 
 For the stronger producer claim, create a strict JSON attestation and pass
 `--evidence-attestation PATH`:
@@ -691,6 +740,7 @@ Run `mmcg watch` in a separate terminal so the index stays current while you wor
 | `mmcg_api_surface` | `prefix`, optional `language` | Symbols under `prefix` referenced from at least one file OUTSIDE `prefix`. Empirical "who-uses-this-module" map; doesn't need declared visibility. |
 | `mmcg_centrality` | optional `prefix`, `language`, `kind`, `top` (default 20) | Rank symbols by in-degree (distinct callers). Pre-flight "where is the gravity" — top hits are the structural attractors of the codebase or a subdirectory. Use to learn what to read first on unfamiliar code. Excludes synthetic `<module>` rows and zero-degree symbols. |
 | `mmcg_semantic` | `symbol`, optional `top` (default 100, max 500) | Compiler-resolved SCIP definitions, references, implementations, type definitions, and explicit provenance. Returns `fallback_active: true` instead of an error when no overlay exists. Stale document facts are omitted with diagnostics. |
+| `mmcg_facts` | optional `path` (default `.`), `top` (default 100, max 400) | Normalized `mastermind-facts/v1` annotations and relationships plus capability negotiation, exact repository/revision identity, provenance, source state, limits, and stale/truncation diagnostics. Read-only; it never loads producer code or creates graph topology. |
 | `mmcg_map` | optional `path` (default `.`), `depth` (1–6, default 2), `top` (1–100, default 20), `production_only` (default `false`) | Schema-v1 architecture briefing with lexical file/directory scope: `%` and `_` are literal bytes, selected-directory components are relative to that directory, root components remain repository-relative, and selected files retain their paths. `production_only` excludes conventional test/fixture/example/generated/vendor path segments and test filenames (`test_*`, `*_test.*`, `*.test.*`, `*.spec.*`, `*Test.*`, `*Tests.*`) before bounded queries run. Hotspots prefer unambiguous definitions before pooled same-name collisions. JSON, text, Mermaid, and CLI SARIF are projections of the same result; Mermaid includes component counts/languages, boundaries, hotspots, and cycle rings, while SARIF exports returned cycles as architecture findings. Caps are 50,000 aggregation paths, 20 languages, 20 components, 20 boundaries/component and 400 globally, 50 entry points, 100 hotspots, 50,000 scoped cycle edges, 50 cycles, and 500 cycle memberships. `path_work_limit` marks path-derived partial aggregates; `top_probe` marks a hotspot or per-component boundary cap+1 probe; `global_probe_limit` marks components whose certainty was prevented by the 401st global boundary row; cycle `work_limit` returns no cycles because SCC analysis was skipped before truncated edges could be analyzed. |
 | `mmcg_temporal` | `since`, optional `root`, `path` (default `.`), `depth` (1–5, default 2), `top` (1–100, default 20), `production_only`, `codeowners` | Schema-v1 base-vs-indexed-worktree architecture delta. It rewinds changed Git blobs only in a private SQLite snapshot and reports components, public boundaries/API, cycles, centrality/hotspot drift, base/head CODEOWNERS changes, exact history review candidates, provenance, limits, and partial diagnostics. A truncated 10,000-file change set fails closed. |
 | `mmcg_change_impact` | `since`, optional `root`, `depth` (1–5), `top` (1–500) | Stable schema-v1 analysis of the resolved baseline against staged, unstaged, and untracked content. Reports added/removed/signature/body-changed symbols, batched transitive callers, component crossings, ranked test candidates, a `disciplines` block routing the change to an evidence set, exact collection metadata, caps, and precision notes. Root, SHA-256 index freshness, Git snapshot, and SQLite snapshot checks fail closed with stable codes. |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -7,4 +7,4 @@
 ### servers/
 | Server | Transport | Description |
 |---|---|---|
-| [`mmcg`](servers/mmcg/README.md) | stdio | Mastermind Codegraph — 26 MCP tools: 25 read-only structural/semantic tools plus one additive local scratchpad write, over a local SQLite index. Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Truth layer for the Mastermind workflow. |
+| [`mmcg`](servers/mmcg/README.md) | stdio | Mastermind Codegraph — 27 MCP tools: 26 read-only structural/semantic/evidence tools plus one additive local scratchpad write, over a local SQLite index. Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Truth layer for the Mastermind workflow. |

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -60,6 +60,7 @@ SQLite and tree-sitter are bundled. No system SQLite or parser libraries are req
 cd your-project
 mmcg index .
 mmcg enrich --scip index.scip # optional compiler-resolved overlay
+mmcg enrich --facts facts.json # optional declarative fact overlay
 mmcg status
 mmcg map .
 mmcg impact --since main
@@ -95,6 +96,7 @@ See the [client integration guides](https://github.com/xcrft/mastermind/tree/mai
 |---|---|
 | Symbol graph | Search, callers, callees, imports, outlines, API surface |
 | Semantic overlay | Optional SCIP definitions, references, implementations, and provenance |
+| Extension facts | Revision-bound declarative annotations and relationships with no plugin execution |
 | Architecture | Project map, temporal drift, centrality, dependency cycles, unreferenced candidates |
 | Change analysis | Git-aware symbol changes, blast radius, component crossings |
 | Review evidence | Read-only diff-first Lens plus autonomous HTML/SARIF/summary packages with revision and evidence digests |
@@ -102,7 +104,7 @@ See the [client integration guides](https://github.com/xcrft/mastermind/tree/mai
 | Workflow gates | `verify-spec`, `audit-spec`, and `run-task` |
 | Local coordination | Bounded additive scratchpad and indexed project history |
 
-The MCP surface contains 25 read-only tools and one additive local scratchpad
+The MCP surface contains 26 read-only tools and one additive local scratchpad
 write. Results are bounded and return precision or truncation notes when the
 engine cannot prove completeness.
 
@@ -139,6 +141,16 @@ Tree-sitter topology and no-toolchain fallback. Embedded SCIP document text is
 verified when available; `project_root` must identify this repository unless
 every document embeds matching text. Later source changes suppress stale
 semantic facts.
+
+`mmcg enrich --facts facts.json` is the safe community-extension boundary. A
+strict [`mastermind-facts/v1`](https://github.com/xcrft/mastermind/blob/main/docs/fact-ingestion-sdk.md)
+manifest declares capabilities and binds every source/provenance artifact to
+the exact repository identity, Git revision, byte size, and SHA-256 digest.
+Mastermind validates the whole manifest before atomically replacing one
+producer dataset in private normalized tables. `query facts`, the fixed
+read-only `mmcg_facts` tool, and Lens can read it; producers cannot load native
+code, register MCP handlers or policy rules, change graph topology, or access
+SQLite directly.
 
 ## Reference
 

--- a/mcp/servers/mmcg/assets/lens/app.js
+++ b/mcp/servers/mmcg/assets/lens/app.js
@@ -10,7 +10,7 @@
   const CONNECTED_PER_LANE = 5;
   const MOBILE_CANDIDATES_PER_PAGE = 5;
   const MOBILE_CONNECTED_PER_LANE = 2;
-  const OVERLAY_KEYS = ["findings", "coverage", "ownership", "churn", "tests", "semantic", "runtime", "knowledge"];
+  const OVERLAY_KEYS = ["findings", "coverage", "ownership", "churn", "tests", "semantic", "runtime", "facts", "knowledge"];
 
   const state = {
     raw: null,
@@ -131,6 +131,23 @@
     const reverse = semanticFromFile === toFile && semanticToFile === fromFile
       && semanticFromName === toName && semanticToName === fromName
       && semanticFromLine === toLine && semanticToLine === fromLine;
+    return direct || reverse;
+  }
+
+  function factMatchesGraphEdge(value, edge) {
+    const fact = record(value);
+    const fromFile = text(edge.from.symbol.file, "");
+    const toFile = text(edge.to.symbol.file, "");
+    const fromLine = finiteNumber(edge.from.symbol.line);
+    const toLine = finiteNumber(edge.to.symbol.line);
+    const factFromFile = text(fact.from_path, "");
+    const factToFile = text(fact.to_path, "");
+    const factFromLine = finiteNumber(fact.from_line);
+    const factToLine = finiteNumber(fact.to_line);
+    const direct = factFromFile === fromFile && factToFile === toFile
+      && factFromLine === fromLine && factToLine === toLine;
+    const reverse = factFromFile === toFile && factToFile === fromFile
+      && factFromLine === toLine && factToLine === fromLine;
     return direct || reverse;
   }
 
@@ -342,7 +359,7 @@
     }
     const signals = [];
     if (overlayEnabled("findings") && evidence.findings.length > 0) {
-      signals.push(evidence.findings.length + " file-level SARIF finding" + (evidence.findings.length === 1 ? "" : "s"));
+      signals.push(evidence.findings.length + " file-level finding" + (evidence.findings.length === 1 ? "" : "s"));
     }
     if (overlayEnabled("coverage") && evidence.coverage) {
       signals.push(coverageLabel(evidence.coverage));
@@ -422,6 +439,8 @@
     const evidenceFiles = collection(evidence.files);
     const evidenceDiagnostics = collection(evidence.diagnostics);
     const runtimeEdges = collection(evidence.runtime_edges);
+    const factArtifacts = collection(evidence.fact_artifacts);
+    const factRelationships = collection(evidence.fact_relationships);
     const semanticEdges = collection(semantic.edges);
     const evidenceByPath = new Map();
     evidenceFiles.items.map(normalizeFileEvidence).forEach(function (item) {
@@ -546,6 +565,9 @@
       edge.semanticEvidence = semanticEdges.items.map(record).filter(function (semanticEdge) {
         return semanticMatchesGraphEdge(semanticEdge, edge);
       });
+      edge.factEvidence = factRelationships.items.map(record).filter(function (fact) {
+        return factMatchesGraphEdge(fact, edge);
+      });
     });
 
     const componentRows = buildComponentRows(
@@ -598,6 +620,8 @@
       evidenceFiles: evidenceFiles,
       evidenceDiagnostics: evidenceDiagnostics,
       runtimeEdges: runtimeEdges,
+      factArtifacts: factArtifacts,
+      factRelationships: factRelationships,
       semanticEdges: semanticEdges,
       evidenceByPath: evidenceByPath,
       nodes: nodes,
@@ -766,6 +790,8 @@
       ["Map cycles", map.cycles],
       ["Evidence files", evidence.files],
       ["Runtime evidence edges", evidence.runtime_edges],
+      ["Normalized fact provenance", evidence.fact_artifacts],
+      ["Normalized fact relationships", evidence.fact_relationships],
       ["Evidence diagnostics", evidence.diagnostics],
       ["SCIP semantic definitions", semantic.definitions],
       ["SCIP semantic edges", semantic.edges],
@@ -1305,6 +1331,7 @@
   function renderEvidenceSources() {
     clearNode(elements.evidenceSourceList);
     const sources = state.model.evidenceSources.items.map(record);
+    const factArtifacts = state.model.factArtifacts.items.map(record);
     const semantic = record(state.model.semantic);
     const semanticSource = isRecord(semantic.source) ? record(semantic.source) : null;
     const sourceCount = sources.length + (semanticSource ? 1 : 0);
@@ -1325,12 +1352,22 @@
         matchedPaths.add(to);
       }
     });
+    state.model.factRelationships.items.map(record).forEach(function (relationship) {
+      const from = text(relationship.from_path, "");
+      const to = text(relationship.to_path, "");
+      if (from) {
+        matchedPaths.add(from);
+      }
+      if (to) {
+        matchedPaths.add(to);
+      }
+    });
     const matchedFiles = matchedPaths.size;
     elements.evidenceSummary.textContent = sourceCount === 0
       ? "No external evidence sources loaded; the static graph remains available."
       : sourceCount + " source" + (sourceCount === 1 ? "" : "s") + " · " + matchedFiles + " matched trace file" + (matchedFiles === 1 ? "" : "s") + ((record(state.model.evidence).partial === true || semantic.partial === true) ? " · partial" : "");
     if (sourceCount === 0) {
-      elements.evidenceSourceList.appendChild(createElement("p", "evidence-source-list__empty", "Use mastermind enrich --scip index.scip or pass external evidence flags to add corroborating facts."));
+      elements.evidenceSourceList.appendChild(createElement("p", "evidence-source-list__empty", "Use mastermind enrich --scip index.scip, enrich --facts facts.json, or external evidence flags to add corroborating facts."));
       return;
     }
     if (semanticSource) {
@@ -1351,6 +1388,27 @@
       const total = finiteNumber(source.facts_total);
       const facts = displayNumber(returned) + " facts" + (total === null ? "" : " / " + displayNumber(total)) + " · " + displayNumber(finiteNumber(source.files_matched)) + " files";
       card.appendChild(createElement("span", "evidence-source__facts", facts));
+      if (text(source.kind, "") === "facts") {
+        const artifactCount = factArtifacts.filter(function (artifact) {
+          return text(artifact.source_id, "") === text(source.id, "");
+        }).length;
+        card.appendChild(createElement(
+          "span",
+          "evidence-source__facts",
+          artifactCount + " provenance artifact" + (artifactCount === 1 ? "" : "s")
+        ));
+      }
+      const digest = text(source.artifact_sha256, "");
+      if (digest) {
+        const digestLabel = text(source.kind, "") === "facts" ? "manifest sha256 " : "artifact sha256 ";
+        const identity = createElement(
+          "span",
+          "evidence-source__facts",
+          digestLabel + digest.slice(0, 12) + "… · " + displayNumber(finiteNumber(source.artifact_bytes)) + " bytes"
+        );
+        identity.setAttribute("title", digest);
+        card.appendChild(identity);
+      }
       elements.evidenceSourceList.appendChild(card);
     });
   }
@@ -2383,9 +2441,10 @@
     const boundary = edge.crossing ? ", boundary crossing" : "";
     const ownership = overlayEnabled("ownership") && edge.ownershipBoundary ? ", ownership boundary" : "";
     const runtime = overlayEnabled("runtime") && edge.runtimeEvidence.length > 0 ? ", runtime trace corroborated" : "";
+    const facts = overlayEnabled("facts") && edge.factEvidence.length > 0 ? ", normalized fact corroborated" : "";
     const semantic = overlayEnabled("semantic") && edge.semanticEvidence.length > 0 ? ", SCIP compiler-resolved, high confidence" : ", Tree-sitter syntactic, medium confidence";
     return relation + " from " + text(edge.from.symbol.name, "unnamed seed")
-      + " to " + text(edge.to.symbol.name, "unnamed claim") + boundary + ownership + semantic + runtime + ". Select for details.";
+      + " to " + text(edge.to.symbol.name, "unnamed claim") + boundary + ownership + semantic + runtime + facts + ". Select for details.";
   }
 
   function drawEdge(layer, edge, from, to, mobile, width) {
@@ -2411,6 +2470,9 @@
     }
     if (overlayEnabled("semantic") && edge.semanticEvidence.length > 0) {
       classes.push("graph-edge--semantic");
+    }
+    if (overlayEnabled("facts") && edge.factEvidence.length > 0) {
+      classes.push("graph-edge--facts");
     }
     if (state.selectedId === edge.id) {
       classes.push("is-selected");
@@ -2798,7 +2860,7 @@
         return text(finding.level, "warning").toUpperCase() + " · " + text(finding.tool, "SARIF") + " / " + text(finding.rule_id, "unclassified") + location + " · " + text(finding.message, "No message returned");
       });
       if (findings.length > 0) {
-        appendClaimList("SARIF findings · file-level", findings, "risk", "No matching findings returned.");
+        appendClaimList("Findings · file-level", findings, "risk", "No matching findings returned.");
       }
     }
     if (overlayEnabled("coverage") && evidence.coverage) {
@@ -2901,6 +2963,7 @@
       ["Boundary crossing", edge.crossing ? "Observed" : "Not returned"],
       ["Ownership boundary", overlayEnabled("ownership") && edge.ownershipBoundary ? "Observed from CODEOWNERS" : "Not returned"],
       ["Runtime trace", overlayEnabled("runtime") && edge.runtimeEvidence.length > 0 ? "Corroborated" : "Not returned"],
+      ["Normalized facts", overlayEnabled("facts") && edge.factEvidence.length > 0 ? "Corroborated" : "Not returned"],
     ]);
     appendClaimList("Evidence endpoints", [
       "FROM · " + text(edge.from.symbol.name, "unnamed") + " · " + text(edge.from.symbol.file, "file unavailable") + formatLine(edge.from.symbol.line),
@@ -2954,6 +3017,38 @@
         }),
         "semantic",
         "No matching SCIP edge returned."
+      );
+    }
+    if (overlayEnabled("facts") && edge.factEvidence.length > 0) {
+      appendClaimList(
+        "Normalized relationship facts",
+        edge.factEvidence.map(function (value) {
+          const fact = record(value);
+          return text(fact.relation, "relationship") + " · "
+            + text(fact.from_path, "file unavailable") + formatLine(fact.from_line)
+            + " → " + text(fact.to_path, "file unavailable") + formatLine(fact.to_line)
+            + " · " + text(fact.confidence, "unknown confidence")
+            + " · " + text(fact.label, "No label returned")
+            + " · " + text(fact.source_id, "unknown source");
+        }),
+        "facts",
+        "No matching normalized relationship facts returned."
+      );
+      const sourceIds = new Set(edge.factEvidence.map(function (value) {
+        return text(record(value).source_id, "");
+      }));
+      appendClaimList(
+        "Normalized fact provenance",
+        state.model.factArtifacts.items.map(record).filter(function (artifact) {
+          return sourceIds.has(text(artifact.source_id, ""));
+        }).map(function (artifact) {
+          return text(artifact.id, "artifact") + " · "
+            + text(artifact.path, "path unavailable") + " · sha256 "
+            + text(artifact.sha256, "unknown digest") + " · "
+            + displayNumber(finiteNumber(artifact.bytes)) + " bytes";
+        }),
+        "facts",
+        "No normalized provenance artifacts returned."
       );
     }
     elements.inspector.appendChild(createElement(

--- a/mcp/servers/mmcg/assets/lens/app.test.cjs
+++ b/mcp/servers/mmcg/assets/lens/app.test.cjs
@@ -8,6 +8,7 @@ const vm = require("node:vm");
 const APP_SOURCE = fs.readFileSync(path.join(__dirname, "app.js"), "utf8");
 const HTML_SOURCE = fs.readFileSync(path.join(__dirname, "index.html"), "utf8");
 const CSS_SOURCE = fs.readFileSync(path.join(__dirname, "styles.css"), "utf8");
+const FACT_SOURCE_ID = "facts:sha256:" + "f".repeat(64);
 
 class TokenList {
   constructor() {
@@ -214,7 +215,7 @@ function createDocument() {
     button.setAttribute("data-scope", scope);
     return button;
   });
-  const overlayButtons = ["findings", "coverage", "ownership", "churn", "tests", "semantic", "runtime", "knowledge"].map((overlay) => {
+  const overlayButtons = ["findings", "coverage", "ownership", "churn", "tests", "semantic", "runtime", "facts", "knowledge"].map((overlay) => {
     const button = new MockElement("button");
     button.dataset.overlay = overlay;
     button.setAttribute("data-overlay", overlay);
@@ -338,8 +339,8 @@ function fixture() {
       schema_version: 1,
       partial: false,
       sources: {
-        total: 7,
-        returned: 7,
+        total: 8,
+        returned: 8,
         truncated: false,
         items: [
           { id: "sarif:0", kind: "sarif", label: "semgrep.sarif", status: "loaded", facts_total: 1, facts_returned: 1, files_matched: 1 },
@@ -349,6 +350,7 @@ function fixture() {
           { id: "junit:0", kind: "junit", label: "junit.xml", status: "loaded", facts_total: 1, facts_returned: 1, files_matched: 1 },
           { id: "otel:0", kind: "otel", label: "traces.json", status: "loaded", facts_total: 2, facts_returned: 2, files_matched: 2 },
           { id: "project-knowledge", kind: "project_knowledge", label: "Indexed project knowledge", status: "loaded", facts_total: 1, facts_returned: 1, files_matched: 1 },
+          { id: FACT_SOURCE_ID, kind: "facts", label: "com.example.arch-lint 1.4.0 · default", status: "loaded", facts_total: 3, facts_returned: 3, files_matched: 2, artifact_sha256: "a".repeat(64), artifact_bytes: 1024 },
         ],
       },
       files: {
@@ -358,7 +360,10 @@ function fixture() {
         items: [
           {
             path: "src/auth.rs",
-            findings: [{ source_id: "sarif:0", tool: "Semgrep", rule_id: "auth.bypass", level: "error", message: "Authorization result is ignored", line: 42, column: 3 }],
+            findings: [
+              { source_id: "sarif:0", tool: "Semgrep", rule_id: "auth.bypass", level: "error", message: "Authorization result is ignored", line: 42, column: 3 },
+              { source_id: FACT_SOURCE_ID, tool: "com.example.arch-lint", rule_id: "architecture.boundary", level: "warning", message: "Payment boundary crossed", line: 42, column: 3 },
+            ],
             coverage: { source_ids: ["coverage:0"], lines_found: 2, lines_hit: 1 },
             ownership: { codeowners_source_id: "codeowners", codeowners: ["@security"], contributors: [{ name: "Alice", commits: 2 }] },
             churn: { commits: 2, lines_added: 7, lines_deleted: 3 },
@@ -399,8 +404,51 @@ function fixture() {
           spans: 1, traces: 1, span_names: ["authorize_target"], names_truncated: false,
         }],
       },
+      fact_artifacts: {
+        total: 1,
+        returned: 1,
+        truncated: false,
+        items: [{
+          source_id: FACT_SOURCE_ID,
+          id: "arch-lint-output",
+          path: "reports/arch-lint.json",
+          sha256: "b".repeat(64),
+          bytes: 4312,
+        }],
+      },
+      fact_relationships: {
+        total: 2,
+        returned: 2,
+        truncated: false,
+        items: [
+          {
+            source_id: FACT_SOURCE_ID,
+            fact_id: "architecture.auth-to-target",
+            relation: "calls",
+            from_path: "src/auth.rs",
+            from_line: 42,
+            from_column: 3,
+            to_path: "src/target.rs",
+            to_line: 7,
+            to_column: 1,
+            confidence: "high",
+            label: "Compiler-resolved auth to target call",
+          },
+          {
+            source_id: FACT_SOURCE_ID,
+            fact_id: "architecture.unrelated-lines",
+            relation: "calls",
+            from_path: "src/auth.rs",
+            from_line: 999,
+            to_path: "src/target.rs",
+            to_line: 998,
+            confidence: "high",
+            label: "Wrong-line relationship must not decorate the edge",
+          },
+        ],
+      },
       diagnostics: { total: 0, returned: 0, truncated: false, items: [] },
-      limits: { artifact_bytes: 33554432, artifact_sources: 64, relevant_files: 1000, findings: 5000, findings_per_file: 100, coverage_lines: 500000, test_cases: 100000, runtime_spans: 100000, runtime_edges: 1000, knowledge_matches: 500, codeowner_rules: 50000, codeowners_bytes: 3145728, owners_per_rule: 50, contributors_per_file: 5, diagnostics: 100, git_commits: 200 },
+      limits: { artifact_bytes: 33554432, artifact_sources: 64, relevant_files: 1000, findings: 5000, findings_per_file: 100, coverage_lines: 500000, test_cases: 100000, runtime_spans: 100000, runtime_edges: 1000, normalized_fact_sources: 64, normalized_fact_artifacts: 64, normalized_fact_relationships: 200, knowledge_matches: 500, codeowner_rules: 50000, codeowners_bytes: 3145728, owners_per_rule: 50, contributors_per_file: 5, diagnostics: 100, git_commits: 200 },
     },
     map: {
       scope: { aggregation_paths_truncated: false },
@@ -541,8 +589,8 @@ async function main() {
   );
 
   const harness = await renderFixture();
-  assert.match(harness.nodes.get("evidence-summary").textContent, /8 sources · 3 matched trace files/i);
-  assert.equal(harness.nodes.get("evidence-source-list").querySelectorAll(".evidence-source").length, 8);
+  assert.match(harness.nodes.get("evidence-summary").textContent, /9 sources · 3 matched trace files/i);
+  assert.equal(harness.nodes.get("evidence-source-list").querySelectorAll(".evidence-source").length, 9);
   assert.match(harness.nodes.get("evidence-source-list").textContent, /repository verified/i);
   assert.match(harness.nodes.get("temporal-summary").textContent, /Architecture drift detected/i);
   assert.equal(harness.nodes.get("temporal-components").textContent, "+1 −1 ~0");
@@ -598,9 +646,15 @@ async function main() {
     1,
     "An exact SCIP symbol, file, and definition-line pair must upgrade static provenance"
   );
+  assert.equal(
+    harness.nodes.get("trace-graph").querySelectorAll(".graph-edge--facts").length,
+    1,
+    "A normalized relationship may decorate only the existing exact-endpoint edge"
+  );
   const changedInspector = harness.nodes.get("inspector-body").textContent;
-  assert.match(changedInspector, /SARIF findings · file-level/i);
+  assert.match(changedInspector, /Findings · file-level/i);
   assert.match(changedInspector, /Semgrep \/ auth\.bypass:42:3/i);
+  assert.match(changedInspector, /com\.example\.arch-lint \/ architecture\.boundary:42:3/i);
   assert.match(changedInspector, /50% reported lines covered \(1\/2\)/i);
   assert.match(changedInspector, /CODEOWNERS · @security/i);
   assert.match(changedInspector, /Git contributor · Alice · 2 commits/i);
@@ -610,12 +664,16 @@ async function main() {
   assert.match(changedInspector, /1 spans · 1 traces/i);
   assert.match(changedInspector, /Project knowledge · exact path/i);
   assert.match(changedInspector, /architecture_decision · Auth boundary/i);
+  assert.match(
+    harness.nodes.get("evidence-source-list").textContent,
+    /manifest sha256 a{12}… · 1,?024 bytes/i
+  );
   const nodeCountBeforeToggle = harness.nodes.get("trace-graph").querySelectorAll("[data-node-id]").length;
   const edgeCountBeforeToggle = harness.nodes.get("trace-graph").querySelectorAll("[data-edge-id]").length;
   const findings = harness.overlayButtons.find((button) => button.dataset.overlay === "findings");
   findings.dispatch("click");
   assert.equal(findings.getAttribute("aria-pressed"), "false");
-  assert.doesNotMatch(harness.nodes.get("inspector-body").textContent, /SARIF findings/i);
+  assert.doesNotMatch(harness.nodes.get("inspector-body").textContent, /Findings · file-level/i);
   assert.equal(
     harness.nodes.get("trace-graph").querySelectorAll("[data-node-id]").length,
     nodeCountBeforeToggle,
@@ -638,6 +696,18 @@ async function main() {
   assert.match(harness.nodes.get("inspector-body").textContent, /reference at src\/target\.rs:9/i);
   assert.match(harness.nodes.get("inspector-body").textContent, /Runtime trace corroboration/i);
   assert.match(harness.nodes.get("inspector-body").textContent, /src\/auth\.rs → src\/target\.rs/i);
+  assert.match(harness.nodes.get("inspector-body").textContent, /Normalized relationship facts/i);
+  assert.match(harness.nodes.get("inspector-body").textContent, /Compiler-resolved auth to target call/i);
+  assert.match(harness.nodes.get("inspector-body").textContent, /facts:sha256:[0-9a-f]{64}/i);
+  assert.match(harness.nodes.get("inspector-body").textContent, /arch-lint-output · reports\/arch-lint\.json · sha256 b{64} · 4,?312 bytes/i);
+  assert.doesNotMatch(harness.nodes.get("inspector-body").textContent, /Wrong-line relationship/i);
+  const facts = harness.overlayButtons.find((button) => button.dataset.overlay === "facts");
+  const factEdgeCount = harness.nodes.get("trace-graph").querySelectorAll("[data-edge-id]").length;
+  facts.dispatch("click");
+  assert.equal(facts.getAttribute("aria-pressed"), "false");
+  assert.equal(harness.nodes.get("trace-graph").querySelectorAll(".graph-edge--facts").length, 0);
+  assert.equal(harness.nodes.get("trace-graph").querySelectorAll("[data-edge-id]").length, factEdgeCount);
+  facts.dispatch("click");
   const semantic = harness.overlayButtons.find((button) => button.dataset.overlay === "semantic");
   const semanticEdgeCount = harness.nodes.get("trace-graph").querySelectorAll("[data-edge-id]").length;
   semantic.dispatch("click");

--- a/mcp/servers/mmcg/assets/lens/index.html
+++ b/mcp/servers/mmcg/assets/lens/index.html
@@ -157,13 +157,14 @@
           <p id="evidence-summary">No external evidence sources loaded yet.</p>
         </div>
         <div class="overlay-control" role="group" aria-label="Visible evidence overlay types">
-          <button type="button" data-overlay="findings" aria-pressed="true" disabled>SARIF</button>
+          <button type="button" data-overlay="findings" aria-pressed="true" disabled>Findings</button>
           <button type="button" data-overlay="coverage" aria-pressed="true" disabled>Coverage</button>
           <button type="button" data-overlay="ownership" aria-pressed="true" disabled>Ownership</button>
           <button type="button" data-overlay="churn" aria-pressed="true" disabled>Churn</button>
           <button type="button" data-overlay="tests" aria-pressed="true" disabled>JUnit</button>
           <button type="button" data-overlay="semantic" aria-pressed="true" disabled>SCIP</button>
           <button type="button" data-overlay="runtime" aria-pressed="true" disabled>Runtime</button>
+          <button type="button" data-overlay="facts" aria-pressed="true" disabled>Facts</button>
           <button type="button" data-overlay="knowledge" aria-pressed="true" disabled>Knowledge</button>
         </div>
         <div class="evidence-source-list" id="evidence-source-list">

--- a/mcp/servers/mmcg/assets/lens/styles.css
+++ b/mcp/servers/mmcg/assets/lens/styles.css
@@ -1209,6 +1209,12 @@ body.is-refreshing .refresh-button__glyph {
   stroke-width: 3.5;
 }
 
+.graph-edge--facts {
+  filter: drop-shadow(0 0 2px rgba(147, 91, 38, 0.72));
+  stroke-dasharray: 9 3;
+  stroke-width: 3.5;
+}
+
 .graph-edge-hit {
   fill: none;
   stroke: transparent;

--- a/mcp/servers/mmcg/src/commands/query.rs
+++ b/mcp/servers/mmcg/src/commands/query.rs
@@ -569,6 +569,9 @@ fn execute(store: &Store, q: QueryCmd) -> Result<Value, Box<dyn std::error::Erro
         QueryCmd::Semantic { symbol, top } => {
             serde_json::to_value(mmcg::scip_overlay::query(store, &symbol, top)?)?
         }
+        QueryCmd::Facts { path, top } => {
+            serde_json::to_value(mmcg::facts::snapshot(store, &path, top as usize)?)?
+        }
     })
 }
 

--- a/mcp/servers/mmcg/src/evidence.rs
+++ b/mcp/servers/mmcg/src/evidence.rs
@@ -71,6 +71,8 @@ pub struct EvidenceSnapshot {
     pub sources: EvidenceCollection<EvidenceSource>,
     pub files: EvidenceCollection<FileEvidence>,
     pub runtime_edges: EvidenceCollection<RuntimeEdgeEvidence>,
+    pub fact_artifacts: EvidenceCollection<crate::facts::FactArtifact>,
+    pub fact_relationships: EvidenceCollection<crate::facts::FactRelationship>,
     pub diagnostics: EvidenceCollection<EvidenceDiagnostic>,
     pub precision_notes: Vec<EvidencePrecisionNote>,
     pub limits: EvidenceLimits,
@@ -242,6 +244,9 @@ pub struct EvidenceLimits {
     pub runtime_spans: u32,
     pub runtime_edges: u32,
     pub runtime_names_per_edge: u32,
+    pub normalized_fact_sources: u32,
+    pub normalized_fact_artifacts: u32,
+    pub normalized_fact_relationships: u32,
     pub knowledge_matches: u32,
     pub knowledge_per_file: u32,
     pub knowledge_artifacts: u32,
@@ -323,6 +328,10 @@ struct Collector<'a> {
     runtime_span_count: usize,
     runtime_edges: BTreeMap<(String, String), RuntimeEdgeAccumulator>,
     runtime_edges_truncated: bool,
+    fact_artifacts: Vec<crate::facts::FactArtifact>,
+    fact_artifacts_truncated: bool,
+    fact_relationships: Vec<crate::facts::FactRelationship>,
+    fact_relationships_truncated: bool,
     knowledge_match_count: usize,
     deadline: Option<Instant>,
     artifact_identities: HashMap<String, (String, u64)>,
@@ -416,7 +425,7 @@ pub fn collect_with_extensions(
     impact: &ChangeImpactResponse,
     deadline: Option<Instant>,
 ) -> EvidenceSnapshot {
-    collect_internal(root, options, extensions, impact, None, deadline)
+    collect_internal(root, options, extensions, impact, None, false, deadline)
 }
 
 pub fn collect_with_store(
@@ -427,7 +436,34 @@ pub fn collect_with_store(
     store: &crate::store::Store,
     deadline: Option<Instant>,
 ) -> EvidenceSnapshot {
-    collect_internal(root, options, extensions, impact, Some(store), deadline)
+    collect_internal(
+        root,
+        options,
+        extensions,
+        impact,
+        Some(store),
+        false,
+        deadline,
+    )
+}
+
+pub(crate) fn collect_with_store_and_normalized_facts(
+    root: &Path,
+    options: &EvidenceOptions,
+    extensions: &EvidenceExtensionOptions,
+    impact: &ChangeImpactResponse,
+    store: &crate::store::Store,
+    deadline: Option<Instant>,
+) -> EvidenceSnapshot {
+    collect_internal(
+        root,
+        options,
+        extensions,
+        impact,
+        Some(store),
+        true,
+        deadline,
+    )
 }
 
 fn collect_internal(
@@ -436,6 +472,7 @@ fn collect_internal(
     extensions: &EvidenceExtensionOptions,
     impact: &ChangeImpactResponse,
     store: Option<&crate::store::Store>,
+    include_normalized_facts: bool,
     deadline: Option<Instant>,
 ) -> EvidenceSnapshot {
     let (relevant, relevant_truncated) = relevant_paths(impact);
@@ -463,6 +500,10 @@ fn collect_internal(
         runtime_span_count: 0,
         runtime_edges: BTreeMap::new(),
         runtime_edges_truncated: false,
+        fact_artifacts: Vec::new(),
+        fact_artifacts_truncated: false,
+        fact_relationships: Vec::new(),
+        fact_relationships_truncated: false,
         knowledge_match_count: 0,
         deadline,
         artifact_identities: HashMap::new(),
@@ -608,6 +649,32 @@ fn collect_internal(
         }
     }
 
+    if include_normalized_facts {
+        let store = store.expect("normalized facts require a Mastermind store");
+        match crate::facts::snapshot_for_paths(
+            store,
+            &collector.relevant,
+            crate::facts::MAX_LENS_FACTS,
+            deadline,
+        ) {
+            Ok(snapshot) => collector.load_normalized_facts(snapshot),
+            Err(error) => {
+                collector.diagnostic("facts", "normalized_facts_unavailable", error.to_string());
+                collector.sources.push(EvidenceSource {
+                    id: "facts".into(),
+                    kind: "facts",
+                    label: "Normalized declarative facts".into(),
+                    status: "error",
+                    facts_total: None,
+                    facts_returned: 0,
+                    files_matched: 0,
+                    artifact_sha256: None,
+                    artifact_bytes: None,
+                });
+            }
+        }
+    }
+
     collector.finish(options.git_commits)
 }
 
@@ -710,6 +777,73 @@ impl Collector<'_> {
             artifact_sha256: artifact.as_ref().map(|value| value.0.clone()),
             artifact_bytes: artifact.map(|value| value.1),
         });
+    }
+
+    fn load_normalized_facts(&mut self, snapshot: crate::facts::FactSnapshot) {
+        self.partial |= snapshot.partial;
+        self.sources_truncated |= snapshot.sources.truncated;
+        self.fact_artifacts_truncated |= snapshot.artifacts.truncated;
+        self.fact_relationships_truncated |= snapshot.relationships.truncated;
+        if !snapshot.sources.items.is_empty() {
+            self.notes.push(EvidencePrecisionNote {
+                source_id: "facts",
+                code: "normalized_fact_overlay",
+                message: "Declarative facts are bound to the indexed repository, exact Git revision, and source digests. Relationship facts decorate only matching static graph endpoints and never create topology.".into(),
+            });
+        }
+        let producers = snapshot
+            .sources
+            .items
+            .iter()
+            .map(|source| (source.id.clone(), source.producer.clone()))
+            .collect::<HashMap<_, _>>();
+        for source in snapshot.sources.items {
+            self.sources.push(EvidenceSource {
+                id: source.id,
+                kind: "facts",
+                label: format!(
+                    "{} {} · {}",
+                    source.producer, source.producer_version, source.dataset
+                ),
+                status: source.status,
+                facts_total: Some(source.facts_total),
+                facts_returned: source.facts_returned,
+                files_matched: source.files_matched,
+                artifact_sha256: Some(source.manifest_sha256),
+                artifact_bytes: Some(source.manifest_bytes),
+            });
+        }
+        let mut annotation_truncated = false;
+        for annotation in snapshot.annotations.items {
+            let tool = producers
+                .get(&annotation.source_id)
+                .cloned()
+                .unwrap_or_else(|| "declarative-facts".into());
+            let finding = EvidenceFinding {
+                source_id: annotation.source_id,
+                tool,
+                rule_id: annotation.category,
+                level: annotation.severity,
+                message: format!("{}: {}", annotation.title, annotation.message),
+                line: Some(annotation.line),
+                column: annotation.column,
+            };
+            if !self.add_finding(&annotation.path, finding) {
+                annotation_truncated = true;
+            }
+        }
+        if annotation_truncated {
+            self.diagnostic(
+                "facts",
+                "normalized_fact_limit",
+                "Some normalized annotations were omitted by the Lens finding limits.",
+            );
+        }
+        self.fact_artifacts = snapshot.artifacts.items;
+        self.fact_relationships = snapshot.relationships.items;
+        for diagnostic in snapshot.diagnostics.items {
+            self.diagnostic(diagnostic.source_id, diagnostic.code, diagnostic.message);
+        }
     }
 
     fn register_artifact(&mut self, id: &str, input: &SourceInput) {
@@ -1691,6 +1825,8 @@ impl Collector<'_> {
             })
             .collect::<Vec<_>>();
         let runtime_edge_count = saturating_u32(runtime_edges.len());
+        let fact_artifact_count = saturating_u32(self.fact_artifacts.len());
+        let fact_relationship_count = saturating_u32(self.fact_relationships.len());
         let files = self
             .files
             .into_iter()
@@ -1801,6 +1937,24 @@ impl Collector<'_> {
                 truncation_reason: self.runtime_edges_truncated.then_some("runtime_edge_limit"),
                 items: runtime_edges,
             },
+            fact_artifacts: EvidenceCollection {
+                total: (!self.fact_artifacts_truncated).then_some(fact_artifact_count),
+                returned: fact_artifact_count,
+                truncated: self.fact_artifacts_truncated,
+                truncation_reason: self
+                    .fact_artifacts_truncated
+                    .then_some("normalized_fact_artifact_limit"),
+                items: self.fact_artifacts,
+            },
+            fact_relationships: EvidenceCollection {
+                total: (!self.fact_relationships_truncated).then_some(fact_relationship_count),
+                returned: fact_relationship_count,
+                truncated: self.fact_relationships_truncated,
+                truncation_reason: self
+                    .fact_relationships_truncated
+                    .then_some("normalized_fact_limit"),
+                items: self.fact_relationships,
+            },
             diagnostics: EvidenceCollection {
                 total: (!self.diagnostics_truncated).then_some(diagnostic_count),
                 returned: diagnostic_count,
@@ -1822,6 +1976,9 @@ impl Collector<'_> {
                 runtime_spans: MAX_RUNTIME_SPANS as u32,
                 runtime_edges: MAX_RUNTIME_EDGES as u32,
                 runtime_names_per_edge: MAX_RUNTIME_NAMES_PER_EDGE as u32,
+                normalized_fact_sources: crate::facts::MAX_LENS_SOURCES as u32,
+                normalized_fact_artifacts: crate::facts::MAX_LENS_ARTIFACTS as u32,
+                normalized_fact_relationships: crate::facts::MAX_LENS_FACTS as u32,
                 knowledge_matches: MAX_KNOWLEDGE_MATCHES as u32,
                 knowledge_per_file: MAX_KNOWLEDGE_PER_FILE as u32,
                 knowledge_artifacts: MAX_KNOWLEDGE_ARTIFACTS as u32,
@@ -2567,6 +2724,10 @@ mod tests {
             runtime_span_count: 0,
             runtime_edges: BTreeMap::new(),
             runtime_edges_truncated: false,
+            fact_artifacts: Vec::new(),
+            fact_artifacts_truncated: false,
+            fact_relationships: Vec::new(),
+            fact_relationships_truncated: false,
             knowledge_match_count: 0,
             deadline: None,
         }

--- a/mcp/servers/mmcg/src/facts.rs
+++ b/mcp/servers/mmcg/src/facts.rs
@@ -1,0 +1,1894 @@
+//! Declarative, revision-bound fact ingestion for community extensions.
+//!
+//! Producers submit a strict JSON manifest. Mastermind validates the complete
+//! document, repository/revision binding, source files, and provenance
+//! artifacts before atomically replacing one producer dataset. Imported data
+//! never selects SQL, registers MCP handlers, or changes the Tree-sitter graph.
+
+use crate::store::Store;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::fmt;
+use std::fs::File;
+#[cfg(unix)]
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+pub const API_VERSION: &str = "mastermind-facts/v1";
+pub const SUPPORTED_CAPABILITIES: [&str; 2] = ["annotations", "relationships"];
+
+const MAX_MANIFEST_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_FILES: usize = 10_000;
+const MAX_FACTS: usize = 100_000;
+const MAX_ARTIFACTS: usize = 64;
+const MAX_SOURCE_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_ARTIFACT_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_ARTIFACT_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
+pub const MAX_LENS_SOURCES: usize = 64;
+const MAX_SOURCES_RETURNED: usize = MAX_LENS_SOURCES;
+pub const MAX_LENS_ARTIFACTS: usize = 64;
+const MAX_ARTIFACTS_RETURNED: usize = MAX_LENS_ARTIFACTS;
+// Even when every path/message byte needs JSON escaping, a standalone MCP
+// response remains below the server's 8 MiB serialized-result limit.
+const MAX_FACTS_RETURNED: usize = 400;
+pub const MAX_LENS_FACTS: usize = 200;
+const MAX_DIAGNOSTICS: usize = 100;
+const MAX_ID_BYTES: usize = 256;
+const MAX_NAME_BYTES: usize = 128;
+const MAX_VERSION_BYTES: usize = 128;
+const MAX_PATH_BYTES: usize = 4 * 1024;
+const MAX_TITLE_BYTES: usize = 256;
+const MAX_MESSAGE_BYTES: usize = 4 * 1024;
+const MAX_LABEL_BYTES: usize = 512;
+
+#[derive(Debug)]
+pub enum FactError {
+    InvalidManifest(String),
+    InvalidQuery(String),
+    Io(String),
+    Store(String),
+    Git(String),
+}
+
+impl fmt::Display for FactError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidManifest(message) => write!(formatter, "invalid fact manifest: {message}"),
+            Self::InvalidQuery(message) => write!(formatter, "invalid fact query: {message}"),
+            Self::Io(message) => write!(formatter, "fact ingestion I/O error: {message}"),
+            Self::Store(message) => write!(formatter, "fact store error: {message}"),
+            Self::Git(message) => write!(formatter, "fact repository error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for FactError {}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FactManifest {
+    api_version: String,
+    capabilities: Vec<String>,
+    repository: ManifestRepository,
+    producer: ManifestProducer,
+    dataset: String,
+    provenance: ManifestProvenance,
+    files: Vec<ManifestFile>,
+    artifacts: Vec<ManifestArtifact>,
+    facts: Vec<ManifestFact>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestRepository {
+    identity: String,
+    revision: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestProducer {
+    name: String,
+    version: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestProvenance {
+    kind: String,
+    artifacts: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestFile {
+    path: String,
+    sha256: String,
+    bytes: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestArtifact {
+    id: String,
+    path: String,
+    sha256: String,
+    bytes: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestLocation {
+    path: String,
+    line: u32,
+    #[serde(default)]
+    column: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum ManifestFact {
+    Annotation {
+        id: String,
+        path: String,
+        line: u32,
+        #[serde(default)]
+        column: Option<u32>,
+        #[serde(default)]
+        end_line: Option<u32>,
+        #[serde(default)]
+        end_column: Option<u32>,
+        severity: String,
+        category: String,
+        title: String,
+        message: String,
+    },
+    Relationship {
+        id: String,
+        relation: String,
+        from: ManifestLocation,
+        to: ManifestLocation,
+        confidence: String,
+        label: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FactSourceRecord {
+    pub id: i64,
+    pub api_version: String,
+    pub producer_name: String,
+    pub producer_version: String,
+    pub dataset: String,
+    pub provenance_kind: String,
+    pub capabilities: String,
+    pub repository_identity: String,
+    pub revision: String,
+    pub manifest_sha256: String,
+    pub manifest_bytes: u64,
+    pub imported_at: i64,
+    pub file_count: u32,
+    pub annotation_count: u32,
+    pub relationship_count: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FactFileRecord {
+    pub path: String,
+    pub sha256: String,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FactArtifactRecord {
+    pub id: String,
+    pub path: String,
+    pub sha256: String,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FactAnnotation {
+    pub source_id: String,
+    pub fact_id: String,
+    pub path: String,
+    pub line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_column: Option<u32>,
+    pub severity: String,
+    pub category: String,
+    pub title: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FactRelationship {
+    pub source_id: String,
+    pub fact_id: String,
+    pub relation: String,
+    pub from_path: String,
+    pub from_line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_column: Option<u32>,
+    pub to_path: String,
+    pub to_line: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_column: Option<u32>,
+    pub confidence: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FactArtifact {
+    pub source_id: String,
+    pub id: String,
+    pub path: String,
+    pub sha256: String,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FactImportBatch {
+    pub source: FactSourceRecord,
+    pub files: Vec<FactFileRecord>,
+    pub artifacts: Vec<FactArtifactRecord>,
+    pub annotations: Vec<FactAnnotation>,
+    pub relationships: Vec<FactRelationship>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum FactQueryFilter {
+    Scope(String),
+    Paths(Vec<String>),
+}
+
+#[derive(Debug, Serialize)]
+pub struct FactContract {
+    pub api_version: &'static str,
+    pub supported_capabilities: [&'static str; 2],
+    pub repository: FactRepository,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FactRepository {
+    pub identity: String,
+    pub revision: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FactImportSummary {
+    pub schema_version: u32,
+    pub replaced_previous_dataset: bool,
+    pub contract: FactContract,
+    pub source: FactSourceView,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FactSourceView {
+    pub id: String,
+    pub producer: String,
+    pub producer_version: String,
+    pub dataset: String,
+    pub provenance: String,
+    pub capabilities: Vec<String>,
+    pub repository_identity: String,
+    pub revision: String,
+    pub manifest_sha256: String,
+    pub manifest_bytes: u64,
+    pub imported_at: i64,
+    pub status: &'static str,
+    pub facts_total: u32,
+    pub facts_returned: u32,
+    pub files_matched: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FactCollection<T> {
+    pub total: Option<u32>,
+    pub returned: u32,
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation_reason: Option<&'static str>,
+    pub items: Vec<T>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FactDiagnostic {
+    pub source_id: String,
+    pub code: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FactLimits {
+    pub sources: u32,
+    pub facts: u32,
+    pub diagnostics: u32,
+    pub provenance_artifacts: u32,
+    pub manifest_bytes: u64,
+    pub files_per_manifest: u32,
+    pub source_bytes_per_manifest: u64,
+    pub artifacts_per_manifest: u32,
+    pub artifact_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FactSnapshot {
+    pub schema_version: u32,
+    pub available: bool,
+    pub partial: bool,
+    pub contract: FactContract,
+    pub sources: FactCollection<FactSourceView>,
+    pub artifacts: FactCollection<FactArtifact>,
+    pub annotations: FactCollection<FactAnnotation>,
+    pub relationships: FactCollection<FactRelationship>,
+    pub diagnostics: FactCollection<FactDiagnostic>,
+    pub limits: FactLimits,
+}
+
+pub(crate) fn source_public_id(producer: &str, dataset: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(producer.as_bytes());
+    hasher.update([0]);
+    hasher.update(dataset.as_bytes());
+    format!("facts:sha256:{}", crate::hex::encode(&hasher.finalize()))
+}
+
+fn invalid(message: impl Into<String>) -> FactError {
+    FactError::InvalidManifest(message.into())
+}
+
+fn validate_text(value: &str, maximum: usize, label: &str) -> Result<(), FactError> {
+    if value.is_empty() || value.len() > maximum {
+        return Err(invalid(format!(
+            "{label} must contain 1..={maximum} UTF-8 bytes"
+        )));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(invalid(format!("{label} contains control characters")));
+    }
+    Ok(())
+}
+
+fn validate_token(value: &str, maximum: usize, label: &str) -> Result<(), FactError> {
+    validate_text(value, maximum, label)?;
+    if !value.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b'/' | b':')
+    }) {
+        return Err(invalid(format!("{label} contains unsupported characters")));
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str, label: &str) -> Result<(), FactError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(invalid(format!(
+            "{label} must be 64 lowercase hexadecimal characters"
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn normalize_fact_path(value: &str) -> Result<String, FactError> {
+    if value.is_empty()
+        || value == "."
+        || value.len() > MAX_PATH_BYTES
+        || value.starts_with("./")
+        || value.ends_with('/')
+        || value.contains('\\')
+        || value.contains(':')
+        || value.contains("//")
+        || value
+            .split('/')
+            .any(|segment| matches!(segment, "." | ".."))
+        || value.chars().any(char::is_control)
+    {
+        return Err(invalid(
+            "fact paths must be canonical repository-relative paths",
+        ));
+    }
+    let path = Path::new(value);
+    if path.is_absolute()
+        || !path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+    {
+        return Err(invalid(
+            "fact paths must not contain traversal or absolute roots",
+        ));
+    }
+    Ok(value.to_string())
+}
+
+pub fn normalize_query_path(value: &str) -> Result<String, FactError> {
+    if value == "." {
+        return Ok(".".into());
+    }
+    normalize_fact_path(value).map_err(|_| {
+        FactError::InvalidQuery("path must be `.` or a canonical repository-relative path".into())
+    })
+}
+
+fn read_regular(path: &Path, maximum: u64, label: &str) -> Result<Vec<u8>, FactError> {
+    read_regular_until(path, maximum, label, None)
+}
+
+fn read_regular_until(
+    path: &Path,
+    maximum: u64,
+    label: &str,
+    deadline: Option<Instant>,
+) -> Result<Vec<u8>, FactError> {
+    let initial = std::fs::symlink_metadata(path)
+        .map_err(|error| FactError::Io(format!("read {label} metadata: {error}")))?;
+    if !initial.file_type().is_file() {
+        return Err(invalid(format!(
+            "{label} must be a regular non-symlink file"
+        )));
+    }
+    if initial.len() > maximum {
+        return Err(invalid(format!("{label} exceeds the {maximum}-byte limit")));
+    }
+    let file = File::open(path).map_err(|error| FactError::Io(format!("open {label}: {error}")))?;
+    let before = file
+        .metadata()
+        .map_err(|error| FactError::Io(format!("read {label} metadata: {error}")))?;
+    if !before.is_file() || before.len() != initial.len() || modified(&before) != modified(&initial)
+    {
+        return Err(invalid(format!("{label} changed before it could be read")));
+    }
+    read_opened_regular_until(file, before, maximum, label, deadline)
+}
+
+fn read_opened_regular_until(
+    mut file: File,
+    before: std::fs::Metadata,
+    maximum: u64,
+    label: &str,
+    deadline: Option<Instant>,
+) -> Result<Vec<u8>, FactError> {
+    if !before.is_file() {
+        return Err(invalid(format!(
+            "{label} must be a regular non-symlink file"
+        )));
+    }
+    if before.len() > maximum {
+        return Err(invalid(format!("{label} exceeds the {maximum}-byte limit")));
+    }
+    let mut bytes = Vec::with_capacity(usize::try_from(before.len()).unwrap_or(0));
+    let mut remaining = maximum.saturating_add(1);
+    let mut buffer = [0_u8; 64 * 1024];
+    while remaining > 0 {
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Err(FactError::Io(format!(
+                "verification deadline exceeded while reading {label}"
+            )));
+        }
+        let chunk = buffer.len().min(remaining as usize);
+        let count = file
+            .read(&mut buffer[..chunk])
+            .map_err(|error| FactError::Io(format!("read {label}: {error}")))?;
+        if count == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buffer[..count]);
+        remaining = remaining.saturating_sub(count as u64);
+    }
+    if bytes.len() as u64 > maximum {
+        return Err(invalid(format!("{label} exceeds the {maximum}-byte limit")));
+    }
+    let after = file
+        .metadata()
+        .map_err(|error| FactError::Io(format!("re-read {label} metadata: {error}")))?;
+    let identity_changed = {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            before.dev() != after.dev() || before.ino() != after.ino()
+        }
+        #[cfg(not(unix))]
+        {
+            false
+        }
+    };
+    if identity_changed || before.len() != after.len() || modified(&before) != modified(&after) {
+        return Err(invalid(format!("{label} changed while it was being read")));
+    }
+    Ok(bytes)
+}
+
+fn modified(metadata: &std::fs::Metadata) -> Option<SystemTime> {
+    metadata.modified().ok()
+}
+
+#[cfg(not(unix))]
+fn resolve_contained_regular(
+    root: &Path,
+    relative: &str,
+    label: &str,
+) -> Result<PathBuf, FactError> {
+    let mut candidate = root.to_path_buf();
+    let components = Path::new(relative).components().collect::<Vec<_>>();
+    for (index, component) in components.iter().enumerate() {
+        let Component::Normal(part) = component else {
+            return Err(invalid(format!("{label} has an unsafe path component")));
+        };
+        candidate.push(part);
+        let metadata = std::fs::symlink_metadata(&candidate)
+            .map_err(|error| FactError::Io(format!("read {label} path metadata: {error}")))?;
+        if metadata.file_type().is_symlink() {
+            return Err(invalid(format!("{label} must not traverse a symlink")));
+        }
+        if index + 1 < components.len() && !metadata.is_dir() {
+            return Err(invalid(format!("{label} has a non-directory parent")));
+        }
+    }
+    let canonical = candidate
+        .canonicalize()
+        .map_err(|error| FactError::Io(format!("resolve {label}: {error}")))?;
+    if !canonical.starts_with(root) {
+        return Err(invalid(format!("{label} escapes the indexed repository")));
+    }
+    Ok(canonical)
+}
+
+#[cfg(unix)]
+fn path_component_cstring(component: &std::ffi::OsStr) -> Result<std::ffi::CString, FactError> {
+    use std::os::unix::ffi::OsStrExt;
+    std::ffi::CString::new(component.as_bytes())
+        .map_err(|_| invalid("fact path contains an unsafe component"))
+}
+
+#[cfg(unix)]
+fn open_contained_at(
+    parent: &File,
+    component: &std::ffi::OsStr,
+    directory: bool,
+) -> Result<File, FactError> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+    let component = path_component_cstring(component)?;
+    let flags = libc::O_RDONLY
+        | libc::O_NOFOLLOW
+        | libc::O_CLOEXEC
+        | if directory { libc::O_DIRECTORY } else { 0 };
+    let descriptor = unsafe { libc::openat(parent.as_raw_fd(), component.as_ptr(), flags) };
+    if descriptor < 0 {
+        return Err(invalid(
+            "fact inputs must use regular non-symlink repository paths",
+        ));
+    }
+    Ok(unsafe { File::from_raw_fd(descriptor) })
+}
+
+#[cfg(unix)]
+fn read_contained_regular(
+    root: &Path,
+    relative: &str,
+    maximum: u64,
+    label: &str,
+    deadline: Option<Instant>,
+) -> Result<Vec<u8>, FactError> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut options = OpenOptions::new();
+    options.read(true);
+    options.custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    let mut directory = options
+        .open(root)
+        .map_err(|error| FactError::Io(format!("open indexed repository: {error}")))?;
+    let parts = Path::new(relative)
+        .components()
+        .map(|component| match component {
+            Component::Normal(part) => Ok(part.to_os_string()),
+            _ => Err(invalid("fact path contains an unsafe component")),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let (leaf, parents) = parts
+        .split_last()
+        .ok_or_else(|| invalid("fact path is empty"))?;
+    for parent in parents {
+        directory = open_contained_at(&directory, parent, true)?;
+    }
+    let file = open_contained_at(&directory, leaf, false)?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| FactError::Io(format!("read {label} metadata: {error}")))?;
+    read_opened_regular_until(file, metadata, maximum, label, deadline)
+}
+
+#[cfg(not(unix))]
+fn read_contained_regular(
+    root: &Path,
+    relative: &str,
+    maximum: u64,
+    label: &str,
+    deadline: Option<Instant>,
+) -> Result<Vec<u8>, FactError> {
+    let resolved = resolve_contained_regular(root, relative, label)?;
+    read_regular_until(&resolved, maximum, label, deadline)
+}
+
+fn canonical_remote(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 4 * 1024 || value.chars().any(char::is_control) {
+        return None;
+    }
+    if let Some((scheme, rest)) = value.split_once("://") {
+        if !matches!(
+            scheme.to_ascii_lowercase().as_str(),
+            "http" | "https" | "ssh" | "git"
+        ) {
+            return None;
+        }
+        let rest = rest.split(['?', '#']).next()?;
+        let (authority, raw_path) = rest.split_once('/')?;
+        let authority = authority
+            .rsplit_once('@')
+            .map_or(authority, |(_, host)| host);
+        if authority.is_empty() {
+            return None;
+        }
+        return canonical_remote_host_path(authority, raw_path);
+    }
+    let scp = value.rsplit_once('@').map_or(value, |(_, rest)| rest);
+    let (host, path) = scp.split_once(':')?;
+    if host.contains('/') || host.is_empty() {
+        return None;
+    }
+    canonical_remote_host_path(host, path)
+}
+
+fn canonical_remote_host_path(host: &str, path: &str) -> Option<String> {
+    let path = path
+        .trim_matches('/')
+        .strip_suffix(".git")
+        .unwrap_or(path.trim_matches('/'));
+    if path.is_empty()
+        || path
+            .split('/')
+            .any(|segment| segment.is_empty() || matches!(segment, "." | ".."))
+    {
+        return None;
+    }
+    Some(format!("{}/{}", host.to_ascii_lowercase(), path))
+}
+
+fn repository_identity(root: &Path) -> Result<String, FactError> {
+    let output = crate::diff::run_bounded_git_with_limit(
+        root,
+        &["config", "--get", "remote.origin.url"],
+        None,
+        4 * 1024,
+    )
+    .map_err(|error| FactError::Git(format!("read bounded origin identity: {error}")))?;
+    let canonical = if output.success {
+        std::str::from_utf8(&output.stdout)
+            .ok()
+            .and_then(canonical_remote)
+            .map(|value| ("git-remote", value))
+    } else {
+        None
+    };
+    let (kind, identity) =
+        canonical.unwrap_or_else(|| ("git-worktree", root.to_string_lossy().replace('\\', "/")));
+    Ok(format!(
+        "{kind}:sha256:{}",
+        crate::hex::encode(&Sha256::digest(identity.as_bytes()))
+    ))
+}
+
+fn repository_contract(store: &Store) -> Result<FactRepository, FactError> {
+    if !store
+        .schema_current()
+        .map_err(|error| FactError::Store(error.to_string()))?
+    {
+        return Err(FactError::Store(
+            "the codegraph schema is stale; run `mastermind index .` first".into(),
+        ));
+    }
+    let root = store
+        .meta_value("index_root")
+        .map_err(|error| FactError::Store(error.to_string()))?
+        .ok_or_else(|| {
+            FactError::Store(
+                "the index has no repository identity; run `mastermind index .` first".into(),
+            )
+        })?;
+    let root = PathBuf::from(root)
+        .canonicalize()
+        .map_err(|error| FactError::Store(format!("resolve index root: {error}")))?;
+    crate::indexer::validate_index_root(store, &root).map_err(FactError::Store)?;
+    let revision =
+        crate::diff::current_head_oid(&root).map_err(|error| FactError::Git(error.to_string()))?;
+    Ok(FactRepository {
+        identity: repository_identity(&root)?,
+        revision,
+    })
+}
+
+pub fn contract(store: &Store) -> Result<FactContract, FactError> {
+    Ok(FactContract {
+        api_version: API_VERSION,
+        supported_capabilities: SUPPORTED_CAPABILITIES,
+        repository: repository_contract(store)?,
+    })
+}
+
+fn indexed_root(store: &Store) -> Result<PathBuf, FactError> {
+    store
+        .meta_value("index_root")
+        .map_err(|error| FactError::Store(error.to_string()))?
+        .ok_or_else(|| FactError::Store("the index has no repository identity".into()))
+        .and_then(|value| {
+            PathBuf::from(value)
+                .canonicalize()
+                .map_err(|error| FactError::Store(format!("resolve index root: {error}")))
+        })
+}
+
+fn validate_capabilities(values: &[String]) -> Result<Vec<String>, FactError> {
+    if values.is_empty() || values.len() > SUPPORTED_CAPABILITIES.len() {
+        return Err(invalid(
+            "capabilities must declare at least one supported capability",
+        ));
+    }
+    let supported = SUPPORTED_CAPABILITIES.into_iter().collect::<HashSet<_>>();
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    for capability in values {
+        if !supported.contains(capability.as_str()) {
+            return Err(invalid(format!(
+                "unsupported capability `{capability}`; supported capabilities: {}",
+                SUPPORTED_CAPABILITIES.join(", ")
+            )));
+        }
+        if !seen.insert(capability.as_str()) {
+            return Err(invalid(format!("duplicate capability `{capability}`")));
+        }
+        normalized.push(capability.clone());
+    }
+    normalized.sort();
+    Ok(normalized)
+}
+
+fn validate_location(
+    location: &ManifestLocation,
+    files: &HashMap<String, FactFileRecord>,
+    label: &str,
+) -> Result<(), FactError> {
+    let path = normalize_fact_path(&location.path)?;
+    if !files.contains_key(&path) {
+        return Err(invalid(format!(
+            "{label} path `{path}` is absent from files"
+        )));
+    }
+    if location.line == 0 || location.column == Some(0) {
+        return Err(invalid(format!("{label} positions are one-based")));
+    }
+    Ok(())
+}
+
+fn verified_file(
+    root: &Path,
+    store: &Store,
+    file: &ManifestFile,
+) -> Result<FactFileRecord, FactError> {
+    let path = normalize_fact_path(&file.path)?;
+    validate_sha256(&file.sha256, "file sha256")?;
+    if file.bytes > crate::indexer::MAX_INDEXABLE_FILE_SIZE {
+        return Err(invalid(format!(
+            "file `{path}` exceeds the indexable source limit"
+        )));
+    }
+    let bytes = read_contained_regular(
+        root,
+        &path,
+        crate::indexer::MAX_INDEXABLE_FILE_SIZE,
+        &format!("source file `{path}`"),
+        None,
+    )?;
+    if bytes.len() as u64 != file.bytes {
+        return Err(invalid(format!(
+            "file `{path}` size does not match manifest"
+        )));
+    }
+    let digest = crate::hex::encode(&Sha256::digest(&bytes));
+    if digest != file.sha256 {
+        return Err(invalid(format!(
+            "file `{path}` digest does not match manifest"
+        )));
+    }
+    let indexed = store
+        .file_content_sha256(&path)
+        .map_err(|error| FactError::Store(error.to_string()))?;
+    if indexed.as_deref().filter(|value| !value.is_empty()) != Some(digest.as_str()) {
+        return Err(invalid(format!(
+            "file `{path}` does not match the current codegraph index"
+        )));
+    }
+    Ok(FactFileRecord {
+        path,
+        sha256: digest,
+        bytes: file.bytes,
+    })
+}
+
+fn verified_artifact(
+    root: &Path,
+    artifact: &ManifestArtifact,
+) -> Result<FactArtifactRecord, FactError> {
+    validate_token(&artifact.id, MAX_ID_BYTES, "artifact id")?;
+    let path = normalize_fact_path(&artifact.path)?;
+    validate_sha256(&artifact.sha256, "artifact sha256")?;
+    if artifact.bytes > MAX_ARTIFACT_BYTES {
+        return Err(invalid(format!(
+            "artifact `{}` exceeds the size limit",
+            artifact.id
+        )));
+    }
+    let label = format!("provenance artifact `{}`", artifact.id);
+    let bytes = read_contained_regular(root, &path, MAX_ARTIFACT_BYTES, &label, None)?;
+    if bytes.len() as u64 != artifact.bytes {
+        return Err(invalid(format!(
+            "artifact `{}` size does not match manifest",
+            artifact.id
+        )));
+    }
+    let digest = crate::hex::encode(&Sha256::digest(&bytes));
+    if digest != artifact.sha256 {
+        return Err(invalid(format!(
+            "artifact `{}` digest does not match manifest",
+            artifact.id
+        )));
+    }
+    Ok(FactArtifactRecord {
+        id: artifact.id.clone(),
+        path,
+        sha256: digest,
+        bytes: artifact.bytes,
+    })
+}
+
+fn build_batch(
+    store: &Store,
+    manifest_path: &Path,
+) -> Result<(FactImportBatch, FactContract), FactError> {
+    let bytes = read_regular(manifest_path, MAX_MANIFEST_BYTES, "fact manifest")?;
+    let manifest: FactManifest = crate::audit_bundle::from_json_strict(&bytes)
+        .map_err(|error| invalid(error.to_string()))?;
+    if manifest.api_version != API_VERSION {
+        return Err(invalid(format!(
+            "unsupported api_version `{}`; expected `{API_VERSION}`",
+            manifest.api_version
+        )));
+    }
+    let capabilities = validate_capabilities(&manifest.capabilities)?;
+    validate_token(&manifest.producer.name, MAX_NAME_BYTES, "producer name")?;
+    validate_text(
+        &manifest.producer.version,
+        MAX_VERSION_BYTES,
+        "producer version",
+    )?;
+    validate_token(&manifest.dataset, MAX_NAME_BYTES, "dataset")?;
+    validate_token(&manifest.provenance.kind, MAX_NAME_BYTES, "provenance kind")?;
+    if manifest.files.len() > MAX_FILES {
+        return Err(invalid(format!("files exceed the {MAX_FILES}-entry limit")));
+    }
+    if manifest.artifacts.len() > MAX_ARTIFACTS {
+        return Err(invalid(format!(
+            "artifacts exceed the {MAX_ARTIFACTS}-entry limit"
+        )));
+    }
+    if manifest.facts.len() > MAX_FACTS {
+        return Err(invalid(format!("facts exceed the {MAX_FACTS}-entry limit")));
+    }
+
+    let contract = contract(store)?;
+    if manifest.repository.identity != contract.repository.identity {
+        return Err(invalid(
+            "repository identity does not match the indexed repository",
+        ));
+    }
+    if manifest.repository.revision != contract.repository.revision {
+        return Err(invalid(
+            "repository revision does not match the current Git HEAD",
+        ));
+    }
+    let root = indexed_root(store)?;
+
+    let mut files = HashMap::new();
+    let mut source_bytes = 0_u64;
+    for file in &manifest.files {
+        let verified = verified_file(&root, store, file)?;
+        source_bytes = source_bytes
+            .checked_add(verified.bytes)
+            .ok_or_else(|| invalid("source byte total overflow"))?;
+        if source_bytes > MAX_SOURCE_BYTES {
+            return Err(invalid(format!(
+                "referenced sources exceed the {MAX_SOURCE_BYTES}-byte total limit"
+            )));
+        }
+        let path = verified.path.clone();
+        if files.insert(path.clone(), verified).is_some() {
+            return Err(invalid(format!("duplicate file path `{path}`")));
+        }
+    }
+
+    let mut artifacts = Vec::new();
+    let mut artifact_ids = HashSet::new();
+    let mut artifact_total = 0_u64;
+    for artifact in &manifest.artifacts {
+        let verified = verified_artifact(&root, artifact)?;
+        if !artifact_ids.insert(verified.id.clone()) {
+            return Err(invalid(format!("duplicate artifact id `{}`", verified.id)));
+        }
+        artifact_total = artifact_total
+            .checked_add(verified.bytes)
+            .ok_or_else(|| invalid("artifact byte total overflow"))?;
+        if artifact_total > MAX_ARTIFACT_TOTAL_BYTES {
+            return Err(invalid(format!(
+                "provenance artifacts exceed the {MAX_ARTIFACT_TOTAL_BYTES}-byte total limit"
+            )));
+        }
+        artifacts.push(verified);
+    }
+    let mut referenced_artifacts = HashSet::new();
+    for id in &manifest.provenance.artifacts {
+        validate_token(id, MAX_ID_BYTES, "provenance artifact id")?;
+        if !artifact_ids.contains(id) {
+            return Err(invalid(format!(
+                "provenance references unknown artifact `{id}`"
+            )));
+        }
+        if !referenced_artifacts.insert(id) {
+            return Err(invalid(format!("duplicate provenance artifact `{id}`")));
+        }
+    }
+    if artifact_ids.len() != referenced_artifacts.len() {
+        return Err(invalid(
+            "every declared artifact must be referenced by provenance",
+        ));
+    }
+
+    let mut fact_ids = HashSet::new();
+    let mut annotations = Vec::new();
+    let mut relationships = Vec::new();
+    let source_id = source_public_id(&manifest.producer.name, &manifest.dataset);
+    for fact in manifest.facts {
+        match fact {
+            ManifestFact::Annotation {
+                id,
+                path,
+                line,
+                column,
+                end_line,
+                end_column,
+                severity,
+                category,
+                title,
+                message,
+            } => {
+                if !capabilities.iter().any(|value| value == "annotations") {
+                    return Err(invalid(
+                        "annotation fact requires the `annotations` capability",
+                    ));
+                }
+                validate_token(&id, MAX_ID_BYTES, "fact id")?;
+                if !fact_ids.insert(id.clone()) {
+                    return Err(invalid(format!("duplicate fact id `{id}`")));
+                }
+                let path = normalize_fact_path(&path)?;
+                if !files.contains_key(&path) {
+                    return Err(invalid(format!(
+                        "annotation path `{path}` is absent from files"
+                    )));
+                }
+                if line == 0 || column == Some(0) || end_line == Some(0) || end_column == Some(0) {
+                    return Err(invalid("annotation positions are one-based"));
+                }
+                if let Some(end) = end_line {
+                    if end < line {
+                        return Err(invalid("annotation end_line precedes line"));
+                    }
+                    if end == line
+                        && end_column
+                            .zip(column)
+                            .is_some_and(|(end, start)| end < start)
+                    {
+                        return Err(invalid("annotation end_column precedes column"));
+                    }
+                }
+                if !matches!(severity.as_str(), "info" | "warning" | "error") {
+                    return Err(invalid(
+                        "annotation severity must be info, warning, or error",
+                    ));
+                }
+                validate_token(&category, MAX_NAME_BYTES, "annotation category")?;
+                validate_text(&title, MAX_TITLE_BYTES, "annotation title")?;
+                validate_text(&message, MAX_MESSAGE_BYTES, "annotation message")?;
+                annotations.push(FactAnnotation {
+                    source_id: source_id.clone(),
+                    fact_id: id,
+                    path,
+                    line,
+                    column,
+                    end_line,
+                    end_column,
+                    severity,
+                    category,
+                    title,
+                    message,
+                });
+            }
+            ManifestFact::Relationship {
+                id,
+                relation,
+                from,
+                to,
+                confidence,
+                label,
+            } => {
+                if !capabilities.iter().any(|value| value == "relationships") {
+                    return Err(invalid(
+                        "relationship fact requires the `relationships` capability",
+                    ));
+                }
+                validate_token(&id, MAX_ID_BYTES, "fact id")?;
+                if !fact_ids.insert(id.clone()) {
+                    return Err(invalid(format!("duplicate fact id `{id}`")));
+                }
+                validate_token(&relation, MAX_NAME_BYTES, "relationship relation")?;
+                validate_location(&from, &files, "relationship from")?;
+                validate_location(&to, &files, "relationship to")?;
+                if !matches!(confidence.as_str(), "low" | "medium" | "high" | "observed") {
+                    return Err(invalid(
+                        "relationship confidence must be low, medium, high, or observed",
+                    ));
+                }
+                validate_text(&label, MAX_LABEL_BYTES, "relationship label")?;
+                relationships.push(FactRelationship {
+                    source_id: source_id.clone(),
+                    fact_id: id,
+                    relation,
+                    from_path: from.path,
+                    from_line: from.line,
+                    from_column: from.column,
+                    to_path: to.path,
+                    to_line: to.line,
+                    to_column: to.column,
+                    confidence,
+                    label,
+                });
+            }
+        }
+    }
+
+    let file_count = u32::try_from(files.len()).map_err(|_| invalid("file count overflow"))?;
+    let annotation_count =
+        u32::try_from(annotations.len()).map_err(|_| invalid("annotation count overflow"))?;
+    let relationship_count =
+        u32::try_from(relationships.len()).map_err(|_| invalid("relationship count overflow"))?;
+    let imported_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    let source = FactSourceRecord {
+        id: 0,
+        api_version: API_VERSION.into(),
+        producer_name: manifest.producer.name,
+        producer_version: manifest.producer.version,
+        dataset: manifest.dataset,
+        provenance_kind: manifest.provenance.kind,
+        capabilities: capabilities.join(","),
+        repository_identity: contract.repository.identity.clone(),
+        revision: contract.repository.revision.clone(),
+        manifest_sha256: crate::hex::encode(&Sha256::digest(&bytes)),
+        manifest_bytes: bytes.len() as u64,
+        imported_at,
+        file_count,
+        annotation_count,
+        relationship_count,
+    };
+    let mut files = files.into_values().collect::<Vec<_>>();
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok((
+        FactImportBatch {
+            source,
+            files,
+            artifacts,
+            annotations,
+            relationships,
+        },
+        contract,
+    ))
+}
+
+fn revalidate_batch_snapshot(
+    store: &Store,
+    batch: &FactImportBatch,
+    expected: &FactContract,
+) -> Result<(), FactError> {
+    let current = contract(store)?;
+    if current.repository.identity != expected.repository.identity
+        || current.repository.revision != expected.repository.revision
+    {
+        return Err(invalid(
+            "repository identity or revision changed while the manifest was being validated",
+        ));
+    }
+    let root = indexed_root(store)?;
+    for file in &batch.files {
+        let binding = ManifestFile {
+            path: file.path.clone(),
+            sha256: file.sha256.clone(),
+            bytes: file.bytes,
+        };
+        verified_file(&root, store, &binding)?;
+    }
+    for artifact in &batch.artifacts {
+        verify_artifact_record(&root, artifact, None)?;
+    }
+    Ok(())
+}
+
+pub fn import(store: &Store, manifest_path: &Path) -> Result<FactImportSummary, FactError> {
+    let (batch, contract) = build_batch(store, manifest_path)?;
+    let replaced_previous_dataset = store
+        .fact_source_exists(&batch.source.producer_name, &batch.source.dataset)
+        .map_err(|error| FactError::Store(error.to_string()))?;
+    revalidate_batch_snapshot(store, &batch, &contract)?;
+    store
+        .replace_fact_dataset(&batch)
+        .map_err(|error| FactError::Store(error.to_string()))?;
+    let source = source_view(
+        &batch.source,
+        "loaded",
+        batch
+            .source
+            .annotation_count
+            .saturating_add(batch.source.relationship_count),
+        batch.source.file_count,
+    );
+    Ok(FactImportSummary {
+        schema_version: 1,
+        replaced_previous_dataset,
+        contract,
+        source,
+    })
+}
+
+fn source_view(
+    source: &FactSourceRecord,
+    status: &'static str,
+    facts_returned: u32,
+    files_matched: u32,
+) -> FactSourceView {
+    FactSourceView {
+        id: source_public_id(&source.producer_name, &source.dataset),
+        producer: source.producer_name.clone(),
+        producer_version: source.producer_version.clone(),
+        dataset: source.dataset.clone(),
+        provenance: source.provenance_kind.clone(),
+        capabilities: source
+            .capabilities
+            .split(',')
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect(),
+        repository_identity: source.repository_identity.clone(),
+        revision: source.revision.clone(),
+        manifest_sha256: source.manifest_sha256.clone(),
+        manifest_bytes: source.manifest_bytes,
+        imported_at: source.imported_at,
+        status,
+        facts_total: source
+            .annotation_count
+            .saturating_add(source.relationship_count),
+        facts_returned,
+        files_matched,
+    }
+}
+
+fn validate_stored_files(
+    store: &Store,
+    root: &Path,
+    source: &FactSourceRecord,
+    verify_filesystem: bool,
+) -> Result<(), FactError> {
+    let files = store
+        .fact_files(source.id, MAX_FILES.saturating_add(1))
+        .map_err(|error| FactError::Store(error.to_string()))?;
+    if files.len() != source.file_count as usize || files.len() > MAX_FILES {
+        return Err(FactError::Store(
+            "stored fact file inventory is inconsistent".into(),
+        ));
+    }
+    for file in files {
+        let indexed = store
+            .file_content_sha256(&file.path)
+            .map_err(|error| FactError::Store(error.to_string()))?;
+        if indexed.as_deref().filter(|value| !value.is_empty()) != Some(file.sha256.as_str()) {
+            return Err(FactError::InvalidQuery(format!(
+                "source file `{}` no longer matches the codegraph",
+                file.path
+            )));
+        }
+        if verify_filesystem {
+            let bytes = read_contained_regular(
+                root,
+                &file.path,
+                crate::indexer::MAX_INDEXABLE_FILE_SIZE,
+                &format!("source file `{}`", file.path),
+                None,
+            )?;
+            if bytes.len() as u64 != file.bytes
+                || crate::hex::encode(&Sha256::digest(&bytes)) != file.sha256
+            {
+                return Err(FactError::InvalidQuery(format!(
+                    "source file `{}` changed after fact ingestion",
+                    file.path
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify_artifact_record(
+    root: &Path,
+    artifact: &FactArtifactRecord,
+    deadline: Option<Instant>,
+) -> Result<(), FactError> {
+    let label = format!("provenance artifact `{}`", artifact.id);
+    let bytes = read_contained_regular(root, &artifact.path, MAX_ARTIFACT_BYTES, &label, deadline)?;
+    if bytes.len() as u64 != artifact.bytes
+        || crate::hex::encode(&Sha256::digest(&bytes)) != artifact.sha256
+    {
+        return Err(FactError::InvalidQuery(format!(
+            "provenance artifact `{}` changed after fact ingestion",
+            artifact.path
+        )));
+    }
+    Ok(())
+}
+
+fn validate_stored_artifacts(
+    store: &Store,
+    root: &Path,
+    source: &FactSourceRecord,
+    deadline: Option<Instant>,
+) -> Result<(), FactError> {
+    let (artifacts, truncated) = store
+        .fact_artifacts(&[source.id], MAX_ARTIFACTS.saturating_add(1))
+        .map_err(|error| FactError::Store(error.to_string()))?;
+    if truncated || artifacts.len() > MAX_ARTIFACTS {
+        return Err(FactError::Store(
+            "stored fact provenance inventory is inconsistent".into(),
+        ));
+    }
+    for artifact in artifacts {
+        verify_artifact_record(
+            root,
+            &FactArtifactRecord {
+                id: artifact.id,
+                path: artifact.path,
+                sha256: artifact.sha256,
+                bytes: artifact.bytes,
+            },
+            deadline,
+        )?;
+    }
+    Ok(())
+}
+
+fn push_diagnostic(
+    diagnostics: &mut Vec<FactDiagnostic>,
+    truncated: &mut bool,
+    source_id: String,
+    code: &'static str,
+    message: impl Into<String>,
+) {
+    if diagnostics.len() >= MAX_DIAGNOSTICS {
+        *truncated = true;
+        return;
+    }
+    diagnostics.push(FactDiagnostic {
+        source_id,
+        code,
+        message: message.into().chars().take(300).collect(),
+    });
+}
+
+pub fn snapshot(store: &Store, path: &str, top: usize) -> Result<FactSnapshot, FactError> {
+    let path = normalize_query_path(path)?;
+    snapshot_filtered(store, FactQueryFilter::Scope(path), top, true, None)
+}
+
+pub(crate) fn snapshot_for_paths(
+    store: &Store,
+    paths: &BTreeSet<String>,
+    top: usize,
+    deadline: Option<Instant>,
+) -> Result<FactSnapshot, FactError> {
+    let mut normalized = Vec::new();
+    for path in paths.iter().take(1_000) {
+        normalized.push(normalize_fact_path(path)?);
+    }
+    snapshot_filtered(
+        store,
+        FactQueryFilter::Paths(normalized),
+        top,
+        false,
+        deadline,
+    )
+}
+
+fn snapshot_filtered(
+    store: &Store,
+    filter: FactQueryFilter,
+    top: usize,
+    verify_filesystem: bool,
+    deadline: Option<Instant>,
+) -> Result<FactSnapshot, FactError> {
+    if !(1..=MAX_FACTS_RETURNED).contains(&top) {
+        return Err(FactError::InvalidQuery(format!(
+            "top must be between 1 and {MAX_FACTS_RETURNED}"
+        )));
+    }
+    let index_version = store
+        .data_version()
+        .map_err(|error| FactError::Store(error.to_string()))?;
+    let contract = contract(store)?;
+    let root = indexed_root(store)?;
+    let mut source_rows = store
+        .fact_sources(MAX_SOURCES_RETURNED.saturating_add(1))
+        .map_err(|error| FactError::Store(error.to_string()))?;
+    let sources_truncated = source_rows.len() > MAX_SOURCES_RETURNED;
+    source_rows.truncate(MAX_SOURCES_RETURNED);
+    let mut diagnostics = Vec::new();
+    let mut diagnostics_truncated = false;
+    let mut current_source_ids = Vec::new();
+    let mut source_status = HashMap::new();
+    for source in &source_rows {
+        let public_id = source_public_id(&source.producer_name, &source.dataset);
+        if source.api_version != API_VERSION
+            || source.repository_identity != contract.repository.identity
+            || source.revision != contract.repository.revision
+        {
+            source_status.insert(source.id, "stale");
+            push_diagnostic(
+                &mut diagnostics,
+                &mut diagnostics_truncated,
+                public_id,
+                "fact_source_stale",
+                "Imported facts were omitted because their repository or revision binding is stale.",
+            );
+            continue;
+        }
+        match validate_stored_files(store, &root, source, verify_filesystem)
+            .and_then(|()| validate_stored_artifacts(store, &root, source, deadline))
+        {
+            Ok(()) => {
+                source_status.insert(source.id, "loaded");
+                current_source_ids.push(source.id);
+            }
+            Err(error) => {
+                source_status.insert(source.id, "stale");
+                push_diagnostic(
+                    &mut diagnostics,
+                    &mut diagnostics_truncated,
+                    public_id,
+                    "fact_source_stale",
+                    error.to_string(),
+                );
+            }
+        }
+    }
+
+    let (annotations, annotations_truncated) = store
+        .fact_annotations(&current_source_ids, &filter, top)
+        .map_err(|error| FactError::Store(error.to_string()))?;
+    let (artifacts, artifacts_truncated) = store
+        .fact_artifacts(&current_source_ids, MAX_ARTIFACTS_RETURNED)
+        .map_err(|error| FactError::Store(error.to_string()))?;
+    let remaining = top.saturating_sub(annotations.len());
+    let (relationships, relationships_truncated) = if remaining == 0 {
+        let (probe, _) = store
+            .fact_relationships(&current_source_ids, &filter, 1)
+            .map_err(|error| FactError::Store(error.to_string()))?;
+        (Vec::new(), !probe.is_empty())
+    } else {
+        store
+            .fact_relationships(&current_source_ids, &filter, remaining)
+            .map_err(|error| FactError::Store(error.to_string()))?
+    };
+    let fact_limit_reached = annotations_truncated || relationships_truncated;
+
+    let mut returned_by_source = HashMap::<String, (u32, BTreeSet<String>)>::new();
+    for annotation in &annotations {
+        let entry = returned_by_source
+            .entry(annotation.source_id.clone())
+            .or_default();
+        entry.0 = entry.0.saturating_add(1);
+        entry.1.insert(annotation.path.clone());
+    }
+    for relationship in &relationships {
+        let entry = returned_by_source
+            .entry(relationship.source_id.clone())
+            .or_default();
+        entry.0 = entry.0.saturating_add(1);
+        entry.1.insert(relationship.from_path.clone());
+        entry.1.insert(relationship.to_path.clone());
+    }
+    let sources = source_rows
+        .iter()
+        .map(|source| {
+            let public_id = source_public_id(&source.producer_name, &source.dataset);
+            let (returned, files) = returned_by_source
+                .get(&public_id)
+                .map(|(count, files)| (*count, files.len() as u32))
+                .unwrap_or((0, 0));
+            source_view(
+                source,
+                source_status.get(&source.id).copied().unwrap_or("stale"),
+                returned,
+                files,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let stale_sources = sources.iter().any(|source| source.status == "stale");
+    let source_count = sources.len() as u32;
+    let artifact_count = artifacts.len() as u32;
+    let diagnostic_count = diagnostics.len() as u32;
+    let after_contract = self::contract(store)?;
+    if store
+        .data_version()
+        .map_err(|error| FactError::Store(error.to_string()))?
+        != index_version
+        || after_contract.repository.identity != contract.repository.identity
+        || after_contract.repository.revision != contract.repository.revision
+    {
+        return Err(FactError::InvalidQuery(
+            "repository or fact-store snapshot changed during the query; retry".into(),
+        ));
+    }
+    let partial = sources_truncated
+        || stale_sources
+        || artifacts_truncated
+        || fact_limit_reached
+        || diagnostics_truncated;
+    Ok(FactSnapshot {
+        schema_version: 1,
+        available: sources.iter().any(|source| source.status == "loaded"),
+        partial,
+        contract,
+        sources: FactCollection {
+            total: (!sources_truncated).then_some(source_count),
+            returned: source_count,
+            truncated: sources_truncated,
+            truncation_reason: sources_truncated.then_some("source_limit"),
+            items: sources,
+        },
+        artifacts: FactCollection {
+            total: (!artifacts_truncated).then_some(artifact_count),
+            returned: artifact_count,
+            truncated: artifacts_truncated,
+            truncation_reason: artifacts_truncated.then_some("provenance_artifact_limit"),
+            items: artifacts,
+        },
+        annotations: FactCollection {
+            total: (!annotations_truncated).then_some(annotations.len() as u32),
+            returned: annotations.len() as u32,
+            truncated: annotations_truncated,
+            truncation_reason: annotations_truncated.then_some("fact_limit"),
+            items: annotations,
+        },
+        relationships: FactCollection {
+            total: (!relationships_truncated).then_some(relationships.len() as u32),
+            returned: relationships.len() as u32,
+            truncated: relationships_truncated,
+            truncation_reason: relationships_truncated.then_some("fact_limit"),
+            items: relationships,
+        },
+        diagnostics: FactCollection {
+            total: (!diagnostics_truncated).then_some(diagnostic_count),
+            returned: diagnostic_count,
+            truncated: diagnostics_truncated,
+            truncation_reason: diagnostics_truncated.then_some("diagnostic_limit"),
+            items: diagnostics,
+        },
+        limits: FactLimits {
+            sources: MAX_SOURCES_RETURNED as u32,
+            facts: MAX_FACTS_RETURNED as u32,
+            diagnostics: MAX_DIAGNOSTICS as u32,
+            provenance_artifacts: MAX_ARTIFACTS_RETURNED as u32,
+            manifest_bytes: MAX_MANIFEST_BYTES,
+            files_per_manifest: MAX_FILES as u32,
+            source_bytes_per_manifest: MAX_SOURCE_BYTES,
+            artifacts_per_manifest: MAX_ARTIFACTS as u32,
+            artifact_bytes: MAX_ARTIFACT_BYTES,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexer::Indexer;
+    use serde_json::{json, Value};
+    use std::fs;
+    use std::process::Command;
+
+    struct Fixture {
+        root: tempfile::TempDir,
+        store: Store,
+        contract: FactContract,
+    }
+
+    fn git(root: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    }
+
+    fn fixture() -> Fixture {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("src")).unwrap();
+        fs::create_dir_all(root.path().join("reports")).unwrap();
+        fs::write(
+            root.path().join("src/lib.rs"),
+            "pub fn charge() { helper(); }\nfn helper() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("src/worker.rs"),
+            "pub fn run() { crate::charge(); }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("reports/analyzer.json"),
+            b"{\"ok\":true}\n",
+        )
+        .unwrap();
+        git(root.path(), &["init", "-q"]);
+        git(
+            root.path(),
+            &["config", "user.email", "facts@example.invalid"],
+        );
+        git(root.path(), &["config", "user.name", "Facts Test"]);
+        git(
+            root.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:example/fact-fixture.git",
+            ],
+        );
+        git(root.path(), &["add", "."]);
+        git(root.path(), &["commit", "-qm", "fixture"]);
+        let db = root.path().join(".mastermind/mmcg.db");
+        fs::create_dir_all(db.parent().unwrap()).unwrap();
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(root.path())
+            .index_all(&mut store, true)
+            .unwrap();
+        let contract = contract(&store).unwrap();
+        Fixture {
+            root,
+            store,
+            contract,
+        }
+    }
+
+    fn digest(path: &Path) -> String {
+        crate::hex::encode(&Sha256::digest(fs::read(path).unwrap()))
+    }
+
+    fn file_binding(root: &Path, path: &str) -> Value {
+        let absolute = root.join(path);
+        json!({
+            "path": path,
+            "sha256": digest(&absolute),
+            "bytes": fs::metadata(absolute).unwrap().len(),
+        })
+    }
+
+    fn manifest(fixture: &Fixture) -> Value {
+        json!({
+            "api_version": API_VERSION,
+            "capabilities": ["annotations", "relationships"],
+            "repository": {
+                "identity": fixture.contract.repository.identity,
+                "revision": fixture.contract.repository.revision,
+            },
+            "producer": {
+                "name": "com.example.arch-lint",
+                "version": "1.4.0"
+            },
+            "dataset": "default",
+            "provenance": {
+                "kind": "static-analysis",
+                "artifacts": ["analyzer-output"]
+            },
+            "files": [
+                file_binding(fixture.root.path(), "src/lib.rs"),
+                file_binding(fixture.root.path(), "src/worker.rs")
+            ],
+            "artifacts": [{
+                "id": "analyzer-output",
+                "path": "reports/analyzer.json",
+                "sha256": digest(&fixture.root.path().join("reports/analyzer.json")),
+                "bytes": fs::metadata(fixture.root.path().join("reports/analyzer.json")).unwrap().len()
+            }],
+            "facts": [
+                {
+                    "kind": "annotation",
+                    "id": "architecture.payment-boundary",
+                    "path": "src/lib.rs",
+                    "line": 1,
+                    "column": 8,
+                    "severity": "warning",
+                    "category": "architecture.boundary",
+                    "title": "Payment boundary crossed",
+                    "message": "The changed function crosses the payment ownership boundary."
+                },
+                {
+                    "kind": "relationship",
+                    "id": "architecture.worker-to-payment",
+                    "relation": "calls",
+                    "from": {"path": "src/worker.rs", "line": 1, "column": 16},
+                    "to": {"path": "src/lib.rs", "line": 1, "column": 8},
+                    "confidence": "high",
+                    "label": "Compiler-resolved worker to payment call"
+                }
+            ]
+        })
+    }
+
+    fn write_manifest(fixture: &Fixture, value: &Value, name: &str) -> PathBuf {
+        let path = fixture.root.path().join(name);
+        fs::write(&path, serde_json::to_vec_pretty(value).unwrap()).unwrap();
+        path
+    }
+
+    #[test]
+    fn imports_and_queries_revision_bound_normalized_facts() {
+        let fixture = fixture();
+        let path = write_manifest(&fixture, &manifest(&fixture), "facts.json");
+        let summary = import(&fixture.store, &path).unwrap();
+        assert!(!summary.replaced_previous_dataset);
+        assert_eq!(summary.contract.api_version, API_VERSION);
+        assert_eq!(summary.source.producer, "com.example.arch-lint");
+        assert_eq!(summary.source.facts_returned, 2);
+        assert_eq!(summary.source.files_matched, 2);
+
+        let snapshot = snapshot(&fixture.store, ".", 100).unwrap();
+        assert!(snapshot.available);
+        assert!(!snapshot.partial);
+        assert_eq!(snapshot.sources.items.len(), 1);
+        assert_eq!(snapshot.sources.items[0].status, "loaded");
+        assert_eq!(snapshot.sources.items[0].facts_total, 2);
+        assert_eq!(snapshot.artifacts.items.len(), 1);
+        assert_eq!(snapshot.artifacts.items[0].id, "analyzer-output");
+        assert_eq!(snapshot.artifacts.items[0].path, "reports/analyzer.json");
+        assert_eq!(snapshot.artifacts.items[0].sha256.len(), 64);
+        assert_eq!(snapshot.annotations.items.len(), 1);
+        assert_eq!(snapshot.annotations.items[0].path, "src/lib.rs");
+        assert_eq!(snapshot.relationships.items.len(), 1);
+        assert_eq!(snapshot.relationships.items[0].confidence, "high");
+        assert!(snapshot.relationships.items[0]
+            .source_id
+            .starts_with("facts:sha256:"));
+    }
+
+    #[test]
+    fn invalid_replacement_is_rejected_before_the_previous_dataset_is_touched() {
+        let fixture = fixture();
+        let valid = manifest(&fixture);
+        let valid_path = write_manifest(&fixture, &valid, "facts.json");
+        import(&fixture.store, &valid_path).unwrap();
+
+        let mut invalid = valid;
+        invalid["facts"][0]["path"] = json!("../src/lib.rs");
+        let invalid_path = write_manifest(&fixture, &invalid, "invalid-facts.json");
+        assert!(import(&fixture.store, &invalid_path)
+            .unwrap_err()
+            .to_string()
+            .contains("fact paths"));
+
+        let snapshot = snapshot(&fixture.store, ".", 100).unwrap();
+        assert_eq!(snapshot.annotations.items.len(), 1);
+        assert_eq!(
+            snapshot.annotations.items[0].fact_id,
+            "architecture.payment-boundary"
+        );
+    }
+
+    #[test]
+    fn strict_manifest_rejects_duplicate_unknown_and_unsupported_contract_fields() {
+        let fixture = fixture();
+        let value = manifest(&fixture);
+        let mut unknown = value.clone();
+        unknown["command"] = json!("./plugin");
+        let path = write_manifest(&fixture, &unknown, "unknown.json");
+        assert!(import(&fixture.store, &path).is_err());
+
+        let raw = serde_json::to_string(&value).unwrap();
+        let duplicate = raw.replacen("{", "{\"api_version\":\"mastermind-facts/v1\",", 1);
+        let duplicate_path = fixture.root.path().join("duplicate.json");
+        fs::write(&duplicate_path, duplicate).unwrap();
+        assert!(import(&fixture.store, &duplicate_path)
+            .unwrap_err()
+            .to_string()
+            .contains("duplicate"));
+
+        let mut unsupported = value;
+        unsupported["capabilities"] = json!(["native-code"]);
+        let path = write_manifest(&fixture, &unsupported, "unsupported.json");
+        assert!(import(&fixture.store, &path)
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported capability"));
+
+        for noncanonical in ["./src/lib.rs", "src/./lib.rs", "src/lib.rs/"] {
+            let mut invalid_path = manifest(&fixture);
+            invalid_path["files"][0]["path"] = json!(noncanonical);
+            let path = write_manifest(&fixture, &invalid_path, "noncanonical.json");
+            assert!(
+                import(&fixture.store, &path).is_err(),
+                "accepted {noncanonical}"
+            );
+        }
+    }
+
+    #[test]
+    fn revision_and_file_drift_fail_closed() {
+        let fixture = fixture();
+        let mut wrong_revision = manifest(&fixture);
+        wrong_revision["repository"]["revision"] =
+            json!("0000000000000000000000000000000000000000");
+        let path = write_manifest(&fixture, &wrong_revision, "wrong-revision.json");
+        assert!(import(&fixture.store, &path)
+            .unwrap_err()
+            .to_string()
+            .contains("revision"));
+
+        let path = write_manifest(&fixture, &manifest(&fixture), "facts.json");
+        import(&fixture.store, &path).unwrap();
+        fs::write(
+            fixture.root.path().join("src/lib.rs"),
+            "pub fn charge() { changed(); }\nfn changed() {}\n",
+        )
+        .unwrap();
+        let snapshot = snapshot(&fixture.store, ".", 100).unwrap();
+        assert!(!snapshot.available);
+        assert!(snapshot.partial);
+        assert!(snapshot.annotations.items.is_empty());
+        assert_eq!(snapshot.sources.items[0].status, "stale");
+        assert_eq!(snapshot.diagnostics.items[0].code, "fact_source_stale");
+    }
+
+    #[test]
+    fn provenance_drift_suppresses_normalized_facts() {
+        let fixture = fixture();
+        let path = write_manifest(&fixture, &manifest(&fixture), "facts.json");
+        import(&fixture.store, &path).unwrap();
+        fs::write(
+            fixture.root.path().join("reports/analyzer.json"),
+            b"{\"changed\":true}\n",
+        )
+        .unwrap();
+
+        let snapshot = snapshot(&fixture.store, ".", 100).unwrap();
+        assert!(!snapshot.available);
+        assert!(snapshot.partial);
+        assert!(snapshot.annotations.items.is_empty());
+        assert!(snapshot.relationships.items.is_empty());
+        assert!(snapshot.artifacts.items.is_empty());
+        assert!(snapshot.diagnostics.items[0]
+            .message
+            .contains("provenance artifact"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provenance_artifact_rejects_a_symlinked_parent() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = fixture();
+        symlink(
+            fixture.root.path().join("reports"),
+            fixture.root.path().join("linked-reports"),
+        )
+        .unwrap();
+        let mut value = manifest(&fixture);
+        value["artifacts"][0]["path"] = json!("linked-reports/analyzer.json");
+        let path = write_manifest(&fixture, &value, "symlinked-artifact.json");
+        assert!(import(&fixture.store, &path)
+            .unwrap_err()
+            .to_string()
+            .contains("symlink"));
+    }
+
+    #[test]
+    fn repository_identity_sanitizes_remote_credentials_and_transport() {
+        assert_eq!(
+            canonical_remote("https://token@example.com/Owner/repo.git?secret=yes"),
+            Some("example.com/Owner/repo".into())
+        );
+        assert_eq!(
+            canonical_remote("git@example.com:Owner/repo.git"),
+            Some("example.com/Owner/repo".into())
+        );
+        assert!(canonical_remote("/tmp/local-repo").is_none());
+        assert_ne!(source_public_id("a/b", "c"), source_public_id("a", "b/c"));
+    }
+
+    #[test]
+    fn public_schema_matches_runtime_contract() {
+        let schema_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../schemas/mastermind-facts-v1.schema.json");
+        if !schema_path.is_file() {
+            // The root contract is repository-owned rather than duplicated in
+            // the crates.io tarball. Repository validation covers it in CI.
+            return;
+        }
+        let schema: Value = serde_json::from_slice(&fs::read(schema_path).unwrap()).unwrap();
+        assert_eq!(schema["additionalProperties"], json!(false));
+        assert_eq!(schema["properties"]["api_version"]["const"], API_VERSION);
+        assert_eq!(
+            schema["properties"]["capabilities"]["items"]["enum"],
+            json!(SUPPORTED_CAPABILITIES)
+        );
+        assert_eq!(
+            schema["required"],
+            json!([
+                "api_version",
+                "capabilities",
+                "repository",
+                "producer",
+                "dataset",
+                "provenance",
+                "files",
+                "artifacts",
+                "facts"
+            ])
+        );
+        for definition in [
+            "repository",
+            "producer",
+            "provenance",
+            "file",
+            "artifact",
+            "location",
+            "annotation",
+            "relationship",
+        ] {
+            assert_eq!(
+                schema["$defs"][definition]["additionalProperties"],
+                json!(false)
+            );
+        }
+    }
+}

--- a/mcp/servers/mmcg/src/indexer.rs
+++ b/mcp/servers/mmcg/src/indexer.rs
@@ -221,7 +221,11 @@ impl Indexer {
             || !store
                 .scratchpad_read(None, None, None, 1)
                 .map_err(|error| IndexError::Other(error.to_string()))?
-                .is_empty();
+                .is_empty()
+            || store
+                .fact_source_count()
+                .map_err(|error| IndexError::Other(error.to_string()))?
+                > 0;
         if has_unbound_data {
             return Err(IndexError::Other(
                 "existing index has no repository identity; rebuild it in a new database"

--- a/mcp/servers/mmcg/src/lens.rs
+++ b/mcp/servers/mmcg/src/lens.rs
@@ -571,7 +571,7 @@ fn build_snapshot_until(
         );
     let semantic = crate::scip_overlay::for_lens(store, &root, semantic_paths)
         .unwrap_or_else(|_| crate::scip_overlay::unavailable_with_diagnostic());
-    let evidence = crate::evidence::collect_with_store(
+    let evidence = crate::evidence::collect_with_store_and_normalized_facts(
         &root,
         evidence_options,
         evidence_extensions,
@@ -1372,6 +1372,88 @@ mod tests {
                 .unwrap(),
             source_bytes
         );
+    }
+
+    #[test]
+    fn snapshot_reads_revision_bound_facts_without_adding_graph_topology() {
+        let (repo, _index_dir, index_path) = fixture();
+        let writable = Store::open(&index_path).unwrap();
+        let contract = crate::facts::contract(&writable).unwrap();
+        let source = fs::read(repo.path().join("src/lib.rs")).unwrap();
+        let source_sha256 = crate::hex::encode(&Sha256::digest(&source));
+        let manifest_path = repo.path().join("facts.json");
+        fs::write(
+            &manifest_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "api_version": crate::facts::API_VERSION,
+                "capabilities": ["annotations", "relationships"],
+                "repository": {
+                    "identity": contract.repository.identity,
+                    "revision": contract.repository.revision
+                },
+                "producer": {"name": "com.example.lens", "version": "1.0.0"},
+                "dataset": "review",
+                "provenance": {"kind": "static-analysis", "artifacts": []},
+                "files": [{
+                    "path": "src/lib.rs",
+                    "sha256": source_sha256,
+                    "bytes": source.len()
+                }],
+                "artifacts": [],
+                "facts": [
+                    {
+                        "kind": "annotation",
+                        "id": "review.seed",
+                        "path": "src/lib.rs",
+                        "line": 1,
+                        "severity": "warning",
+                        "category": "architecture.review",
+                        "title": "Seed changed",
+                        "message": "Review the changed seed contract."
+                    },
+                    {
+                        "kind": "relationship",
+                        "id": "review.seed-caller",
+                        "relation": "calls",
+                        "from": {"path": "src/lib.rs", "line": 2},
+                        "to": {"path": "src/lib.rs", "line": 1},
+                        "confidence": "high",
+                        "label": "Caller reaches the changed seed"
+                    }
+                ]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        crate::facts::import(&writable, &manifest_path).unwrap();
+        drop(writable);
+
+        let store = Store::open_read_only(&index_path).unwrap();
+        let snapshot = build_snapshot(&store, repo.path(), &options()).unwrap();
+        let json = serde_json::to_value(snapshot).unwrap();
+        let source = json["evidence"]["sources"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|item| item["kind"] == "facts")
+            .unwrap();
+        assert_eq!(source["status"], "loaded");
+        assert!(source["id"].as_str().unwrap().starts_with("facts:sha256:"));
+        let source_id = source["id"].clone();
+        let file = json["evidence"]["files"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|item| item["path"] == "src/lib.rs")
+            .unwrap();
+        assert!(file["findings"].as_array().unwrap().iter().any(|finding| {
+            finding["source_id"] == source_id && finding["rule_id"] == "architecture.review"
+        }));
+        assert_eq!(
+            json["evidence"]["fact_relationships"]["items"][0]["fact_id"],
+            "review.seed-caller"
+        );
+        assert_eq!(json["impact"]["impact"]["returned"], 1);
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/lib.rs
+++ b/mcp/servers/mmcg/src/lib.rs
@@ -16,6 +16,7 @@ pub mod diff;
 pub mod doctor;
 pub mod evidence;
 pub mod executor_report;
+pub mod facts;
 pub mod fingerprint;
 pub mod hex;
 pub mod indexer;

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -4,7 +4,7 @@
 //!   mastermind init           — scaffold a project, build the index, draft CONTEXT.md
 //!   mastermind setup claude   — register the codegraph with Claude Code (MCP)
 //!   mastermind index [PATH]   — build or refresh the index
-//!   mastermind enrich --scip  — add optional compiler-resolved evidence
+//!   mastermind enrich         — add validated semantic or declarative evidence
 //!   mastermind temporal       — compare architecture at a Git baseline
 //!   mastermind ui --since REF — open the local diff-first Lens UI
 //!   mastermind review export  — write an autonomous PR evidence package
@@ -125,12 +125,24 @@ enum Cmd {
         #[arg(long)]
         force: bool,
     },
-    /// Add an optional compiler-resolved semantic overlay to the existing
-    /// Tree-sitter codegraph. Replaces only the previous SCIP overlay.
+    /// Add a validated evidence overlay without replacing the Tree-sitter graph.
     Enrich {
         /// SCIP protobuf index produced by a language-specific SCIP indexer.
-        #[arg(long, value_name = "PATH")]
-        scip: PathBuf,
+        #[arg(
+            long,
+            value_name = "PATH",
+            required_unless_present = "facts",
+            conflicts_with = "facts"
+        )]
+        scip: Option<PathBuf>,
+        /// Strict mastermind-facts/v1 manifest produced by a declarative extension.
+        #[arg(
+            long,
+            value_name = "PATH",
+            required_unless_present = "scip",
+            conflicts_with = "scip"
+        )]
+        facts: Option<PathBuf>,
     },
     /// Build a compact deterministic architecture briefing from the codegraph.
     Map {
@@ -838,6 +850,15 @@ enum QueryCmd {
         #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u32).range(1..=500))]
         top: u32,
     },
+    /// Read normalized declarative facts. The response also exposes the exact
+    /// repository identity, revision, API version, and supported capabilities
+    /// that a producer must place in its manifest.
+    Facts {
+        #[arg(long, default_value = ".")]
+        path: String,
+        #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u32).range(1..=400))]
+        top: u32,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1003,7 +1024,7 @@ fn run_cli_inner(
                 eprintln!("extractor contract changed: rebuilt all structural data");
             }
         }
-        Cmd::Enrich { scip } => {
+        Cmd::Enrich { scip, facts } => {
             if !index_path.is_file() {
                 return Err(format!(
                     "codegraph index {} does not exist; run `mastermind index .` first",
@@ -1012,7 +1033,13 @@ fn run_cli_inner(
                 .into());
             }
             let store = Store::open(&index_path)?;
-            let summary = mmcg::scip_overlay::import(&store, &scip)?;
+            let summary = match (scip, facts) {
+                (Some(scip), None) => {
+                    serde_json::to_value(mmcg::scip_overlay::import(&store, &scip)?)?
+                }
+                (None, Some(facts)) => serde_json::to_value(mmcg::facts::import(&store, &facts)?)?,
+                _ => unreachable!("clap requires exactly one enrichment input"),
+            };
             println!("{}", serde_json::to_string_pretty(&summary)?);
         }
         Cmd::Map {
@@ -1632,7 +1659,7 @@ mod tests {
         ])
         .unwrap();
         assert!(
-            matches!(enrich.cmd, Cmd::Enrich { scip } if scip == std::path::Path::new("index.scip"))
+            matches!(enrich.cmd, Cmd::Enrich { scip: Some(scip), facts: None } if scip == std::path::Path::new("index.scip"))
         );
 
         let query = Cli::try_parse_from([
@@ -1649,6 +1676,50 @@ mod tests {
             Cmd::Query(QueryCmd::Semantic { symbol, top })
                 if symbol == "scip-clang . demo . target()." && top == 25
         ));
+    }
+
+    #[test]
+    fn enrich_accepts_one_declarative_fact_manifest() {
+        let enrich = Cli::try_parse_from([
+            "mastermind",
+            "--index",
+            "graph.db",
+            "enrich",
+            "--facts",
+            "mastermind-facts.json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            enrich.cmd,
+            Cmd::Enrich { scip: None, facts: Some(path) }
+                if path == std::path::Path::new("mastermind-facts.json")
+        ));
+
+        assert!(Cli::try_parse_from([
+            "mastermind",
+            "enrich",
+            "--scip",
+            "index.scip",
+            "--facts",
+            "mastermind-facts.json",
+        ])
+        .is_err());
+
+        let query = Cli::try_parse_from([
+            "mastermind",
+            "query",
+            "facts",
+            "--path",
+            "src",
+            "--top",
+            "250",
+        ])
+        .unwrap();
+        assert!(matches!(
+            query.cmd,
+            Cmd::Query(QueryCmd::Facts { path, top }) if path == "src" && top == 250
+        ));
+        assert!(Cli::try_parse_from(["mastermind", "query", "facts", "--top", "401",]).is_err());
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/mcp.rs
+++ b/mcp/servers/mmcg/src/mcp.rs
@@ -218,6 +218,7 @@ static TOOLS: &[ToolDef] = &[
     read_only_tool("mmcg_history", schema_history, handle_history),
     read_only_tool("mmcg_centrality", schema_centrality, handle_centrality),
     read_only_tool("mmcg_semantic", schema_semantic, handle_semantic),
+    read_only_tool("mmcg_facts", schema_facts, handle_facts),
     read_only_tool("mmcg_map", schema_map, handle_map),
     read_only_tool("mmcg_temporal", schema_temporal, handle_temporal),
     read_only_tool(
@@ -1413,6 +1414,20 @@ fn schema_semantic() -> Value {
     })
 }
 
+fn schema_facts() -> Value {
+    json!({
+        "name": "mmcg_facts",
+        "description": "Read bounded normalized facts imported from strict mastermind-facts/v1 manifests. The response includes the fixed API/capability contract and exact repository/revision binding. Extensions cannot register handlers or mutate SQLite directly.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "default": ".", "description": "Repository-relative file or directory scope" },
+                "top": { "type": "integer", "minimum": 1, "maximum": 400, "default": 100 }
+            }
+        }
+    })
+}
+
 fn impact_input_schema(name: &str, description: &str) -> Value {
     json!({
         "name": name,
@@ -1825,6 +1840,32 @@ fn handle_semantic(store: &mut Store, args: &Value) -> Result<Value, HandlerErro
     };
     let result = crate::scip_overlay::query(store, symbol, top)
         .map_err(|error| HandlerError::internal("semantic_query", error))?;
+    serde_json::to_value(result)
+        .map_err(|error| HandlerError::internal("serialize_response", error))
+}
+
+fn handle_facts(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
+    let path = match args.get("path") {
+        None => ".",
+        Some(Value::String(value)) => value,
+        Some(_) => {
+            return Err(HandlerError::InvalidArguments(
+                "Invalid argument: path".into(),
+            ))
+        }
+    };
+    crate::facts::normalize_query_path(path)
+        .map_err(|_| HandlerError::InvalidArguments("Invalid argument: path".into()))?;
+    let top = match args.get("top") {
+        None => 100,
+        Some(value) => value
+            .as_u64()
+            .filter(|value| (1..=400).contains(value))
+            .and_then(|value| usize::try_from(value).ok())
+            .ok_or_else(|| HandlerError::InvalidArguments("Invalid argument: top".into()))?,
+    };
+    let result = crate::facts::snapshot(store, path, top)
+        .map_err(|error| HandlerError::internal("fact_query", error))?;
     serde_json::to_value(result)
         .map_err(|error| HandlerError::internal("serialize_response", error))
 }
@@ -2538,7 +2579,7 @@ mod tests {
     #[test]
     fn tool_annotations_match_behavior_table() {
         let legacy = tools_list(ProtocolVersion::Legacy);
-        assert_eq!(legacy["tools"].as_array().unwrap().len(), 26);
+        assert_eq!(legacy["tools"].as_array().unwrap().len(), 27);
         assert!(legacy["tools"]
             .as_array()
             .unwrap()
@@ -2547,7 +2588,7 @@ mod tests {
 
         let current = tools_list(ProtocolVersion::Current);
         let tools = current["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 26);
+        assert_eq!(tools.len(), 27);
         let mut readers = 0;
         for tool in tools {
             let annotations = &tool["annotations"];
@@ -2566,7 +2607,7 @@ mod tests {
                 readers += 1;
             }
         }
-        assert_eq!(readers, 25);
+        assert_eq!(readers, 26);
     }
 
     #[test]
@@ -2590,6 +2631,37 @@ mod tests {
         assert_eq!(payload["fallback_active"], true);
         assert_eq!(payload["resolution"]["default_graph"], "tree-sitter");
         std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn facts_tool_is_fixed_read_only_and_exposes_capability_negotiation() {
+        let (root, mut store) = impact_fixture("facts-contract");
+        let before = store.source_index_state().unwrap();
+        let result = handle_facts(&mut store, &json!({ "path": ".", "top": 25 })).unwrap();
+        assert_eq!(result["available"], false);
+        assert_eq!(result["contract"]["api_version"], crate::facts::API_VERSION);
+        assert_eq!(
+            result["contract"]["supported_capabilities"],
+            json!(["annotations", "relationships"])
+        );
+        assert_eq!(store.source_index_state().unwrap(), before);
+        assert!(matches!(
+            handle_facts(&mut store, &json!({ "path": "../outside" })),
+            Err(HandlerError::InvalidArguments(message)) if message == "Invalid argument: path"
+        ));
+        assert!(matches!(
+            handle_facts(&mut store, &json!({ "top": 401 })),
+            Err(HandlerError::InvalidArguments(message)) if message == "Invalid argument: top"
+        ));
+        let listed = tools_list(ProtocolVersion::Current);
+        let facts = listed["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|tool| tool["name"] == "mmcg_facts")
+            .unwrap();
+        assert_eq!(facts["annotations"], json!({ "readOnlyHint": true }));
+        std::fs::remove_dir_all(root).ok();
     }
 
     #[test]
@@ -3224,7 +3296,7 @@ mod tests {
     #[test]
     fn tools_list_covers_every_handler() {
         let listed: Vec<&str> = TOOLS.iter().map(|t| t.name).collect();
-        assert_eq!(listed.len(), 26, "expected 26 tools, got {}", listed.len());
+        assert_eq!(listed.len(), 27, "expected 27 tools, got {}", listed.len());
         for name in &listed {
             assert!(
                 TOOLS.iter().any(|t| &t.name == name),

--- a/mcp/servers/mmcg/src/policy/evidence.rs
+++ b/mcp/servers/mmcg/src/policy/evidence.rs
@@ -813,6 +813,7 @@ fn normalize_evidence_path(path: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
     use std::fs;
 
     #[test]
@@ -1034,6 +1035,34 @@ rules:
         crate::indexer::Indexer::new(repo)
             .index_all(&mut store, true)
             .unwrap();
+        let bound_path = repo.join("services/payment/charge.py");
+        let bound_source = fs::read(&bound_path).unwrap();
+        let fact_contract = crate::facts::contract(&store).unwrap();
+        let fact_manifest = repo.join(".mastermind/policy-facts.json");
+        fs::write(
+            &fact_manifest,
+            serde_json::to_vec(&serde_json::json!({
+                "api_version": crate::facts::API_VERSION,
+                "capabilities": ["annotations"],
+                "repository": {
+                    "identity": fact_contract.repository.identity,
+                    "revision": fact_contract.repository.revision
+                },
+                "producer": {"name": "com.example.policy-test", "version": "1.0.0"},
+                "dataset": "stale-overlay",
+                "provenance": {"kind": "test", "artifacts": []},
+                "files": [{
+                    "path": "services/payment/charge.py",
+                    "sha256": crate::hex::encode(&Sha256::digest(&bound_source)),
+                    "bytes": bound_source.len()
+                }],
+                "artifacts": [],
+                "facts": []
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        crate::facts::import(&store, &fact_manifest).unwrap();
         fs::write(
             repo.join("services/payment/b.py"),
             "from services.payment.a import a\ndef b():\n    return a()\n",
@@ -1086,7 +1115,11 @@ rules:
             report.violations,
             report.diagnostics
         );
-        assert!(report.complete, "diagnostics: {:#?}", report.diagnostics);
+        assert!(
+            report.complete,
+            "a stale declarative overlay must not extend or block the closed policy DSL: {:#?}",
+            report.diagnostics
+        );
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/review_package.rs
+++ b/mcp/servers/mmcg/src/review_package.rs
@@ -325,6 +325,19 @@ pub fn export(options: &ReviewExportOptions) -> Result<ReviewExportResult, Revie
             message: "A producer-side evidence attestation matched the package Git head and exact artifact digests. The attestation is an unsigned CI fact unless the surrounding workflow supplies a stronger trust anchor.".into(),
         });
     }
+    if snapshot
+        .evidence
+        .sources
+        .items
+        .iter()
+        .any(|source| source.kind == "facts" && source.status == "loaded")
+    {
+        snapshot.evidence.precision_notes.push(EvidencePrecisionNote {
+            source_id: "review-package",
+            code: "normalized_fact_revision_binding",
+            message: "manifest.json records each loaded mastermind-facts/v1 manifest and provenance-artifact digest as an unsigned producer-attested claim for this exact Git head; the autonomous HTML contains the normalized facts that were reviewed. A surrounding workflow must provide any stronger trust anchor.".into(),
+        });
+    }
     snapshot
         .evidence
         .precision_notes
@@ -662,7 +675,7 @@ fn evidence_binding(
     attestation: Option<AttestationBinding>,
     head_oid: &str,
 ) -> Result<EvidenceBinding, ReviewPackageError> {
-    let bound_sources = sources
+    let mut bound_sources = sources
         .iter()
         .map(|source| {
             let observed = snapshot
@@ -703,6 +716,40 @@ fn evidence_binding(
             })
         })
         .collect::<Result<Vec<_>, ReviewPackageError>>()?;
+    for source in snapshot
+        .evidence
+        .sources
+        .items
+        .iter()
+        .filter(|source| source.kind == "facts" && source.status == "loaded")
+    {
+        let (Some(sha256), Some(bytes)) = (&source.artifact_sha256, source.artifact_bytes) else {
+            return Err(ReviewPackageError::EvidenceBinding(source.id.clone()));
+        };
+        bound_sources.push(EvidenceSourceBinding {
+            id: source.id.clone(),
+            kind: "facts".into(),
+            label: source.label.clone(),
+            repository_relative: false,
+            sha256: sha256.clone(),
+            bytes,
+            analysis_status: source.status,
+            revision_binding: "producer-attested",
+        });
+    }
+    for artifact in &snapshot.evidence.fact_artifacts.items {
+        bound_sources.push(EvidenceSourceBinding {
+            id: format!("{}/artifact/{}", artifact.source_id, artifact.id),
+            kind: "facts".into(),
+            label: artifact.path.clone(),
+            repository_relative: true,
+            sha256: artifact.sha256.clone(),
+            bytes: artifact.bytes,
+            analysis_status: "loaded",
+            revision_binding: "producer-attested",
+        });
+    }
+    bound_sources.sort_by(|left, right| left.id.cmp(&right.id));
     let attested_count = bound_sources
         .iter()
         .filter(|source| source.revision_binding == "producer-attested")
@@ -1113,6 +1160,7 @@ mod tests {
     use super::*;
     use crate::indexer::Indexer;
     use crate::store::Store;
+    use sha2::{Digest, Sha256};
     use std::process::Command;
 
     fn git(root: &Path, args: &[&str]) -> String {
@@ -1254,6 +1302,94 @@ mod tests {
             export(&options),
             Err(ReviewPackageError::OutputExists)
         ));
+    }
+
+    #[test]
+    fn export_binds_normalized_fact_manifest_and_provenance_to_head() {
+        let (repository, state, index_path) = fixture();
+        std::fs::create_dir_all(repository.path().join("reports")).unwrap();
+        let artifact_path = repository.path().join("reports/arch-lint.json");
+        std::fs::write(&artifact_path, b"{\"producer\":\"arch-lint\"}\n").unwrap();
+        let source_path = repository.path().join("src/lib.rs");
+        let source = std::fs::read(&source_path).unwrap();
+        let artifact = std::fs::read(&artifact_path).unwrap();
+        let store = Store::open(&index_path).unwrap();
+        let contract = crate::facts::contract(&store).unwrap();
+        let manifest_path = state.path().join("facts.json");
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_vec(&serde_json::json!({
+                "api_version": crate::facts::API_VERSION,
+                "capabilities": ["annotations", "relationships"],
+                "repository": {
+                    "identity": contract.repository.identity,
+                    "revision": contract.repository.revision
+                },
+                "producer": {"name": "com.example.arch-lint", "version": "1.0.0"},
+                "dataset": "review",
+                "provenance": {"kind": "static-analysis", "artifacts": ["arch-lint"]},
+                "files": [{
+                    "path": "src/lib.rs",
+                    "sha256": crate::hex::encode(&Sha256::digest(&source)),
+                    "bytes": source.len()
+                }],
+                "artifacts": [{
+                    "id": "arch-lint",
+                    "path": "reports/arch-lint.json",
+                    "sha256": crate::hex::encode(&Sha256::digest(&artifact)),
+                    "bytes": artifact.len()
+                }],
+                "facts": [
+                    {
+                        "kind": "annotation",
+                        "id": "arch.review",
+                        "path": "src/lib.rs",
+                        "line": 1,
+                        "severity": "warning",
+                        "category": "architecture.review",
+                        "title": "Review charge",
+                        "message": "The producer marked this changed function."
+                    },
+                    {
+                        "kind": "relationship",
+                        "id": "arch.checkout-charge",
+                        "relation": "calls",
+                        "from": {"path": "src/lib.rs", "line": 2},
+                        "to": {"path": "src/lib.rs", "line": 1},
+                        "confidence": "high",
+                        "label": "Producer-resolved checkout to charge call"
+                    }
+                ]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let imported = crate::facts::import(&store, &manifest_path).unwrap();
+        let manifest_digest = imported.source.manifest_sha256;
+        drop(store);
+
+        let output = repository.path().join("fact-review");
+        let options = export_options(repository.path(), index_path, output.clone());
+        export(&options).unwrap();
+
+        let manifest: Value =
+            serde_json::from_slice(&std::fs::read(output.join("manifest.json")).unwrap()).unwrap();
+        assert_eq!(manifest["evidence_binding"]["status"], "producer-attested");
+        let bindings = manifest["evidence_binding"]["sources"].as_array().unwrap();
+        assert_eq!(bindings.len(), 2);
+        assert!(bindings.iter().all(|binding| {
+            binding["kind"] == "facts" && binding["revision_binding"] == "producer-attested"
+        }));
+        assert!(bindings
+            .iter()
+            .any(|binding| binding["sha256"] == manifest_digest));
+        assert!(bindings.iter().any(|binding| {
+            binding["label"] == "reports/arch-lint.json"
+                && binding["sha256"] == crate::hex::encode(&Sha256::digest(&artifact))
+        }));
+        let html = std::fs::read_to_string(output.join("index.html")).unwrap();
+        assert!(html.contains("arch.checkout-charge"));
+        assert!(html.contains(&crate::hex::encode(&Sha256::digest(&artifact))));
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/store.rs
+++ b/mcp/servers/mmcg/src/store.rs
@@ -5,8 +5,13 @@
 //!   edges(id, from_id, to_id?, to_name, kind, line)
 //!   files(path, indexed_at, symbol_count)
 //!   semantic_* (optional compiler-resolved overlay; never rewrites the graph)
+//!   fact_* (validated declarative evidence; never rewrites the graph)
 //!   meta(key, value)
 
+use crate::facts::{
+    source_public_id, FactAnnotation, FactArtifact, FactFileRecord, FactImportBatch,
+    FactQueryFilter, FactRelationship, FactSourceRecord,
+};
 use crate::scip_overlay::{SemanticDefinition, SemanticEdge, SemanticImportBatch, SemanticSource};
 use rusqlite::{
     params, types::Value as SqlValue, Connection, OpenFlags, OptionalExtension, Result as SqlResult,
@@ -24,6 +29,11 @@ const SCHEMA_VERSION: &str = "7";
 const READ_ONLY_SNAPSHOT_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const READ_ONLY_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(60);
 const SNAPSHOT_COPY_BUFFER_BYTES: usize = 1024 * 1024;
+
+fn row_u64(row: &rusqlite::Row<'_>, index: usize) -> SqlResult<u64> {
+    let value = row.get::<_, i64>(index)?;
+    u64::try_from(value).map_err(|_| rusqlite::Error::IntegralValueOutOfRange(index, value))
+}
 
 /// A per-request work-budget: a wall-clock deadline and/or a cap on SQLite
 /// progress-handler ticks (each tick fires every 1,000 VM instructions).
@@ -1253,6 +1263,86 @@ impl Store {
                 ON semantic_edges(to_file);
             CREATE INDEX IF NOT EXISTS idx_semantic_edges_kind
                 ON semantic_edges(kind);
+
+            -- Declarative community facts. Producers never receive SQLite
+            -- access: Mastermind validates a v1 manifest, normalizes every
+            -- record, and atomically owns these tables.
+            CREATE TABLE IF NOT EXISTS fact_sources (
+                id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+                api_version          TEXT NOT NULL,
+                producer_name        TEXT NOT NULL,
+                producer_version     TEXT NOT NULL,
+                dataset              TEXT NOT NULL,
+                provenance_kind      TEXT NOT NULL,
+                capabilities         TEXT NOT NULL,
+                repository_identity  TEXT NOT NULL,
+                revision             TEXT NOT NULL,
+                manifest_sha256      TEXT NOT NULL,
+                manifest_bytes       INTEGER NOT NULL,
+                imported_at          INTEGER NOT NULL,
+                file_count           INTEGER NOT NULL,
+                annotation_count     INTEGER NOT NULL,
+                relationship_count   INTEGER NOT NULL,
+                UNIQUE (producer_name, dataset)
+            );
+            CREATE INDEX IF NOT EXISTS idx_fact_sources_revision
+                ON fact_sources(repository_identity, revision);
+            CREATE TABLE IF NOT EXISTS fact_files (
+                source_id  INTEGER NOT NULL REFERENCES fact_sources(id) ON DELETE CASCADE,
+                path       TEXT NOT NULL,
+                sha256     TEXT NOT NULL,
+                bytes      INTEGER NOT NULL,
+                PRIMARY KEY (source_id, path)
+            );
+            CREATE INDEX IF NOT EXISTS idx_fact_files_path ON fact_files(path);
+            CREATE TABLE IF NOT EXISTS fact_artifacts (
+                source_id    INTEGER NOT NULL REFERENCES fact_sources(id) ON DELETE CASCADE,
+                artifact_id  TEXT NOT NULL,
+                path         TEXT NOT NULL,
+                sha256       TEXT NOT NULL,
+                bytes        INTEGER NOT NULL,
+                PRIMARY KEY (source_id, artifact_id)
+            );
+            CREATE TABLE IF NOT EXISTS fact_annotations (
+                source_id   INTEGER NOT NULL REFERENCES fact_sources(id) ON DELETE CASCADE,
+                fact_id     TEXT NOT NULL,
+                path        TEXT NOT NULL,
+                line        INTEGER NOT NULL,
+                column_no   INTEGER,
+                end_line    INTEGER,
+                end_column  INTEGER,
+                severity    TEXT NOT NULL,
+                category    TEXT NOT NULL,
+                title       TEXT NOT NULL,
+                message     TEXT NOT NULL,
+                PRIMARY KEY (source_id, fact_id),
+                FOREIGN KEY (source_id, path)
+                    REFERENCES fact_files(source_id, path) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_fact_annotations_path
+                ON fact_annotations(path, line);
+            CREATE TABLE IF NOT EXISTS fact_relationships (
+                source_id    INTEGER NOT NULL REFERENCES fact_sources(id) ON DELETE CASCADE,
+                fact_id      TEXT NOT NULL,
+                relation     TEXT NOT NULL,
+                from_path    TEXT NOT NULL,
+                from_line    INTEGER NOT NULL,
+                from_column  INTEGER,
+                to_path      TEXT NOT NULL,
+                to_line      INTEGER NOT NULL,
+                to_column    INTEGER,
+                confidence   TEXT NOT NULL,
+                label        TEXT NOT NULL,
+                PRIMARY KEY (source_id, fact_id),
+                FOREIGN KEY (source_id, from_path)
+                    REFERENCES fact_files(source_id, path) ON DELETE CASCADE,
+                FOREIGN KEY (source_id, to_path)
+                    REFERENCES fact_files(source_id, path) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_fact_relationships_from
+                ON fact_relationships(from_path, from_line);
+            CREATE INDEX IF NOT EXISTS idx_fact_relationships_to
+                ON fact_relationships(to_path, to_line);
             "#,
         )?;
 
@@ -1603,6 +1693,418 @@ impl Store {
             }
         }
         Ok(hashes)
+    }
+
+    fn fact_tables_exist(&self) -> SqlResult<bool> {
+        self.conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master
+                 WHERE type = 'table' AND name = 'fact_sources'",
+                [],
+                |_| Ok(true),
+            )
+            .optional()
+            .map(|value| value.unwrap_or(false))
+    }
+
+    pub(crate) fn fact_source_count(&self) -> SqlResult<u32> {
+        if !self.fact_tables_exist()? {
+            return Ok(0);
+        }
+        self.conn
+            .query_row("SELECT count(*) FROM fact_sources", [], |row| row.get(0))
+    }
+
+    pub(crate) fn fact_source_exists(&self, producer: &str, dataset: &str) -> SqlResult<bool> {
+        if !self.fact_tables_exist()? {
+            return Ok(false);
+        }
+        self.conn
+            .query_row(
+                "SELECT 1 FROM fact_sources
+                 WHERE producer_name = ?1 AND dataset = ?2",
+                params![producer, dataset],
+                |_| Ok(true),
+            )
+            .optional()
+            .map(|value| value.unwrap_or(false))
+    }
+
+    /// Replace exactly one producer dataset after the facts module has fully
+    /// validated the manifest in memory. A failed insert rolls back to the
+    /// previous known-good dataset.
+    pub(crate) fn replace_fact_dataset(&self, batch: &FactImportBatch) -> SqlResult<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        for file in &batch.files {
+            let indexed = tx
+                .query_row(
+                    "SELECT content_sha256 FROM files WHERE path = ?1",
+                    params![file.path],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+                .optional()?
+                .flatten();
+            if indexed.as_deref().filter(|value| !value.is_empty()) != Some(file.sha256.as_str()) {
+                return Err(rusqlite::Error::InvalidQuery);
+            }
+        }
+        tx.execute(
+            "DELETE FROM fact_sources WHERE producer_name = ?1 AND dataset = ?2",
+            params![batch.source.producer_name, batch.source.dataset],
+        )?;
+        tx.execute(
+            "INSERT INTO fact_sources(
+                api_version, producer_name, producer_version, dataset,
+                provenance_kind, capabilities, repository_identity, revision,
+                manifest_sha256, manifest_bytes, imported_at, file_count,
+                annotation_count, relationship_count
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+            params![
+                batch.source.api_version,
+                batch.source.producer_name,
+                batch.source.producer_version,
+                batch.source.dataset,
+                batch.source.provenance_kind,
+                batch.source.capabilities,
+                batch.source.repository_identity,
+                batch.source.revision,
+                batch.source.manifest_sha256,
+                i64::try_from(batch.source.manifest_bytes).unwrap_or(i64::MAX),
+                batch.source.imported_at,
+                batch.source.file_count,
+                batch.source.annotation_count,
+                batch.source.relationship_count,
+            ],
+        )?;
+        let source_id = tx.last_insert_rowid();
+        {
+            let mut statement = tx.prepare(
+                "INSERT INTO fact_files(source_id, path, sha256, bytes)
+                 VALUES (?1, ?2, ?3, ?4)",
+            )?;
+            for file in &batch.files {
+                statement.execute(params![
+                    source_id,
+                    file.path,
+                    file.sha256,
+                    i64::try_from(file.bytes).unwrap_or(i64::MAX),
+                ])?;
+            }
+        }
+        {
+            let mut statement = tx.prepare(
+                "INSERT INTO fact_artifacts(source_id, artifact_id, path, sha256, bytes)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+            )?;
+            for artifact in &batch.artifacts {
+                statement.execute(params![
+                    source_id,
+                    artifact.id,
+                    artifact.path,
+                    artifact.sha256,
+                    i64::try_from(artifact.bytes).unwrap_or(i64::MAX),
+                ])?;
+            }
+        }
+        {
+            let mut statement = tx.prepare(
+                "INSERT INTO fact_annotations(
+                    source_id, fact_id, path, line, column_no, end_line,
+                    end_column, severity, category, title, message
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            )?;
+            for fact in &batch.annotations {
+                statement.execute(params![
+                    source_id,
+                    fact.fact_id,
+                    fact.path,
+                    fact.line,
+                    fact.column,
+                    fact.end_line,
+                    fact.end_column,
+                    fact.severity,
+                    fact.category,
+                    fact.title,
+                    fact.message,
+                ])?;
+            }
+        }
+        {
+            let mut statement = tx.prepare(
+                "INSERT INTO fact_relationships(
+                    source_id, fact_id, relation, from_path, from_line,
+                    from_column, to_path, to_line, to_column, confidence, label
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            )?;
+            for fact in &batch.relationships {
+                statement.execute(params![
+                    source_id,
+                    fact.fact_id,
+                    fact.relation,
+                    fact.from_path,
+                    fact.from_line,
+                    fact.from_column,
+                    fact.to_path,
+                    fact.to_line,
+                    fact.to_column,
+                    fact.confidence,
+                    fact.label,
+                ])?;
+            }
+        }
+        tx.commit()
+    }
+
+    pub(crate) fn fact_sources(&self, limit: usize) -> SqlResult<Vec<FactSourceRecord>> {
+        if !self.fact_tables_exist()? {
+            return Ok(Vec::new());
+        }
+        let limit = limit.clamp(1, 1_000);
+        let mut statement = self.conn.prepare(
+            "SELECT id, api_version, producer_name, producer_version, dataset,
+                    provenance_kind, capabilities, repository_identity, revision,
+                    manifest_sha256, manifest_bytes, imported_at, file_count,
+                    annotation_count, relationship_count
+             FROM fact_sources
+             ORDER BY producer_name, dataset
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map(params![limit as i64], |row| {
+            Ok(FactSourceRecord {
+                id: row.get(0)?,
+                api_version: row.get(1)?,
+                producer_name: row.get(2)?,
+                producer_version: row.get(3)?,
+                dataset: row.get(4)?,
+                provenance_kind: row.get(5)?,
+                capabilities: row.get(6)?,
+                repository_identity: row.get(7)?,
+                revision: row.get(8)?,
+                manifest_sha256: row.get(9)?,
+                manifest_bytes: row_u64(row, 10)?,
+                imported_at: row.get(11)?,
+                file_count: row.get(12)?,
+                annotation_count: row.get(13)?,
+                relationship_count: row.get(14)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    pub(crate) fn fact_files(
+        &self,
+        source_id: i64,
+        limit: usize,
+    ) -> SqlResult<Vec<FactFileRecord>> {
+        if !self.fact_tables_exist()? {
+            return Ok(Vec::new());
+        }
+        let mut statement = self.conn.prepare(
+            "SELECT path, sha256, bytes FROM fact_files
+             WHERE source_id = ?1 ORDER BY path LIMIT ?2",
+        )?;
+        let rows =
+            statement.query_map(params![source_id, limit.clamp(1, 20_000) as i64], |row| {
+                Ok(FactFileRecord {
+                    path: row.get(0)?,
+                    sha256: row.get(1)?,
+                    bytes: row_u64(row, 2)?,
+                })
+            })?;
+        rows.collect()
+    }
+
+    pub(crate) fn fact_artifacts(
+        &self,
+        source_ids: &[i64],
+        limit: usize,
+    ) -> SqlResult<(Vec<FactArtifact>, bool)> {
+        if !self.fact_tables_exist()? || source_ids.is_empty() {
+            return Ok((Vec::new(), false));
+        }
+        let limit = limit.clamp(1, 1_000);
+        let mut values = Vec::<SqlValue>::new();
+        let predicate = Self::fact_source_filter_sql(source_ids, &mut values);
+        let sql = format!(
+            "SELECT fs.producer_name, fs.dataset, fa.artifact_id, fa.path,
+                    fa.sha256, fa.bytes
+             FROM fact_artifacts fa
+             JOIN fact_sources fs ON fs.id = fa.source_id
+             WHERE {predicate}
+             ORDER BY fs.producer_name, fs.dataset, fa.artifact_id
+             LIMIT ?"
+        );
+        values.push((limit.saturating_add(1) as i64).into());
+        let mut statement = self.conn.prepare(&sql)?;
+        let rows = statement.query_map(rusqlite::params_from_iter(values.iter()), |row| {
+            let producer: String = row.get(0)?;
+            let dataset: String = row.get(1)?;
+            Ok(FactArtifact {
+                source_id: source_public_id(&producer, &dataset),
+                id: row.get(2)?,
+                path: row.get(3)?,
+                sha256: row.get(4)?,
+                bytes: row_u64(row, 5)?,
+            })
+        })?;
+        let mut items = rows.collect::<SqlResult<Vec<_>>>()?;
+        let truncated = items.len() > limit;
+        items.truncate(limit);
+        Ok((items, truncated))
+    }
+
+    fn fact_source_filter_sql(source_ids: &[i64], values: &mut Vec<SqlValue>) -> String {
+        let placeholders = std::iter::repeat_n("?", source_ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        values.extend(source_ids.iter().copied().map(SqlValue::Integer));
+        format!("source_id IN ({placeholders})")
+    }
+
+    fn fact_path_filter_sql(
+        filter: &FactQueryFilter,
+        path_columns: &[&str],
+        values: &mut Vec<SqlValue>,
+    ) -> Option<String> {
+        match filter {
+            FactQueryFilter::Scope(scope) if scope == "." => None,
+            FactQueryFilter::Scope(scope) => {
+                let predicates = path_columns
+                    .iter()
+                    .map(|column| {
+                        values.push(scope.clone().into());
+                        values.push(scope.clone().into());
+                        values.push(scope.clone().into());
+                        format!("({column} = ? OR substr({column}, 1, length(?) + 1) = ? || '/')")
+                    })
+                    .collect::<Vec<_>>();
+                Some(format!("({})", predicates.join(" OR ")))
+            }
+            FactQueryFilter::Paths(paths) if paths.is_empty() => Some("0 = 1".into()),
+            FactQueryFilter::Paths(paths) => {
+                let placeholders = std::iter::repeat_n("?", paths.len())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let predicates = path_columns
+                    .iter()
+                    .map(|column| {
+                        values.extend(paths.iter().cloned().map(SqlValue::Text));
+                        format!("{column} IN ({placeholders})")
+                    })
+                    .collect::<Vec<_>>();
+                let joiner = if path_columns.len() > 1 {
+                    " AND "
+                } else {
+                    " OR "
+                };
+                Some(format!("({})", predicates.join(joiner)))
+            }
+        }
+    }
+
+    pub(crate) fn fact_annotations(
+        &self,
+        source_ids: &[i64],
+        filter: &FactQueryFilter,
+        limit: usize,
+    ) -> SqlResult<(Vec<FactAnnotation>, bool)> {
+        if !self.fact_tables_exist()? || source_ids.is_empty() {
+            return Ok((Vec::new(), false));
+        }
+        let limit = limit.clamp(1, 10_000);
+        let mut values = Vec::<SqlValue>::new();
+        let mut predicates = vec![Self::fact_source_filter_sql(source_ids, &mut values)];
+        if let Some(predicate) = Self::fact_path_filter_sql(filter, &["fa.path"], &mut values) {
+            predicates.push(predicate);
+        }
+        let sql = format!(
+            "SELECT fs.producer_name, fs.dataset, fa.fact_id, fa.path, fa.line,
+                    fa.column_no, fa.end_line, fa.end_column, fa.severity,
+                    fa.category, fa.title, fa.message
+             FROM fact_annotations fa
+             JOIN fact_sources fs ON fs.id = fa.source_id
+             WHERE {}
+             ORDER BY fa.path, fa.line, fa.fact_id, fs.producer_name, fs.dataset
+             LIMIT ?",
+            predicates.join(" AND ")
+        );
+        values.push((limit.saturating_add(1) as i64).into());
+        let mut statement = self.conn.prepare(&sql)?;
+        let rows = statement.query_map(rusqlite::params_from_iter(values.iter()), |row| {
+            let producer: String = row.get(0)?;
+            let dataset: String = row.get(1)?;
+            Ok(FactAnnotation {
+                source_id: source_public_id(&producer, &dataset),
+                fact_id: row.get(2)?,
+                path: row.get(3)?,
+                line: row.get(4)?,
+                column: row.get(5)?,
+                end_line: row.get(6)?,
+                end_column: row.get(7)?,
+                severity: row.get(8)?,
+                category: row.get(9)?,
+                title: row.get(10)?,
+                message: row.get(11)?,
+            })
+        })?;
+        let mut items = rows.collect::<SqlResult<Vec<_>>>()?;
+        let truncated = items.len() > limit;
+        items.truncate(limit);
+        Ok((items, truncated))
+    }
+
+    pub(crate) fn fact_relationships(
+        &self,
+        source_ids: &[i64],
+        filter: &FactQueryFilter,
+        limit: usize,
+    ) -> SqlResult<(Vec<FactRelationship>, bool)> {
+        if !self.fact_tables_exist()? || source_ids.is_empty() {
+            return Ok((Vec::new(), false));
+        }
+        let limit = limit.clamp(1, 10_000);
+        let mut values = Vec::<SqlValue>::new();
+        let mut predicates = vec![Self::fact_source_filter_sql(source_ids, &mut values)];
+        if let Some(predicate) =
+            Self::fact_path_filter_sql(filter, &["fr.from_path", "fr.to_path"], &mut values)
+        {
+            predicates.push(predicate);
+        }
+        let sql = format!(
+            "SELECT fs.producer_name, fs.dataset, fr.fact_id, fr.relation,
+                    fr.from_path, fr.from_line, fr.from_column, fr.to_path,
+                    fr.to_line, fr.to_column, fr.confidence, fr.label
+             FROM fact_relationships fr
+             JOIN fact_sources fs ON fs.id = fr.source_id
+             WHERE {}
+             ORDER BY fr.from_path, fr.from_line, fr.to_path, fr.to_line,
+                      fr.fact_id, fs.producer_name, fs.dataset
+             LIMIT ?",
+            predicates.join(" AND ")
+        );
+        values.push((limit.saturating_add(1) as i64).into());
+        let mut statement = self.conn.prepare(&sql)?;
+        let rows = statement.query_map(rusqlite::params_from_iter(values.iter()), |row| {
+            let producer: String = row.get(0)?;
+            let dataset: String = row.get(1)?;
+            Ok(FactRelationship {
+                source_id: source_public_id(&producer, &dataset),
+                fact_id: row.get(2)?,
+                relation: row.get(3)?,
+                from_path: row.get(4)?,
+                from_line: row.get(5)?,
+                from_column: row.get(6)?,
+                to_path: row.get(7)?,
+                to_line: row.get(8)?,
+                to_column: row.get(9)?,
+                confidence: row.get(10)?,
+                label: row.get(11)?,
+            })
+        })?;
+        let mut items = rows.collect::<SqlResult<Vec<_>>>()?;
+        let truncated = items.len() > limit;
+        items.truncate(limit);
+        Ok((items, truncated))
     }
 
     /// Wipe everything related to a single file before re-indexing it.

--- a/schemas/mastermind-facts-v1.schema.json
+++ b/schemas/mastermind-facts-v1.schema.json
@@ -1,0 +1,327 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/xcrft/mastermind/schemas/mastermind-facts-v1.schema.json",
+  "title": "Mastermind declarative facts manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "api_version",
+    "capabilities",
+    "repository",
+    "producer",
+    "dataset",
+    "provenance",
+    "files",
+    "artifacts",
+    "facts"
+  ],
+  "properties": {
+    "api_version": {
+      "const": "mastermind-facts/v1"
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "enum": ["annotations", "relationships"]
+      }
+    },
+    "repository": {
+      "$ref": "#/$defs/repository"
+    },
+    "producer": {
+      "$ref": "#/$defs/producer"
+    },
+    "dataset": {
+      "$ref": "#/$defs/token"
+    },
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    },
+    "files": {
+      "type": "array",
+      "maxItems": 10000,
+      "items": {
+        "$ref": "#/$defs/file"
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "$ref": "#/$defs/artifact"
+      }
+    },
+    "facts": {
+      "type": "array",
+      "maxItems": 100000,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/annotation"
+          },
+          {
+            "$ref": "#/$defs/relationship"
+          }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "token": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9._/:-]+$"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^[A-Za-z0-9._/:-]+$"
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "not": {
+        "anyOf": [
+          {
+            "const": "."
+          },
+          {
+            "pattern": "^(?:/|.*(?:^|/)\\.\\.(?:/|$))"
+          },
+          {
+            "pattern": "(?:^|/)\\.(?:/|$)"
+          },
+          {
+            "pattern": "/$"
+          },
+          {
+            "pattern": "[\\\\:\\u0000-\\u001f\\u007f]"
+          },
+          {
+            "pattern": "//"
+          }
+        ]
+      }
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identity", "revision"],
+      "properties": {
+        "identity": {
+          "type": "string",
+          "pattern": "^git-(?:remote|worktree):sha256:[0-9a-f]{64}$"
+        },
+        "revision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/token"
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "artifacts"],
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/token"
+        },
+        "artifacts": {
+          "type": "array",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        }
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "bytes"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/path"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5242880
+        }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "path", "sha256", "bytes"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "path": {
+          "$ref": "#/$defs/path"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 33554432
+        }
+      }
+    },
+    "location": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "line"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/path"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4294967295
+        },
+        "column": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4294967295
+        }
+      }
+    },
+    "annotation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id",
+        "path",
+        "line",
+        "severity",
+        "category",
+        "title",
+        "message"
+      ],
+      "properties": {
+        "kind": {
+          "const": "annotation"
+        },
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "path": {
+          "$ref": "#/$defs/path"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4294967295
+        },
+        "column": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4294967295
+        },
+        "end_line": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4294967295
+        },
+        "end_column": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4294967295
+        },
+        "severity": {
+          "enum": ["info", "warning", "error"]
+        },
+        "category": {
+          "$ref": "#/$defs/token"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096,
+          "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+        }
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id",
+        "relation",
+        "from",
+        "to",
+        "confidence",
+        "label"
+      ],
+      "properties": {
+        "kind": {
+          "const": "relationship"
+        },
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "relation": {
+          "$ref": "#/$defs/token"
+        },
+        "from": {
+          "$ref": "#/$defs/location"
+        },
+        "to": {
+          "$ref": "#/$defs/location"
+        },
+        "confidence": {
+          "enum": ["low", "medium", "high", "observed"]
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+        }
+      }
+    }
+  }
+}

--- a/schemas/mastermind-review-manifest-v1.schema.json
+++ b/schemas/mastermind-review-manifest-v1.schema.json
@@ -102,7 +102,7 @@
         "head_oid": { "$ref": "#/$defs/git_oid" },
         "sources": {
           "type": "array",
-          "maxItems": 65,
+          "maxItems": 193,
           "items": { "$ref": "#/$defs/evidence_source" }
         },
         "attestation": { "$ref": "#/$defs/attestation" }
@@ -137,7 +137,7 @@
       "required": ["id", "kind", "label", "repository_relative", "sha256", "bytes", "analysis_status", "revision_binding"],
       "properties": {
         "id": { "type": "string", "minLength": 1 },
-        "kind": { "enum": ["sarif", "coverage", "junit", "otel", "codeowners"] },
+        "kind": { "enum": ["sarif", "coverage", "junit", "otel", "codeowners", "facts"] },
         "label": { "type": "string", "minLength": 1 },
         "repository_relative": { "type": "boolean" },
         "sha256": { "$ref": "#/$defs/sha256" },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,8 @@ npm, or model-backed test suites. CI executes it on every change.
 ### What it checks
 
 - artifact frontmatter, names, versions, domains, links, and template mirrors;
-- exact MCP tool count plus read/write annotations;
+- exact MCP tool count plus read/write annotations, and parity of the public
+  declarative-fact schema with its CLI/MCP/Lens ingestion boundary;
 - portable skill adapters and one behavioral eval case per shipped skill;
 - planner/executor/auditor ownership and structured-report schema parity;
 - GitHub Action SHA pins, required-check routing, Docker runtime packaging, and

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1035,6 +1035,140 @@ def validate_review_package_contract() -> list[Issue]:
     return issues
 
 
+# ----- declarative fact-ingestion SDK -----------------------------------
+
+def validate_fact_ingestion_sdk_contract() -> list[Issue]:
+    """Keep the public fact schema and its non-executable ingestion boundary aligned."""
+    issues: list[Issue] = []
+    schema_path = REPO_ROOT / "schemas/mastermind-facts-v1.schema.json"
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        return [Issue(schema_path, "error", f"invalid fact manifest schema: {error}")]
+
+    required = {
+        "api_version",
+        "capabilities",
+        "repository",
+        "producer",
+        "dataset",
+        "provenance",
+        "files",
+        "artifacts",
+        "facts",
+    }
+    if schema.get("additionalProperties") is not False:
+        issues.append(Issue(schema_path, "error", "fact schema must reject unknown root fields"))
+    if set(schema.get("required", [])) != required:
+        issues.append(Issue(schema_path, "error", "fact schema required fields drifted"))
+    properties = schema.get("properties", {})
+    if properties.get("api_version", {}).get("const") != "mastermind-facts/v1":
+        issues.append(Issue(schema_path, "error", "fact schema must pin mastermind-facts/v1"))
+    capabilities = properties.get("capabilities", {}).get("items", {}).get("enum", [])
+    if capabilities != ["annotations", "relationships"]:
+        issues.append(Issue(schema_path, "error", "fact capability allowlist drifted"))
+    definitions = schema.get("$defs", {})
+    for name in (
+        "repository",
+        "producer",
+        "provenance",
+        "file",
+        "artifact",
+        "location",
+        "annotation",
+        "relationship",
+    ):
+        if definitions.get(name, {}).get("additionalProperties") is not False:
+            issues.append(
+                Issue(schema_path, "error", f"fact schema definition {name!r} must reject unknown fields")
+            )
+
+    facts_path = REPO_ROOT / "mcp/servers/mmcg/src/facts.rs"
+    try:
+        rust = facts_path.read_text(encoding="utf-8")
+    except OSError as error:
+        issues.append(Issue(facts_path, "error", f"cannot read fact ingestion module: {error}"))
+    else:
+        for token in (
+            'API_VERSION: &str = "mastermind-facts/v1"',
+            'SUPPORTED_CAPABILITIES: [&str; 2] = ["annotations", "relationships"]',
+            "deny_unknown_fields",
+            "from_json_strict",
+            "run_bounded_git_with_limit",
+            "validate_index_root",
+            "current_head_oid",
+            "MAX_MANIFEST_BYTES",
+            "replace_fact_dataset",
+            "snapshot_for_paths",
+            "fact_source_stale",
+        ):
+            if token not in rust:
+                issues.append(Issue(facts_path, "error", f"fact ingestion contract missing {token!r}"))
+        production = rust.split("#[cfg(test)]", 1)[0]
+        for forbidden in ("Command::new(", "CREATE TABLE", "libloading", "dlopen"):
+            if forbidden in production:
+                issues.append(
+                    Issue(facts_path, "error", f"fact ingestion boundary contains forbidden {forbidden!r}")
+                )
+
+    store_path = REPO_ROOT / "mcp/servers/mmcg/src/store.rs"
+    try:
+        store = store_path.read_text(encoding="utf-8")
+    except OSError as error:
+        issues.append(Issue(store_path, "error", f"cannot read normalized fact store: {error}"))
+    else:
+        for token in (
+            "fact_sources",
+            "fact_files",
+            "fact_artifacts",
+            "fact_annotations",
+            "fact_relationships",
+            "replace_fact_dataset",
+            "transaction()",
+        ):
+            if token not in store:
+                issues.append(Issue(store_path, "error", f"normalized fact store missing {token!r}"))
+
+    surface_paths = {
+        "mcp/servers/mmcg/src/main.rs": ("facts: Option<PathBuf>", "QueryCmd::Facts"),
+        "mcp/servers/mmcg/src/mcp.rs": (
+            'read_only_tool("mmcg_facts"',
+            "crate::facts::snapshot",
+        ),
+        "mcp/servers/mmcg/src/evidence.rs": (
+            "snapshot_for_paths",
+            "fact_artifacts",
+            "fact_relationships",
+        ),
+        "mcp/servers/mmcg/src/review_package.rs": (
+            "normalized_fact_revision_binding",
+            "fact_artifacts",
+            'kind: "facts".into()',
+        ),
+        "mcp/servers/mmcg/assets/lens/app.js": (
+            "factMatchesGraphEdge",
+            "factEvidence",
+        ),
+        "docs/fact-ingestion-sdk.md": (
+            "mastermind-facts/v1",
+            "mastermind enrich --facts",
+            "no direct SQLite access",
+        ),
+    }
+    for relative, tokens in surface_paths.items():
+        path = REPO_ROOT / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as error:
+            issues.append(Issue(path, "error", f"cannot read fact SDK surface: {error}"))
+            continue
+        for token in tokens:
+            if token not in text:
+                issues.append(Issue(path, "error", f"fact SDK surface missing {token!r}"))
+
+    return issues
+
+
 # ----- repository workflow supply-chain contract -----------------------
 
 def validate_repository_workflow_pins() -> list[Issue]:
@@ -1524,6 +1658,7 @@ def main(argv: list[str]) -> int:
     issues.extend(validate_workflow_eval_contract())
     issues.extend(validate_executor_report_schema_contract())
     issues.extend(validate_review_package_contract())
+    issues.extend(validate_fact_ingestion_sdk_contract())
     issues.extend(validate_repository_workflow_pins())
     issues.extend(validate_audit_action_security())
 


### PR DESCRIPTION
## Summary

- publish the strict `mastermind-facts/v1` JSON schema and SDK guide
- validate repository identity, exact Git revision, canonical source paths, sizes, SHA-256 digests, capabilities, and provenance before ingestion
- atomically normalize annotations and relationships into Mastermind-owned `fact_*` SQLite tables
- expose facts through `mastermind enrich --facts`, `mastermind query facts`, and the static read-only `mmcg_facts` MCP tool
- project normalized facts into Lens and autonomous PR evidence packages without allowing them to create graph topology
- bind fact manifests and provenance artifacts to the exported review manifest

## Security boundaries

- no native or in-process plugin execution
- no dynamic MCP handler registration
- no executable custom policy rules
- no producer access to SQLite
- no native Tree-sitter grammar loading
- bounded manifests, sources, artifacts, facts, diagnostics, and query responses
- traversal, non-canonical paths, symlink parents, stale revisions, changed sources, and changed provenance fail closed
- `producer-attested` remains an explicit unsigned claim unless the surrounding workflow supplies a stronger trust anchor

## Proof

- `just check`
  - Rust: 519 library tests, 53 CLI tests, 20 golden tests, policy CLI
  - npm: 17 tests
  - Lens DOM/static regression suite
  - workflow security fixtures: 37 tests
  - eval harness: 16 tests
  - validator: 39 artifacts, 0 errors, 0 warnings
  - clippy/fmt and cargo-deny passed
- `cargo package --locked --allow-dirty`
  - packaged 78 files
  - crate verification build passed
- focused review-package fact binding regression passed
- `git diff --check` passed

## Review status

Draft pending independent review of the public API, SQLite/data contract, and security boundary.

## Non-scope

This does not merge or release anything. It does not add executable plugins, dynamic policy/MCP extension points, custom native grammars, or direct SQLite access.

## Rollback

Revert the feature commit. The new tables are additive local index state; rebuilding the local index removes retained imported facts if cleanup is needed.
