### PR TITLE
chore(release): prepare Mastermind 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-13
+
+### Upgrade notes
+- 2.0.0 raises the on-disk graph schema from `6` to `7` and the extractor
+  contract from `mmcg-extractors-v2` to `mmcg-extractors-v3`. Run
+  `mastermind index .` once after upgrading. It rebuilds derived graph tables
+  in place while preserving repository identity and durable history/scratchpad
+  data; no manual SQLite migration is required. Refresh the index before
+  trusting Lens, MCP, map, impact, temporal, or policy results.
+- Package and command names remain `@xcraftmind/mastermind`, `mastermind`, and
+  `mmcg`. The Node.js 24+ and Rust 1.96+ requirements are unchanged.
+
 ### Added
 - Built-in `mastermind facts adapt` converters turn bounded SARIF,
   LCOV/Cobertura, JUnit, and OTLP JSON artifacts into strict
@@ -635,7 +647,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Seven prebuilt platform packages (`@xcraftmind/mmcg-*`) covering macOS (arm64, x64), Linux glibc and musl (x64, arm64), and Windows (x64). npm installs only the package matching the host's `os` / `cpu` / `libc`.
 - Install-mode-aware `setup claude` that writes the correct MCP `command` form for npx, global, project-local, and cargo installs.
 
-[Unreleased]: https://github.com/xcrft/mastermind/compare/npm-v1.1.1...HEAD
+[Unreleased]: https://github.com/xcrft/mastermind/compare/npm-v2.0.0...HEAD
+[2.0.0]: https://github.com/xcrft/mastermind/compare/npm-v1.2.1...npm-v2.0.0
+[1.2.1]: https://github.com/xcrft/mastermind/compare/npm-v1.2.0...npm-v1.2.1
+[1.2.0]: https://github.com/xcrft/mastermind/compare/npm-v1.1.1...npm-v1.2.0
 [1.1.1]: https://github.com/xcrft/mastermind/compare/npm-v1.1.0...npm-v1.1.1
 [1.1.0]: https://github.com/xcrft/mastermind/compare/npm-v1.0.0...npm-v1.1.0
 [1.0.0]: https://github.com/xcrft/mastermind/compare/npm-v0.38.1...npm-v1.0.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@xcraftmind/mastermind"><img src="https://img.shields.io/badge/npm-v1.2.1-CB3837?logo=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@xcraftmind/mastermind"><img src="https://img.shields.io/badge/npm-v2.0.0-CB3837?logo=npm" alt="npm version"></a>
   <a href="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml"><img src="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <a href="evals/scorecard.md"><img src="https://img.shields.io/badge/evals-critic%20%2B%20auditor%20%2B%20intake%20%2B%20workflow-yellowgreen" alt="Evals"></a>

--- a/agents/claude-md/mastermind-workflow.md
+++ b/agents/claude-md/mastermind-workflow.md
@@ -2,7 +2,7 @@
 name: mastermind-workflow
 description: Compact project router for the Mastermind Direct, Verified, and Strict workflows.
 metadata:
-  version: 1.2.1
+  version: 2.0.0
   authors: [mastermind]
   tags: [claude-md, workflow, delegation, audit]
 ---

--- a/docs/examples/mastermind-review-pr.yml
+++ b/docs/examples/mastermind-review-pr.yml
@@ -40,7 +40,7 @@ jobs:
             install -m 0755 mcp/servers/mmcg/target/release/mmcg "$RUNNER_TEMP/mastermind-bin/mastermind"
             echo "MASTERMIND_BIN=$RUNNER_TEMP/mastermind-bin/mastermind" >> "$GITHUB_ENV"
           else
-            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@1.2.1
+            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@2.0.0
             echo "MASTERMIND_BIN=mastermind" >> "$GITHUB_ENV"
           fi
 

--- a/mcp/servers/mmcg/Cargo.lock
+++ b/mcp/servers/mmcg/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "mmcg"
-version = "1.2.1"
+version = "2.0.0"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/mcp/servers/mmcg/Cargo.toml
+++ b/mcp/servers/mmcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmcg"
-version = "1.2.1"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.96"
 build = "build.rs"

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -2,7 +2,7 @@
 name: mmcg
 description: Mastermind Codegraph — fast multi-language code indexer (Python + TypeScript/TSX + JavaScript/JSX + Vue SFC + Rust + C# + Go + Java + PHP + C/C++) exposed over MCP. Indexes symbols, calls, imports, and durable project history into a local SQLite database and exposes 25 bounded tools for AI coding agents.
 metadata:
-  version: 1.2.1
+  version: 2.0.0
   authors:
     - mastermind
   tags:

--- a/mcp/servers/mmcg/assets/mastermind-review-pr.yml
+++ b/mcp/servers/mmcg/assets/mastermind-review-pr.yml
@@ -40,7 +40,7 @@ jobs:
             install -m 0755 mcp/servers/mmcg/target/release/mmcg "$RUNNER_TEMP/mastermind-bin/mastermind"
             echo "MASTERMIND_BIN=$RUNNER_TEMP/mastermind-bin/mastermind" >> "$GITHUB_ENV"
           else
-            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@1.2.1
+            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@2.0.0
             echo "MASTERMIND_BIN=mastermind" >> "$GITHUB_ENV"
           fi
 

--- a/mcp/servers/mmcg/templates/workflow.md
+++ b/mcp/servers/mmcg/templates/workflow.md
@@ -2,7 +2,7 @@
 name: mastermind-workflow
 description: Compact project router for the Mastermind Direct, Verified, and Strict workflows.
 metadata:
-  version: 1.2.1
+  version: 2.0.0
   authors: [mastermind]
   tags: [claude-md, workflow, delegation, audit]
 ---

--- a/npm/mastermind/README.md
+++ b/npm/mastermind/README.md
@@ -1,6 +1,6 @@
 # @xcraftmind/mastermind
 
-[![npm](https://img.shields.io/badge/npm-v1.2.1-CB3837?logo=npm)](https://www.npmjs.com/package/@xcraftmind/mastermind)
+[![npm](https://img.shields.io/badge/npm-v2.0.0-CB3837?logo=npm)](https://www.npmjs.com/package/@xcraftmind/mastermind)
 [![CI](https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml/badge.svg)](https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/xcrft/mastermind/blob/main/LICENSE)
 

--- a/npm/mastermind/package.json
+++ b/npm/mastermind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mastermind",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Local codegraph and verifiable workflow for AI coding agents — project maps, change and test impact, MCP queries, Vue SFC indexing, and diff-backed implementation audits. Prebuilt binaries for macOS, Linux, and Windows.",
   "license": "MIT",
   "author": "xcraftmind",
@@ -42,12 +42,12 @@
     "mastermind"
   ],
   "optionalDependencies": {
-    "@xcraftmind/mmcg-darwin-arm64": "1.2.1",
-    "@xcraftmind/mmcg-darwin-x64": "1.2.1",
-    "@xcraftmind/mmcg-linux-x64-gnu": "1.2.1",
-    "@xcraftmind/mmcg-linux-arm64-gnu": "1.2.1",
-    "@xcraftmind/mmcg-linux-x64-musl": "1.2.1",
-    "@xcraftmind/mmcg-linux-arm64-musl": "1.2.1",
-    "@xcraftmind/mmcg-win32-x64-msvc": "1.2.1"
+    "@xcraftmind/mmcg-darwin-arm64": "2.0.0",
+    "@xcraftmind/mmcg-darwin-x64": "2.0.0",
+    "@xcraftmind/mmcg-linux-x64-gnu": "2.0.0",
+    "@xcraftmind/mmcg-linux-arm64-gnu": "2.0.0",
+    "@xcraftmind/mmcg-linux-x64-musl": "2.0.0",
+    "@xcraftmind/mmcg-linux-arm64-musl": "2.0.0",
+    "@xcraftmind/mmcg-win32-x64-msvc": "2.0.0"
   }
 }

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-darwin-arm64",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Prebuilt mmcg binary for macOS arm64 (Apple Silicon). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/darwin-x64/package.json
+++ b/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-darwin-x64",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Prebuilt mmcg binary for macOS x86_64 (Intel). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-arm64-gnu/package.json
+++ b/npm/platforms/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-arm64-gnu",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Prebuilt mmcg binary for Linux arm64 glibc. Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-arm64-musl/package.json
+++ b/npm/platforms/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-arm64-musl",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Prebuilt mmcg binary for Linux arm64 musl (Alpine, distroless). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-x64-gnu/package.json
+++ b/npm/platforms/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-x64-gnu",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Prebuilt mmcg binary for Linux x86_64 glibc. Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-x64-musl/package.json
+++ b/npm/platforms/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-x64-musl",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Prebuilt mmcg binary for Linux x86_64 musl (Alpine, distroless). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/win32-x64-msvc/package.json
+++ b/npm/platforms/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-win32-x64-msvc",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Prebuilt mmcg binary for Windows x86_64 (MSVC). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",


### PR DESCRIPTION
## Release scope

Prepare Mastermind 2.0.0 in lockstep across:

- `mmcg` on crates.io;
- `@xcraftmind/mastermind` on npm;
- all seven `@xcraftmind/mmcg-*` native npm packages;
- shipped workflow metadata, install examples, badges, and changelog links.

This PR only prepares the release. It does **not** create tags, publish packages, or create a GitHub Release.

## 2.0 highlights

- Mastermind Lens: local, read-only, diff-first architecture review UI.
- Evidence overlays for SARIF, coverage, JUnit, OpenTelemetry, CODEOWNERS, churn, and project knowledge.
- Autonomous PR evidence package with HTML, SARIF, summary, revision-bound manifest, and CI workflow.
- Optional SCIP semantic enrichment with explicit provenance and confidence.
- Architecture policy as code and temporal architecture graph.
- Declarative fact-ingestion SDK, revision binding, Ed25519 producer provenance, and normalized Lens/MCP facts.
- Bounded local team graph across pinned repository indexes.

## Upgrade notes

- The graph schema moves from `6` to `7` and the extractor contract from `mmcg-extractors-v2` to `mmcg-extractors-v3`.
- Run `mastermind index .` once after upgrading. Derived graph tables rebuild in place; repository identity and durable history/scratchpad data are preserved.
- Refresh the index before trusting Lens, MCP, map, impact, temporal, or policy output.
- No manual SQLite migration is required.
- Package names, `mastermind` / `mmcg` commands, Node.js 24+, and Rust 1.96+ remain unchanged.

## Proof

- `just check` — PASS
  - Rust: 530 library + 54 CLI + 5 fact-lifecycle + 20 golden + 1 policy tests
  - npm: 17/17
  - Lens DOM/static: PASS
  - workflow security: 38/38
  - eval harness: 16/16
  - validator: 39 artifacts, 0 errors, 0 warnings
  - fmt, clippy, cargo-deny: PASS
- `just package` — PASS; `mmcg-2.0.0.crate`, 82 files, packaged and rebuilt successfully.
- `just publish-dry` — PASS; reached the crates.io upload boundary and aborted without upload as expected.
- `just npm-smoke-native` — PASS on `aarch64-apple-darwin`; assembled the 2.0.0 binary, packed root + native tarballs, installed them into a clean temporary project, and verified `mastermind 2.0.0`.
- Archive inspection — PASS:
  - crate manifest: `mmcg 2.0.0`;
  - root npm tarball: `@xcraftmind/mastermind 2.0.0`, 79 files;
  - native npm tarball: `@xcraftmind/mmcg-darwin-arm64 2.0.0`, 3 files.
- Release contract review — PASS: exactly 18 release-only files, Cargo + eight npm manifests in lockstep, workflow/template mirrors exact, changelog links consistent, no P0–P3 findings.

Local proof artifact SHA-256 values (CI will rebuild and seal the actual publish artifacts):

```text
c0df83998cbce866212e1f4aa733ed5314308d2d53f67b8a01e68ad342480a63  mmcg-2.0.0.crate
13c100b6836129dbd861296b669846e21fc0831da2a9dcb1d4eddccd506aff0f  xcraftmind-mastermind-2.0.0.tgz
fcb475e3e2c292a9396936830117ea047c86b6c054b7c8e5940eb775e9202261  xcraftmind-mmcg-darwin-arm64-2.0.0.tgz
```

## Live release readiness

- `2.0.0` is absent from npm and crates.io.
- `npm-v2.0.0` and `mmcg-v2.0.0` do not exist.
- Active tag rulesets cover both `npm-v*` and `mmcg-v*`.
- `npm-prod` and `prod` environments have required-reviewer gates and exact tag policies.
- `NPM_TOKEN` and `CARGO_REGISTRY_TOKEN` are configured in their respective environments.
- The latest 1.2.1 npm and crates.io publish workflows, including public registry smoke jobs, completed successfully.

## Post-merge release plan

1. Require all protected PR checks and approval, then squash-merge this PR.
2. Resolve and pin the exact resulting `main` SHA.
3. Run both publish workflows with `workflow_dispatch` on that SHA. Manual dispatch is verify-only and cannot publish.
4. After both verify-only runs pass, create `mmcg-v2.0.0` and `npm-v2.0.0` on the exact same `main` SHA and push both tags atomically.
5. Approve the `prod` and `npm-prod` deployment gates.
6. Wait for crates.io and npm publication plus both public installed-package smoke jobs.
7. Verify all eight npm packages, the crate, and installed `mastermind --version` from the public registries.
8. Create the GitHub Release only after both registry workflows are green.

## Abort and recovery

- Before tags: revert this release-prep commit or close the PR; no external state exists.
- After tags but before publication: stop at the environment approval gate and investigate; do not move or reuse the tags.
- After any registry publication: package versions are immutable. Do not overwrite 2.0.0; deprecate/yank only when justified and ship a corrected 2.0.1.
- If one registry succeeds and the other fails, stop further manual actions, preserve logs/artifacts, and recover the missing target without republishing different bytes under 2.0.0.
