### PR TITLE
docs: overhaul documentation for 2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,35 +1,38 @@
 ---
 name: Bug report
-about: An artifact doesn't work as documented
-title: "[bug] <artifact-path>: <short summary>"
+about: Report reproducible incorrect behavior
+title: "[bug] "
 labels: bug
 ---
 
-## Artifact
+## Summary
 
-Path: `<e.g., skills/code-review/pr-review/SKILL.md>`
+<!-- One sentence describing the incorrect behavior. -->
 
-## What you tried
+## Reproduction
 
-<What did you do? What prompt did you give? What was the setup?>
+```text
+# Minimal commands, configuration, or repository shape
+```
 
-## What you expected
+## Expected behavior
 
-<What should have happened, based on the artifact's description and docs?>
+<!-- What should happen? Link the relevant contract when possible. -->
 
-## What actually happened
+## Actual behavior
 
-<What did happen? Include error output, agent response, or unexpected behavior.>
+```text
+# Exact error, bounded log, or incorrect result
+```
 
 ## Environment
 
-- Tool: <Claude Code / claude.ai / API / other>
-- Model: <opus 4.7 / sonnet 4.6 / …>
-- OS: <macOS 15 / Ubuntu 24.04 / …>
-- Anything else relevant: <plugins, MCP servers, custom settings>
+- Mastermind version (`mastermind --version`):
+- Installation method: npm / Cargo / source / GitHub Action
+- Operating system and architecture:
+- Git version:
+- Client, if MCP-related:
 
-## Reproducible?
+## Additional evidence
 
-- [ ] Yes, every time
-- [ ] Yes, sometimes (flaky)
-- [ ] Saw it once
+<!-- Minimal fixture, redacted manifest, screenshot, or trace. Do not include secrets. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,21 @@
-<!--
-Thanks for contributing. Fill in the sections below; delete any that don't apply.
--->
+## Summary
 
-## What this PR does
+<!-- What changed and why? Keep this to the behavior or contract. -->
 
-<One or two sentences — what changes and why.>
+## Scope
 
-## Type of change
+<!-- Name the affected surfaces and any deliberate exclusions. -->
 
-- [ ] mmcg (Rust) — indexer / MCP / CLI / miner
-- [ ] Workflow artifact — skill / subagent / CLAUDE.md template
-- [ ] Docs
-- [ ] Bug fix
+## Verification
 
-## Checklist
+<!-- List exact commands and results. Mark unavailable live proof explicitly. -->
 
-- [ ] `cargo test` + `cargo clippy -- -D warnings` + `cargo fmt --check` pass (if Rust touched)
-- [ ] `python3 scripts/validate.py` passes (if artifacts touched)
-- [ ] Ran the evals for any changed subagent/skill prompt (`evals/runner.py`)
-- [ ] Change is focused; commit subjects use a conventional prefix
+- [ ] `just check`
+- [ ] Focused regression test added or updated when behavior changed
+- [ ] Documentation updated when a public command, schema, or limit changed
+- [ ] Screenshots attached when rendered behavior changed
+- [ ] No release or external publication was performed from this branch
 
-## How I tested it
+## Compatibility and risk
 
-<Concrete. What did you run? Input → output.>
-
-## Breaking change?
-
-<If yes: what breaks and the migration path. If no, delete this section.>
+<!-- Breaking behavior, migration path, security boundary, or `None`. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,18 +1,28 @@
 # Code of Conduct
 
-This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+This project follows the
+[Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+The full linked text is the governing policy.
 
-## In short
+## Expected conduct
 
-- Be respectful. Critique ideas, not people.
-- Assume good intent.
-- No harassment, no discrimination, no personal attacks.
-- Disagreements happen — keep them technical and concrete.
+- Critique code and ideas, not people.
+- Keep technical disagreements specific and evidence-based.
+- Do not harass, discriminate, threaten, or publish another person's private
+  information.
+- Respect a maintainer's decision to close or moderate a discussion.
 
-## Reporting
+## Report a violation
 
-If you experience or witness behavior that violates this code, open a private issue or email the maintainers. Reports are handled confidentially.
+Do not put sensitive details in a public issue. Contact the repository owner
+through the [xcrft GitHub profile](https://github.com/xcrft) and request a
+private reporting channel. Include links or screenshots, dates, participants,
+and the behavior that violated the policy. Reports are shared only with the
+people required to investigate and respond.
 
 ## Enforcement
 
-Maintainers may remove comments, commits, or contributors who violate this code. Repeated or serious violations result in a permanent ban.
+Maintainers may edit or remove content, lock discussions, reject contributions,
+issue a warning, or temporarily or permanently exclude a participant. The
+response depends on impact, context, and repeated behavior. Retaliation against
+a reporter is itself a violation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,74 +1,122 @@
 # Contributing
 
-Mastermind is two things: **mmcg** (a Rust codegraph binary) and a **spec-driven workflow** (the subagents + skills installed into Claude Code). Contributions to either are welcome.
+Mastermind combines a Rust codegraph engine with installable workflow artifacts.
+Keep changes focused, preserve local-first behavior, and attach the exact checks
+you ran.
 
-## Project layout
+## Repository layout
 
-| Path | What it is |
+| Path | Responsibility |
 |---|---|
-| `mcp/servers/mmcg/` | The mmcg binary — Rust crate: indexer, MCP server, CLI gates, miners. |
-| `skills/` · `agents/` | The workflow artifacts (markdown + YAML frontmatter) installed by `mastermind init`. |
-| `npm/mastermind/` | The npm wrapper that ships the prebuilt binary + the workflow bundle. |
-| `scripts/` | `validate.py` (artifact-structure check) and friends. |
-| `evals/` | Adversarial eval suites for critic, auditor, intake, and all portable workflow skills. |
+| `mcp/servers/mmcg/` | Rust CLI, indexer, SQLite store, MCP server, Lens backend |
+| `mcp/servers/mmcg/assets/lens/` | Static Lens application |
+| `skills/`, `agents/` | Installed workflow and agent contracts |
+| `schemas/` | Public, versioned JSON contracts |
+| `npm/` | npm wrapper and platform packages |
+| `action.yml`, `Dockerfile` | GitHub Action runtime |
+| `docs/` | User and maintainer documentation |
+| `scripts/` | Validation, packaging, release, and smoke-test tooling |
+| `evals/` | Deterministic harness tests and optional model-backed evaluations |
 
-## Dev setup & checks
+## Prerequisites
 
-**Rust (`mcp/servers/mmcg/`)** — run all three before opening a PR:
+- Rust toolchain declared in `rust-toolchain.toml`
+- Node.js 24 or newer
+- Python 3.11 or newer
+- [`just`](https://github.com/casey/just)
+- `cargo-deny`
 
-```bash
-cd mcp/servers/mmcg
-cargo test
-cargo clippy --all-targets -- -D warnings
-cargo fmt -- --check
-cargo deny check
-```
-
-**Workflow artifacts (`skills/`, `agents/`)** — markdown with frontmatter; CI runs the structure validator, run it locally too:
+Install the Python validator dependencies once:
 
 ```bash
 python3 -m venv .venv
 .venv/bin/pip install --require-hashes -r scripts/requirements.txt
-.venv/bin/python scripts/validate.py
 ```
 
-Exit code 0 means clean. See [`scripts/README.md`](scripts/README.md) for what it checks.
+## Canonical check
 
-**npm distribution** — run the host-native packaging smoke before changing the
-wrapper or release assembly:
+Run this before opening a pull request:
 
 ```bash
-just npm-smoke-native
+just check
 ```
 
-This builds the native release binary, assembles its platform package, packs
-the root and platform npm tarballs, installs both tarballs in a scratch project,
-and runs the installed wrapper. It does not read from or publish to npm.
+It runs the locked Rust tests, formatting and Clippy checks, npm tests, Lens
+tests, workflow-security tests, deterministic eval-harness tests, repository
+validation, and `cargo deny` policy checks. A passing subset is useful while
+developing but does not replace this gate.
 
-The crates.io release workflow similarly uploads the exact `.crate` produced
-and tested by its verify job. It prepares Cargo registry metadata from that
-archive, carries the archive plus SHA-256 checksums across the approval gate,
-then uses Cargo's documented
-[registry Web API](https://doc.rust-lang.org/cargo/reference/registry-web-api.html#publish)
-without repackaging source.
+## Focused checks
 
-**Agent behavior** — if you change a subagent/skill prompt, run the relevant
-suite (`critic`, `auditor`, `intake`, or `workflow`). Before merging a broad
-workflow change, run `bash evals/run-verified.sh`; it executes deterministic
-gates and then every model-backed suite. The evals need the `claude` CLI on
-PATH. `validate.py` checks structure, not behavior.
+| Change | Fast local command |
+|---|---|
+| Rust implementation | `cargo test --manifest-path mcp/servers/mmcg/Cargo.toml --locked` |
+| Rust lint | `cargo clippy --manifest-path mcp/servers/mmcg/Cargo.toml --locked --all-targets --all-features -- -D warnings` |
+| Rust formatting | `cargo fmt --manifest-path mcp/servers/mmcg/Cargo.toml --all -- --check` |
+| Public docs or repository contracts | `.venv/bin/python scripts/validate.py` |
+| npm wrapper or packaging | `just npm-smoke-native` |
+| Lens frontend | `node --test mcp/servers/mmcg/assets/lens/app.test.cjs` |
+| Eval harness | `.venv/bin/python -m unittest evals/test_runner.py` |
+
+`just npm-smoke-native` builds and installs local tarballs in a temporary
+project. It never reads from or publishes to npm.
+
+Model-backed evals require an authenticated `claude` CLI and are intentionally
+not part of ordinary CI:
+
+```bash
+bash evals/run-verified.sh
+```
+
+See [evals/README.md](evals/README.md) for suites and limitations.
+
+## Documentation changes
+
+- Put task-oriented guides in `docs/`; keep the root README as a short product
+  and onboarding page.
+- Put exhaustive CLI and MCP details in
+  [docs/reference/mmcg.md](docs/reference/mmcg.md).
+- Use commands that run from the repository root unless a section says
+  otherwise.
+- Label syntactic, compiler-resolved, declared, and observed evidence
+  separately.
+- Do not publish speed or accuracy comparisons without a reproducible corpus,
+  command, environment, and correctness boundary.
+- Run `.venv/bin/python scripts/validate.py`; it checks internal links, mirrors,
+  versioned artifacts, tool documentation, and release contracts.
+
+Benchmark methodology and current reference measurements live in
+[docs/benchmarks.md](docs/benchmarks.md). Benchmark changes must record the
+fixture size, command, number of runs, machine class, toolchain, and range—not
+only the fastest sample.
 
 ## Pull requests
 
-- Keep the change focused; describe **what** it does and **how you tested it**.
-- All checks above must pass — CI enforces them.
-- Commit subjects: a conventional prefix, imperative (`feat(miner): …`, `fix: …`); no long body needed.
-- Breaking changes (renames, removed flags, changed behavior): open an issue first to discuss.
+Include:
 
-## Reporting bugs
+1. the behavior or contract changed;
+2. the affected files and deliberate exclusions;
+3. the commands run and their results;
+4. any unavailable live, registry, browser, model, or authorization proof;
+5. screenshots only when rendered behavior changed.
 
-Use the [bug issue template](.github/ISSUE_TEMPLATE/bug.md) — include the version (`mmcg --version`), what you expected, what happened, and your OS.
+Use an imperative commit subject with a conventional prefix, for example
+`fix(index): reject stale snapshots`. Discuss compatibility-breaking CLI,
+schema, or workflow changes in an issue before implementation.
 
-## Code of conduct
+## Releases
 
-See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+Do not publish from a local checkout. The repository workflows build and carry
+forward exact artifacts, checksums, and approval evidence. Release smoke tests
+install the public registry package rather than reusing workspace artifacts.
+
+## Security
+
+Report vulnerabilities privately as described in [SECURITY.md](SECURITY.md).
+For other bugs, use the
+[bug report template](.github/ISSUE_TEMPLATE/bug.md) and include
+`mastermind --version`, the operating system, expected behavior, and the exact
+failure.
+
+All participation is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,243 +1,150 @@
 # Mastermind
 
 <p align="center">
-  <img src="docs/assets/banner.webp" alt="Mastermind — a local codegraph and verifiable workflow for AI coding agents" width="720">
+  <img src="docs/assets/banner.webp" alt="Mastermind — local codegraph and evidence-backed architecture review" width="720">
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@xcraftmind/mastermind"><img src="https://img.shields.io/badge/npm-v2.0.0-CB3837?logo=npm" alt="npm version"></a>
-  <a href="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml"><img src="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml/badge.svg" alt="CI"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="evals/scorecard.md"><img src="https://img.shields.io/badge/evals-critic%20%2B%20auditor%20%2B%20intake%20%2B%20workflow-yellowgreen" alt="Evals"></a>
+  <a href="https://www.npmjs.com/package/@xcraftmind/mastermind"><img src="https://img.shields.io/badge/npm-v2.0.0-CB3837?logo=npm" alt="npm version 2.0.0"></a>
+  <a href="https://crates.io/crates/mmcg"><img src="https://img.shields.io/crates/v/mmcg.svg" alt="crates.io version"></a>
+  <a href="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml"><img src="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml/badge.svg" alt="CI status"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT license"></a>
 </p>
 
-**A local codegraph and verifiable workflow for AI coding agents.**
+**A local codegraph for reviewing code changes with traceable evidence.**
 
-Mastermind gives Claude Code, Codex, Cursor, and Continue a structural view of your code: what exists, who calls it, what a change can affect, and which tests are relevant. Its optional workflow checks an agent's plan and implementation against the real repository instead of trusting the agent's memory.
+Mastermind indexes a repository into SQLite, exposes bounded structural queries
+over CLI and MCP, and connects a diff to affected callers, tests, components,
+policies, ownership, coverage, runtime traces, and project decisions. The same
+snapshot powers the terminal, the read-only Lens UI, SARIF, and a standalone PR
+review package.
 
-## What you get
+## Quick start
 
-| When you need to… | Mastermind gives you… |
-|---|---|
-| Understand an unfamiliar repository | Components, entry points, dependencies, hotspots, and cycles |
-| Change code safely | Changed symbols, affected callers, API crossings, and blast radius |
-| Choose focused tests | Direct, transitive, and heuristic test candidates with evidence |
-| Verify agent work | Pre-execution spec checks, post-execution diff audits, and signed evidence |
-
-The codegraph and deterministic style miner stay on your machine in local SQLite
-databases. Agent-assisted modes are explicit: `init` without `--no-claude` may
-send repository content through the configured Claude CLI, while
-`miner profile --deep` sends bounded samples for synthesis.
-
-## Try it in two minutes
-
-Requires Node.js 24+. Prebuilt binaries are included; Rust is not required.
-
-### 1. Install once
+Requires Node.js 24+. The npm package includes native binaries; Rust is not
+required.
 
 ```bash
 npm install -g @xcraftmind/mastermind
-```
 
-Connect the client you use:
-
-```bash
-mastermind install --client all                # Claude + Codex workflow adapters and MCP
-mastermind setup cursor --scope user --write   # Cursor MCP
-mastermind setup continue --scope user --write # Continue MCP
-```
-
-Use `mastermind install` for Claude only or `mastermind install --client codex`
-for Codex only. `mastermind doctor --workflow --client all` verifies that the
-ownership manifests, artifact lists, and SHA-256 content match the current package.
-
-Global installation and MCP registration do **not** require a project or `mastermind init`. Setup is dry-run-first when `--write` is omitted.
-
-### 2. Use it in a repository
-
-```bash
-cd your-project
+cd your-repository
 mastermind index .
-mastermind map .
+mastermind impact --since main
+mastermind ui --since main
+```
+
+`mastermind index .` creates `.mastermind/mmcg.db`. `ui` opens a loopback-only,
+read-only review surface; it does not upload the repository or load a CDN.
+
+<p align="center">
+  <img src="docs/images/lens/review-workbench-desktop.png" alt="Mastermind Lens showing a changed-to-impacted-to-test trace with evidence" width="900">
+</p>
+
+Connect an AI client only if you want MCP or the optional workflow bundle:
+
+```bash
+mastermind install --client all                 # Claude Code + Codex
+mastermind setup cursor --scope user --write
+mastermind setup continue --scope user --write
+mastermind doctor --workflow --client all
+```
+
+Setup is dry-run-first unless `--write` is present. See
+[Getting started](docs/getting-started.md) for project-local installs, generic
+MCP clients, updates, removal, and state ownership.
+
+## What it answers
+
+| Question | Command or surface |
+|---|---|
+| What are the components, entry points, hotspots, and cycles? | `mastermind map .` |
+| What can this branch affect? | `mastermind impact --since main` |
+| How did architecture change between base and head? | `mastermind temporal --since main` |
+| Which tests are structurally connected to the change? | `mastermind impact` or `mmcg_test_impact` |
+| Does the change violate a repository rule? | `mastermind policy check --since main` |
+| Can a reviewer inspect the result without Mastermind installed? | `mastermind review export --since main --out mastermind-review` |
+| Can an agent query symbols, callers, imports, history, and evidence? | 28 MCP tools over stdio |
+
+The MCP surface contains 27 read-only tools and one additive write,
+`mmcg_scratchpad_append`, to the local gitignored index. The
+[technical reference](docs/reference/mmcg.md#mcp-server-usage) lists every tool and
+its bounds.
+
+## How it works
+
+```mermaid
+flowchart LR
+  S["Source files"] --> T["Tree-sitter index"]
+  T --> D["Local SQLite"]
+  P["Optional SCIP index"] --> D
+  E["SARIF · coverage · JUnit · OTLP · signed facts"] --> D
+  D --> Q["Bounded map · impact · temporal · policy queries"]
+  Q --> C["CLI"]
+  Q --> M["MCP"]
+  Q --> L["Lens"]
+  Q --> R["HTML · SARIF · summary · manifest"]
+```
+
+The default graph is syntactic and toolchain-free. Optional
+[SCIP](https://github.com/scip-code/scip) data adds compiler-resolved
+definitions, references, implementations, and type definitions in separate
+tables. [Fact manifests](docs/fact-ingestion-sdk.md) add revision-bound
+annotations without loading plugin code or granting SQLite access.
+
+Evidence never silently creates topology. A runtime trace or imported fact can
+corroborate an existing exact edge; it cannot invent a caller/callee path.
+
+## Core capabilities
+
+### Diff-first architecture review
+
+```bash
 mastermind impact --since main
 mastermind temporal --since main
-mastermind policy check --since main
-mastermind ui --since main
+mastermind ui --since main --production-only
 ```
 
-`index` is enough for codegraph, map, and impact features. Run `mastermind init` only when you want the complete spec-driven project workflow:
+Impact covers committed, staged, unstaged, and untracked changes. Temporal
+analysis reports component and public-boundary drift, new/resolved cycles,
+centrality and hotspot movement, ownership changes, and history records that may
+need review. Stale indexes, snapshot races, work limits, and truncated evidence
+are explicit states rather than clean results.
+
+### Evidence overlays
 
 ```bash
-mastermind init
-mastermind doctor
-```
-
-See [Getting started](docs/getting-started.md) for global vs per-repository state, project-local installation, and client-specific setup.
-
-The fast local Tree-sitter graph is always the default. Repositories that
-already produce a [SCIP](https://github.com/scip-code/scip) index can add
-compiler-resolved definitions, references, implementations, and type
-definitions without replacing that graph:
-
-```bash
-mastermind enrich --scip index.scip
-mastermind query semantic "scip-clang . my-package . PaymentService#charge()."
-```
-
-SCIP facts live in separate SQLite tables with `provenance=scip` and
-`confidence=high`. Lens prefers an exact SCIP symbol/file pair over matching
-Tree-sitter evidence, keeps runtime traces as `observed`, and falls back to the
-syntactic graph when the overlay is absent or stale. Imports are bound to the
-indexed repository through SCIP `project_root` or exact embedded document text.
-
-Community analyzers can add bounded annotations and relationship evidence
-through the declarative [`mastermind-facts/v1` SDK](docs/fact-ingestion-sdk.md):
-
-```bash
-mastermind query facts --top 1          # capability and revision contract
-mastermind facts adapt --format sarif \
-  --input semgrep.sarif --output facts.json \
-  --producer semgrep --producer-version 1.82.0 --dataset pr-security
-mastermind enrich --facts facts.json    # validate, then atomically normalize
-mastermind query facts --path src
-```
-
-Producers never run inside Mastermind and never receive SQLite, MCP-handler,
-policy-engine, or graph-mutation access. Lens reads current normalized facts;
-relationships only corroborate an existing exact file-and-line graph edge.
-Built-in adapters cover SARIF, LCOV/Cobertura, JUnit, and OTLP JSON. An optional
-domain-separated Ed25519 signature plus explicit trusted/revoked key policy
-turns the unsigned producer claim into verifiable producer provenance;
-`mastermind facts keygen` creates the local producer keypair without exposing
-or overwriting its private seed.
-
-Multiple local indexes can be joined without centralizing their databases:
-
-```bash
-mastermind team lock team.json --output team.lock.json
-mastermind team map team.lock.json
-```
-
-The [local team graph](docs/team-graph.md) pins every repository identity,
-revision, and DB/WAL snapshot. Nodes are repository-namespaced, internal edges
-retain Tree-sitter provenance, and cross-repository edges are present only when
-the manifest declares them explicitly.
-
-## Core workflows
-
-### Map a project
-
-```bash
-mastermind map .                     # readable architecture briefing
-mastermind map src --format mermaid  # scoped diagram
-mastermind map . --format json       # stable schema for automation
-mastermind map . --format sarif      # dependency cycles for GitHub code scanning
-mastermind map . --production-only   # hide tests, fixtures, examples, generated/vendor code
-```
-
-The map highlights languages, components, entry points, dependency boundaries, hotspots, and cycles without asking an agent to grep the entire repository.
-
-### Review architecture over time
-
-```bash
-mastermind temporal --since main
-mastermind temporal --since HEAD~5 --path services/payment --format json
-```
-
-Temporal Graph compares the indexed working copy with a resolved Git baseline.
-It reports added and removed components and boundaries, introduced, resolved,
-and membership-changed cycles, centrality and hotspot drift, CODEOWNERS changes,
-public API drift, and indexed history records that exactly mention removed or
-signature-drifted architecture paths. The baseline is reconstructed by
-rewinding changed Git blobs in a private temporary SQLite snapshot; Mastermind
-does not checkout files or write to the source index. Ownership-only rules and
-fully deleted scopes are preserved, concurrent index revisions fail closed,
-and every section marks bounded partial projections explicitly.
-
-### Review a change in Mastermind Lens
-
-```bash
-mastermind ui --since main
 mastermind ui --since main \
   --sarif semgrep.sarif --sarif codeql.sarif \
   --coverage lcov.info --coverage cobertura.xml \
   --junit junit.xml --otel traces.json
 ```
 
-Lens serves a local, read-only, diff-first review UI on an ephemeral loopback
-port. It uses the same bounded architecture-map and change-impact schemas as the
-CLI/MCP surfaces, adds no CDN or telemetry, and never exposes a write endpoint.
-Use `--path`, `--depth`, `--top`, or `--production-only` to narrow a large
-monorepo review.
+Lens correlates the returned trace with SARIF, LCOV/Cobertura, JUnit,
+OpenTelemetry code paths, CODEOWNERS, Git churn, specs, ADRs, audits, lessons,
+and imported facts. Each item retains its source and completeness state.
 
-Lens evidence overlays correlate the returned static trace with SARIF findings,
-LCOV/Cobertura line coverage, JUnit results, explicit OpenTelemetry code paths,
-CODEOWNERS, bounded Git churn/contributors, and exact changed-file mentions in
-indexed specs, ADRs, audits, lessons, and context. Imported SCIP and declarative
-fact overlays are loaded automatically and decorate only exact endpoints.
-The graph topology stays unchanged: overlays add source-labelled marks and
-inspector facts rather than an opaque risk score. Lens auto-discovers
-`.github/CODEOWNERS`, `CODEOWNERS`, or `docs/CODEOWNERS`; use `--codeowners` to
-override it and `--git-commits 0..1000` to control history (`200` by default).
-Project-knowledge correlation is enabled by default; use
-`--no-project-knowledge` to suppress it. Runtime evidence decorates an existing
-static edge only when the two file endpoints match in either direction; it
-never creates graph topology.
-CODEOWNERS is matched as working-tree syntax only; Lens does not claim that a
-listed account has GitHub write access or replace base-branch review policy.
-Unreadable, oversized, invalid, or truncated sources remain visible as partial
-diagnostics. Reports and history are parsed in memory and are never written to
-the repository or codegraph database.
-
-Lens also renders the same Temporal Graph response below the blast trace. A
-temporal failure is isolated and labelled instead of turning missing evidence
-into a clean architecture verdict; snapshot races still fail the whole refresh.
-
-### Export a PR evidence package
+### Portable PR evidence
 
 ```bash
 mastermind review export --since main --out mastermind-review
 ```
 
-The command writes one autonomous `index.html`, a combined
-`mastermind.sarif`, a bounded `summary.md`, a strict `manifest.json`, and a
-ready-to-copy `mastermind-review.yml` GitHub Actions workflow. The HTML embeds
-the same Lens snapshot and runs offline under a hash-only CSP. The manifest
-records baseline/head OIDs, working-tree state, exact SHA-256 digests for every
-payload and external evidence input, plus every returned partial, truncated,
-or unavailable analysis state. Existing output paths are never overwritten.
-Valid declarative fact datasets carry their already-verified manifest and
-provenance digests into this package. Unsigned sources remain
-`producer-attested`; trusted Ed25519 sources carry reproducible proof and are
-labelled `producer-signed`.
+The output directory contains:
 
-Use the same repeatable `--sarif`, `--coverage`, `--junit`, and `--otel`
-options as Lens. Exact artifact bytes are always bound to the exported head.
-For producer-to-revision binding, pass a strict v1 attestation with
-`--evidence-attestation`; digest and head mismatches fail the export. See the
-[review-package contract](docs/reference/mmcg.md#pr-evidence-package-mmcg-review-export)
-and [GitHub Actions example](docs/examples/mastermind-review-pr.yml).
-
-### Understand change and test impact
-
-```bash
-mastermind impact --since main
-mastermind impact --since HEAD~1 --format json
-mastermind impact --since main --format sarif > mastermind-impact.sarif
+```text
+mastermind-review/
+├── index.html              # standalone offline Lens snapshot
+├── mastermind.sarif        # GitHub code scanning input
+├── summary.md              # bounded reviewer summary
+├── manifest.json           # revision, evidence digests, partial states
+└── mastermind-review.yml   # pinned GitHub Actions workflow
 ```
 
-Impact analysis compares a Git baseline with committed, staged, unstaged, and untracked work. It reports symbol-level changes, affected callers, component crossings, and candidate tests. Focused candidates are evidence for prioritization, not a replacement for the repository's required test suite.
+The exporter refuses to overwrite an existing directory. External evidence can
+be bound to the head revision with a strict attestation; signed fact manifests
+carry reproducible Ed25519 provenance into the package.
 
-The SARIF projections use stable architecture rule IDs and repository-relative
-artifact URIs so dependency cycles and cross-component change risks can be
-uploaded through GitHub's standard SARIF workflow. They export only returned
-bounded findings and preserve partial-result metadata; an empty partial export
-is not a clean verdict.
-
-### Enforce architecture policy as code
-
-Keep a small, reviewable `mastermind-policy.yml` in the repository and evaluate
-it against the same bounded change graph used by impact and Lens:
+### Architecture policy as code
 
 ```yaml
 version: 1
@@ -245,12 +152,9 @@ rules:
   - id: domain-must-not-import-infrastructure
     from: src/domain/**
     deny_imports: src/infrastructure/**
-  - id: no-new-payment-cycles
+  - id: payment-blast-radius
     scope: services/payment/**
-    max_new_cycles: 0
-  - id: public-api-review
-    when: api_surface_changed
-    require_owner: platform
+    max_affected_symbols: 80
 ```
 
 ```bash
@@ -258,148 +162,118 @@ mastermind policy check --since main
 mastermind policy check --since main --format sarif > mastermind-policy.sarif
 ```
 
-The v1 DSL also supports blast-radius budgets, related-test requirements,
-CODEOWNERS boundary checks, and held strict-workflow evidence for critical
-paths. A check exits non-zero for either a violation or incomplete evidence; a
-work limit can never become a clean result. See the complete
-[example policy](docs/examples/mastermind-policy.yml) and
-[CLI contract](docs/reference/mmcg.md#architecture-policy-as-code-mmcg-policy-check).
+The v1 DSL covers dependency direction, new-cycle and blast-radius budgets,
+public API ownership, related tests, ownership crossings, and strict-workflow
+evidence. Violations and incomplete required evidence both exit non-zero.
 
-### Review architecture invariants
-
-Use `/mastermind-architecture-review` for changes that cross service, queue,
-state, retry, migration, or public-contract boundaries. It reconstructs the
-real runtime path and tests source-of-truth ownership, idempotency, and
-backward compatibility against concrete failure sequences.
-
-### Review the comments a change left behind
-
-Use `/mastermind-comment-audit` (or the `mastermind-comment-auditor` subagent)
-once an implementation is finished. It reviews only the comments that change
-added, modified, or deleted: narration is flagged with the code line that already
-says it, load-bearing comments are named as kept, and rationale the change
-deleted is reported. Write-time comment rules are the first thing an
-implementation agent drops, and the mechanical contract cannot see them — so a
-reader verifies them, in every mode.
-
-### Ask why the project works this way
+### Optional semantic and community evidence
 
 ```bash
-mastermind history "webhook dedupe"
-mastermind why "why is webhook dedupe durable?"
+mastermind enrich --scip index.scip
+
+mastermind facts adapt --format sarif \
+  --input semgrep.sarif --output facts.json \
+  --producer semgrep --producer-version 1.82.0 --dataset pr-security
+mastermind enrich --facts facts.json
 ```
 
-History searches active and archived `CONTEXT` files, canonical task specs,
-executor reports, audits, `.mastermind/releases/`, and reviewed lessons. A
-`candidate` lesson is only an audit signal until semantic review. The index is
-only a retrieval layer: Markdown remains authoritative, and the answer separates
-observed records from inference and missing proof.
+Built-in adapters support SARIF, LCOV/Cobertura, JUnit, and OTLP JSON. The
+[`mastermind-facts/v1` contract](docs/fact-ingestion-sdk.md) checks repository
+identity, Git revision, paths, sizes, digests, capabilities, and provenance
+before atomically replacing one producer dataset.
 
-### Carry personal style across repositories
+### Local multi-repository maps
 
 ```bash
-mastermind miner profile .
+mastermind team lock team.json --output team.lock.json
+mastermind team map team.lock.json
 ```
 
-The deterministic miner writes a user-global `~/.mastermind/style.md` and
-`style.db`; it works without `mastermind init`. Planner and executor treat the
-profile as advisory. Repository code, formatter/linter policy, the approved
-contract, product behavior, and security always win. Corpus-level code-shape
-observations are diagnostic rather than coding instructions;
-`/mastermind-style-deep` adds a qualitative, evidence-backed portrait that normal
-re-mining preserves.
+The [team graph](docs/team-graph.md) pins each local repository, revision, and
+DB/WAL snapshot. Cross-repository edges exist only when the manifest declares
+them; Mastermind does not infer service calls across repositories.
 
-### Query the graph from an agent
+## Performance
 
-The MCP server exposes 25 bounded tools for symbol search, callers/callees,
-imports, architecture maps, change impact, test impact, cycles, API surface, and
-project history. The same engine is available through the CLI.
+Release-mode synthetic benchmark on an Apple M3 Pro, 12 cores, 36 GB memory.
+Each generated Rust file contained 20 public functions; changed runs modified
+10% of files.
 
-```text
-"Does parseConfig exist?"
-"Who calls createSession?"
-"What could this branch affect?"
-"Which tests are connected to these changes?"
-```
+| Corpus | Cold index | Warm unchanged | 10% changed | Peak RSS |
+|---|---:|---:|---:|---:|
+| 1,000 files / 20,000 functions | 310 ms | 41 ms | 81 ms | about 19 MiB |
+| 10,000 files / 200,000 functions | 3.20 s | 353 ms | 867 ms | about 80 MiB |
 
-See the [mmcg reference](docs/reference/mmcg.md) for the complete tool and protocol contract.
+Values are medians over 7 and 5 runs respectively. See
+[benchmarks](docs/benchmarks.md) for ranges, exact parameters, methodology,
+reproduction commands, and limits. These are indexing measurements, not
+competitor comparisons or portable latency guarantees.
 
-### Use only the workflow depth you need
+## Where it fits
 
-Small changes stay direct: query the graph, implement, and run the repository
-checks. Normal delegated work uses a compact verified contract. Auth,
-migrations, public APIs, data-loss, and supply-chain changes use strict review.
+These projects solve adjacent problems. Choose by the evidence you need rather
+than by a generic “code graph” label.
 
-```mermaid
-flowchart LR
-  U["Request"] --> M{"Risk"}
-  M -->|small| D["Direct: impact + tests"]
-  M -->|normal| P["Verified spec"]
-  M -->|high| S["Strict spec + review"]
-  P --> V["Verify"]
-  S --> V
-  V --> E["Implement"]
-  E --> A["Audit the real diff"]
-  D --> R["Report evidence"]
-  A --> R
-```
-
-Direct mode needs only `mastermind index .`; no `init` or task spec is required.
-Verified and strict tasks keep planner, executor, and controller ownership
-separate, and post-flight requires a canonical executor report. Read [How the
-workflow works](docs/workflow.md) for the exact modes and task lifecycle.
-
-### Produce verifiable audit evidence
-
-Mastermind can seal audit results with SHA-256 integrity and detached Ed25519 signatures. The included GitHub Action verifies repository, baseline, head, worktree, signature, and policy inputs before evidence is published.
-
-See [Verifiable audits and GitHub Action](docs/github-action.md).
-
-## What is global and what is per project?
-
-| State | Scope | Created by |
+| Tool | Best fit | Difference in focus |
 |---|---|---|
-| `mastermind` CLI | Global or project-local npm install | `npm install` |
-| Claude workflow agents and skills | Global | `mastermind install` |
-| Codex workflow skills | Global | `mastermind install --client codex` |
-| MCP client registration | User or project, depending on client | `mastermind setup …` |
-| Personal style profile | User-global, optional | `mastermind miner profile` or `mastermind init` |
-| `.mastermind/mmcg.db` codegraph | Per repository | `mastermind index .` or `mastermind init` |
-| Task specs and project context | Per repository, optional | `mastermind init` |
+| **Mastermind** | Local PR/change review, bounded impact, architecture policy, evidence export, MCP | Diff-first and revision-bound; Tree-sitter by default with optional SCIP and external facts |
+| [Graphify](https://github.com/Graphify-Labs/graphify) | Interactive knowledge graphs spanning code, docs, and media | Broader multimodal exploration; Mastermind is narrower around code-change evidence and CI contracts |
+| [Joern](https://github.com/joernio/joern) | Code-property-graph and security/data-flow analysis | Deeper security query platform; Mastermind emphasizes repository architecture, change impact, and agent review |
+| [CodeQL](https://github.com/github/codeql) | Security queries and GitHub code scanning | Compiler/language-specific security analysis; Mastermind can consume its SARIF as evidence |
+| [Glean](https://github.com/facebookincubator/Glean) | Organization-scale source facts and custom indexers | General fact infrastructure; Mastermind keeps a bounded single-repository default in local SQLite |
 
-## Support
+Mastermind does not replace compiler analysis, security query engines, or a
+runtime observability backend. It joins their outputs to one reviewable change
+snapshot.
 
-- **Clients:** Claude Code, Codex, Cursor, Continue, and generic MCP stdio clients
-- **Languages:** Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++
-- **Platforms:** macOS arm64/x64, Linux glibc and musl arm64/x64, Windows x64
-- **Privacy:** deterministic parsing and storage are local; explicit agent-assisted modes disclose when repository samples are sent to the configured AI client
+## Support and precision
 
-The graph is syntactic rather than compiler-semantic. Dynamic dispatch, reflection, re-exports, overload resolution, and cross-language calls can reduce precision. Mastermind reports bounded results and precision notes instead of presenting incomplete analysis as certain.
+- **Languages:** Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go,
+  Java, PHP, and C/C++.
+- **Platforms:** macOS arm64/x64; Linux glibc and musl arm64/x64; Windows x64.
+- **Clients:** Claude Code, Codex, Cursor, Continue, and generic MCP stdio
+  clients.
+- **Storage:** local SQLite; source parsing and normal queries require no
+  hosted service.
+
+The Tree-sitter graph is syntactic. Dynamic dispatch, reflection, generated
+code, re-exports, dependency injection, overload resolution, and cross-language
+calls may be incomplete. Results carry collision, truncation, stale-index, and
+precision notes. Candidate tests and unreferenced symbols are review inputs,
+not authorization to skip tests or delete code.
+
+Explicit agent-assisted commands are the privacy exception: `mastermind init`
+without `--no-claude` may send repository content through the configured Claude
+CLI, and `mastermind miner profile --deep` sends bounded samples for synthesis.
+Deterministic indexing, Lens, MCP, policy, facts, and review export remain local.
 
 ## Documentation
 
+- [Documentation index](docs/README.md)
 - [Getting started](docs/getting-started.md)
-- [Claude Code](docs/integrations/claude-code.md) · [Codex](docs/integrations/codex.md) · [Cursor](docs/integrations/cursor.md) · [Continue](docs/integrations/continue.md) · [Generic MCP](docs/integrations/generic-mcp.md)
+- [CLI and MCP reference](docs/reference/mmcg.md)
 - [Workflow](docs/workflow.md)
-- [mmcg technical reference](docs/reference/mmcg.md)
-- [GitHub Action and audit security model](docs/github-action.md)
+- [Fact-ingestion SDK](docs/fact-ingestion-sdk.md)
+- [Verifiable GitHub Action](docs/github-action.md)
+- [Benchmarks](docs/benchmarks.md)
 - [Changelog](CHANGELOG.md)
 
-## Build from source
+## Build and contribute
 
-Rust 1.96+ is required for source builds:
+Source builds require Rust 1.96+:
 
 ```bash
-cargo install mmcg
-# or from a clone
-cargo install --path mcp/servers/mmcg
+cargo install --path mcp/servers/mmcg --locked
+just check
 ```
 
-The cargo-installed command is `mmcg`; the npm package exposes the same binary as both `mastermind` and `mmcg`.
+The Cargo command is `mmcg`; npm installs the same binary as both `mastermind`
+and `mmcg`. See [CONTRIBUTING.md](CONTRIBUTING.md) for repository layout,
+focused checks, evals, release packaging, and pull-request requirements.
 
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the project layout, checks, evals, and pull-request conventions.
+Report reproducible defects through
+[GitHub Issues](https://github.com/xcrft/mastermind/issues). Report security
+issues privately under [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,38 +1,74 @@
 # Security policy
 
-## Reporting a vulnerability
+## Supported versions
 
-**Do not open a public issue for security problems.** Use GitHub's private vulnerability reporting:
+| Version | Security fixes |
+|---|---|
+| 2.x | Supported |
+| 1.x and earlier | Upgrade required |
 
-1. Go to <https://github.com/xcrft/mastermind/security/advisories/new>
-2. Describe the issue with enough detail to reproduce — the more concrete, the faster the fix
-3. Include affected versions if you know them (e.g. `mmcg 0.6.0`, plugin `mastermind-workflow 0.6.0`)
+## Report a vulnerability
 
-If GitHub's private reporting is unavailable to you, reach the maintainer via their GitHub profile.
+Do not open a public issue. Use
+[GitHub private vulnerability reporting](https://github.com/xcrft/mastermind/security/advisories/new).
 
-## What we consider in scope
+Include:
 
-- **`mmcg` (Rust crate):** parser bugs that crash on malformed input, SQL injection via crafted file paths, path traversal during `mmcg index` or `mmcg init`, MCP protocol handling bugs
-- **Workflow artifacts:** skills/subagents that instruct an LLM to take dangerous actions (delete files, exfil data, bypass user approval) when invoked normally
-- **Plugin manifests / build scripts:** anything that runs untrusted code at install or build time
+- affected Mastermind version and installation method;
+- operating system and relevant client/runtime versions;
+- minimal reproduction or proof of concept;
+- expected and actual security boundary;
+- impact, required attacker access, and whether untrusted repository content is
+  involved;
+- logs with credentials, tokens, private source, and personal data removed.
 
-## What we do NOT consider in scope
+If private reporting is unavailable, contact the maintainer through the GitHub
+profile and request a private channel. Do not send exploit details in a public
+comment.
 
-- LLM jailbreaks against the subagents — the workflow assumes the user trusts the model
-- Vulnerabilities in upstream dependencies (`tree-sitter-*`, `rusqlite`, `notify`, etc.) — report to those projects; we'll bump versions
-- Self-induced issues (e.g. running `mmcg index` on a path you don't trust, then complaining about what the indexer wrote there)
-- Findings from automated scanners with no proof of exploitability
+## In scope
 
-## Response expectations
+- path traversal, unsafe overwrite, or command execution in indexing, setup,
+  install, export, or workflow commands;
+- SQL injection or database corruption through crafted repository paths or
+  imported evidence;
+- MCP protocol or tool-permission defects that cross the documented read-only
+  and additive-write boundary;
+- Lens binding, same-origin, script-injection, CSP, or source-index mutation
+  defects;
+- fact, SARIF, coverage, JUnit, OTLP, SCIP, signature, revision, provenance,
+  size, or path validation bypasses;
+- workflow artifacts that instruct an agent to expose secrets, bypass explicit
+  approval, or perform destructive actions during normal documented use;
+- npm, Cargo, Docker Action, GitHub Actions, or release-provenance defects that
+  can replace or publish unverified artifacts;
+- setup/uninstall ownership bugs that modify unrelated client configuration or
+  user files.
 
-This is a small-team OSS project. Response timing is best-effort:
+## Usually out of scope
 
-- Acknowledgement: within 1 week
-- Triage / first reply: within 2 weeks
-- Fix shipped: depends on severity (sev0 days, sev1 weeks, lower handled in next normal release)
+- an upstream dependency advisory without a demonstrated Mastermind impact;
+- generic model jailbreaks that do not bypass a Mastermind-enforced boundary;
+- denial of service that requires the local user to index an intentionally
+  hostile repository, unless it bypasses a documented size/work limit or causes
+  persistent data loss;
+- scanner output without a reproducible path and impact;
+- social engineering, account compromise, or GitHub/npm/crates.io platform
+  issues outside this repository's control.
 
-If a fix is non-trivial we may publish a GitHub Security Advisory with a CVE. Reporters who want credit get attribution in the advisory.
+We still welcome a private report when scope is uncertain.
 
-## Disclosure
+## Response and disclosure
 
-We follow coordinated disclosure: please give us a reasonable window (default 90 days) before public disclosure. We'll work with you on the timeline if a quick fix isn't possible.
+This is a small-maintainer open-source project. Targets are best effort:
+
+| Stage | Target |
+|---|---|
+| Acknowledgement | 7 days |
+| Initial triage | 14 days |
+| Remediation | Based on severity and release safety |
+
+We use coordinated disclosure. Please allow up to 90 days by default and avoid
+publishing details while a fix or registry release is in progress. Material
+issues may receive a GitHub Security Advisory and CVE. Reporter credit is
+included when requested.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,20 +1,23 @@
 # Agents
 
-Configurations that shape **how an agent behaves** in a project or session — distinct from skills (capabilities) and prompts (instruction blocks).
+Agent definitions are Claude Code-specific orchestration roles. Portable
+capabilities live under [`skills/`](../skills/); do not copy an agent file into
+another client and assume equivalent delegation behavior.
 
-| Sub-folder | What it is |
+| Directory | Contents |
 |---|---|
-| [`subagents/`](subagents/) | Specialized agents the main agent can spawn (Claude Code subagent format) |
-| [`claude-md/`](claude-md/) | `CLAUDE.md` templates for common project shapes |
+| [`subagents/`](subagents/) | Spawnable Claude Code subagents with bounded responsibilities |
+| [`claude-md/`](claude-md/) | Project-level `CLAUDE.md` and `CONTEXT.md` templates |
 
 ## Index
 
-### subagents/
+## Subagents
 | Subagent | Description |
 |---|---|
 | [`mastermind-prompt-refiner`](subagents/mastermind-prompt-refiner.md) | Normalizes explicit prompt rewrites or cold-agent handoffs while preserving the original request. |
 | [`mastermind-critic`](subagents/mastermind-critic.md) | Pre-spec design challenger. Stress-tests a proposed approach, returns 3 weaknesses + verdict. |
-| [`mastermind-researcher`](subagents/mastermind-researcher.md) | Haiku-tier fact-gatherer. Runs grep/read/glob and returns structured citations, never decides. |
+| [`mastermind-investigator`](subagents/mastermind-investigator.md) | Debugging investigator that tracks competing hypotheses and evidence before confirming a cause. |
+| [`mastermind-researcher`](subagents/mastermind-researcher.md) | Read-only fact gathering with file and line citations; does not make design decisions. |
 | [`mastermind-task-executor`](subagents/mastermind-task-executor.md) | Executes an approved task by acceptance criteria, uses bounded in-scope repair, and writes the canonical report. |
 | [`mastermind-auditor`](subagents/mastermind-auditor.md) | Post-flight auditor. Verifies executor report claims against `git diff` and mmcg. |
 | [`mastermind-comment-auditor`](subagents/mastermind-comment-auditor.md) | Post-implementation comment reviewer. Flags added narration with quoted evidence and reports deleted rationale. |
@@ -22,8 +25,12 @@ Configurations that shape **how an agent behaves** in a project or session — d
 | [`mastermind-test-auditor`](subagents/mastermind-test-auditor.md) | Post-implementation test reviewer. Uses `mmcg_test_impact` classifications to separate real coverage from a filename match. |
 | [`mastermind-security-auditor`](subagents/mastermind-security-auditor.md) | Independent security reviewer. Spawned only on security-sensitive scope (auth, tools, secrets, delegation, supply chain, prompt injection); optional OWASP ASI mode. |
 
-### claude-md/
+## Project templates
 | Template | Description |
 |---|---|
-| [`mastermind-workflow`](claude-md/mastermind-workflow.md) | `CLAUDE.md` that pre-wires the planner+executor delegation workflow — drop-in setup for projects using `.mastermind/tasks/` specs. |
-| [`mastermind-context`](claude-md/mastermind-context.md) | `CONTEXT.md` template — project-level institutional memory (decision log, gotchas, glossary, don't-touch). Lives at project root alongside CLAUDE.md; updated by the planner during post-flight semantic review. |
+| [`mastermind-workflow`](claude-md/mastermind-workflow.md) | `CLAUDE.md` contract for Direct, Verified, and Strict task delivery. |
+| [`mastermind-context`](claude-md/mastermind-context.md) | `CONTEXT.md` template for durable decisions, constraints, glossary terms, and protected areas. |
+
+The npm package stages these files into its installable workflow bundle.
+`scripts/validate.py` checks the canonical template mirrors embedded in the Rust
+crate.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,52 @@
+# Documentation
+
+Use this page as the documentation index. The root [README](../README.md) is the
+product overview; this directory contains guides and contracts.
+
+## Start here
+
+| Goal | Document |
+|---|---|
+| Install Mastermind and index a repository | [Getting started](getting-started.md) |
+| Connect an AI client | [Claude Code](integrations/claude-code.md), [Codex](integrations/codex.md), [Cursor](integrations/cursor.md), [Continue](integrations/continue.md), or [generic MCP](integrations/generic-mcp.md) |
+| Use Direct, Verified, or Strict delivery | [Workflow](workflow.md) |
+| Look up a command, schema, limit, or MCP tool | [CLI and MCP reference](reference/mmcg.md) |
+
+## Review and CI
+
+| Goal | Document |
+|---|---|
+| Run the local diff-first UI | [`mastermind ui` reference](reference/mmcg.md#mastermind-lens-mmcg-ui) |
+| Export standalone HTML, SARIF, summary, and manifest files | [PR evidence package](reference/mmcg.md#pr-evidence-package-mmcg-review-export) |
+| Verify and publish signed audit evidence | [GitHub Action](github-action.md) |
+| Enforce architecture rules | [Policy CLI](reference/mmcg.md#architecture-policy-as-code-mmcg-policy-check) |
+| Review architecture drift over time | [Temporal graph](reference/mmcg.md#temporal-graph-mmcg-temporal) |
+
+## Extensions
+
+| Goal | Document |
+|---|---|
+| Import SARIF, coverage, JUnit, OTLP, or custom facts | [Fact-ingestion SDK](fact-ingestion-sdk.md) |
+| Add compiler-resolved definitions and references | [SCIP overlay](reference/mmcg.md#optional-scip-semantic-overlay) |
+| Query several pinned local indexes | [Local team graph](team-graph.md) |
+
+## Maintainers
+
+| Topic | Document |
+|---|---|
+| Reproduce indexing measurements | [Benchmarks](benchmarks.md) |
+| Build, test, and submit a change | [Contributing](../CONTRIBUTING.md) |
+| Understand repository-level validators | [Scripts](../scripts/README.md) |
+| Run behavioral evaluation suites | [Evals](../evals/README.md) |
+| Report a vulnerability | [Security policy](../SECURITY.md) |
+
+## Documentation rules
+
+- Guides explain a task. Reference pages define exact behavior and limits.
+- Commands must be copyable from the repository root unless a different
+  working directory is stated.
+- Performance claims must link to [methodology and raw parameters](benchmarks.md).
+- Static graph results are evidence, not runtime proof. Every page must preserve
+  that distinction where it matters.
+- `docs/examples/` contains copyable configuration. CI parses those files; they
+  are not pseudocode.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,76 @@
+# Indexing benchmarks
+
+This page reports the repository's synthetic indexing benchmark. It measures
+cold indexing, an unchanged incremental scan, and a 10% incremental update.
+It does **not** compare Mastermind with another tool: no shared corpus and
+equivalent query contract currently exist for a defensible comparison.
+
+## Results
+
+Measurements were taken on 2026-08-13 at commit
+`2ee0807e4aab480d95d8b9199e703f9408ab21d5` with the release profile.
+
+Machine: Apple M3 Pro, 12 CPU cores, 36 GB memory, macOS 26.5.2, Rust 1.97.1.
+Each generated Rust file contains 20 public functions. Times are medians; the
+parenthesized values are the observed minimum and maximum. Peak RSS is the
+median sampled process resident set.
+
+| Corpus | Runs | Cold index | Warm unchanged | 10% changed | Peak RSS, cold / warm / changed |
+|---|---:|---:|---:|---:|---:|
+| 1,000 files / 20,000 functions | 7 | 310 ms (272–416) | 41 ms (39–48) | 81 ms (75–91) | 19.0 / 19.0 / 19.2 MiB |
+| 10,000 files / 200,000 functions | 5 | 3.20 s (2.91–3.54) | 353 ms (351–393) | 867 ms (790–1,107) | 79.5 / 79.6 / 80.0 MiB |
+
+All measured runs indexed the expected number of files and reported zero parse
+failures. The changed runs reparsed 100 of 1,000 files and 1,000 of 10,000
+files respectively.
+
+## What is timed
+
+The benchmark creates a temporary repository and SQLite database, then records:
+
+1. **Cold:** parse and commit every generated source file.
+2. **Warm unchanged:** discover the same files and skip all of them by the
+   incremental fingerprint.
+3. **10% changed:** update the selected files, then discover all files and
+   reparse only the changed set.
+
+Fixture generation and Rust compilation occur outside the reported timings.
+Parsing is parallel; SQLite writes use the production single-writer path and a
+64-file bounded parse batch. Peak RSS is sampled every 2 ms by the benchmark
+process.
+
+## Reproduce
+
+From the repository root:
+
+```bash
+just benchmark-index
+```
+
+The default corpus is 1,000 files, 20 functions per file, and 100 changed
+files. To run the larger profile:
+
+```bash
+MMCG_BENCH_FILES=10000 \
+MMCG_BENCH_SYMBOLS_PER_FILE=20 \
+MMCG_BENCH_CHANGED_FILES=1000 \
+  just benchmark-index
+```
+
+The command prints schema-v1 JSON containing the corpus parameters, elapsed
+milliseconds, peak RSS, and indexed/unchanged/failed file counts. Record every
+parameter when publishing a result.
+
+## Limits
+
+- The corpus is synthetic Rust. It does not model mixed languages, generated
+  files, large translation units, slow network filesystems, Git submodules, or
+  pathological parser inputs.
+- Results measure indexing only. They do not include SCIP generation, external
+  evidence adaptation, Lens rendering, or model calls.
+- Warm runs are unchanged scans, not cached cold parses.
+- The numbers describe this machine and commit. They are not a CI threshold or
+  a portable latency guarantee.
+- A competitor comparison belongs here only after both tools run an equivalent
+  corpus, ignore policy, extraction contract, storage mode, and correctness
+  check.

--- a/docs/fact-ingestion-sdk.md
+++ b/docs/fact-ingestion-sdk.md
@@ -1,22 +1,33 @@
 # Declarative fact-ingestion SDK
 
-Mastermind extensions are data producers, not in-process plugins. A producer
-writes a strict, revision-bound JSON manifest; Mastermind validates the entire
-manifest and then atomically normalizes it into private SQLite tables. Lens and
-the fixed read-only `mmcg_facts` MCP tool consume those normalized facts.
+The extension boundary is data ingestion, not plugin execution. A producer
+emits a revision-bound JSON manifest. Mastermind validates the complete input,
+then atomically replaces that producer's normalized dataset in private SQLite
+tables. Lens, CLI, and the fixed read-only `mmcg_facts` tool read the result.
 
 The public v1 schema is
 [`schemas/mastermind-facts-v1.schema.json`](../schemas/mastermind-facts-v1.schema.json).
 Its API identifier is `mastermind-facts/v1`, with two capabilities:
 `annotations` and `relationships`.
 
+## Contract at a glance
+
+| Property | v1 behavior |
+|---|---|
+| Producer output | Inert JSON matching the public schema |
+| Repository binding | Exact repository identity and 40-character Git revision |
+| File binding | Canonical path, byte size, and SHA-256 digest |
+| Provenance | Bounded local artifacts, optionally signed with Ed25519 |
+| Database writes | Performed only by Mastermind after full validation |
+| Read surfaces | `query facts`, `mmcg_facts`, Lens, and review export |
+| Executable extension points | None |
+
 ## Built-in adapters
 
-Mastermind can turn common inert reports into the same strict manifest without
-requiring each producer to implement the schema. The adapter reads one bounded
-artifact, matches every emitted fact to the current index, records its exact
-digest and size, and refuses to write an output when parsing is partial or any
-fact cannot be mapped to an indexed repository file.
+Built-in adapters convert common reports into the same manifest. An adapter
+reads one bounded local artifact, maps every fact to the current index, records
+the exact digest and size, and emits nothing if parsing is partial or any fact
+cannot be mapped to an indexed repository file.
 
 ```bash
 mastermind facts adapt --format sarif \
@@ -40,7 +51,7 @@ mastermind facts adapt --format otel \
 relationships use `confidence=observed`; they still only decorate matching
 static endpoints in Lens and never create codegraph topology.
 
-## Producer flow
+## Custom producer flow
 
 Index the repository, then ask Mastermind for the exact contract that the
 manifest must bind:
@@ -51,9 +62,9 @@ mastermind query facts --top 1 > mastermind-facts-contract.json
 ```
 
 The response contains `contract.api_version`, `contract.repository.identity`,
-`contract.repository.revision`, and `contract.supported_capabilities`. A
-producer copies the API version and exact repository values into its manifest,
-hashes every referenced source and provenance artifact, and emits facts only.
+`contract.repository.revision`, and `contract.supported_capabilities`. Copy
+those exact values, hash every referenced source and provenance artifact, and
+emit only the declared fact kinds.
 
 ```json
 {
@@ -177,12 +188,12 @@ whether a signature predates key compromise. Those claims require an external
 identity and timestamp/transparency policy.
 
 The MCP equivalent is the built-in, read-only `mmcg_facts` tool with `path`
-and `top` arguments. Its bounded response includes the verified provenance
-artifact paths, sizes, and SHA-256 digests. Lens loads current facts
-automatically and shows the binding manifest digest on the producer card. Annotations appear
-as source-labelled findings; relationships may corroborate an already returned
-codegraph edge only when both file and line endpoints match. Facts never create
-or remove graph topology.
+and `top` arguments. Its bounded response includes verified provenance artifact
+paths, sizes, and SHA-256 digests. Lens loads current facts and shows the
+binding manifest digest on the producer card. Annotations appear as
+source-labelled findings. Relationships can corroborate a returned codegraph
+edge only when both file and line endpoints match; facts never create or remove
+graph topology.
 
 `mastermind review export` carries the same normalized facts into its autonomous
 HTML. Unsigned datasets remain `producer-attested`; verified datasets and their

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,49 +1,105 @@
 # Getting started
 
-Mastermind has two independent layers:
-
-1. A global CLI, workflow bundle, MCP registration, and optional personal style profile.
-2. A local codegraph for each repository you choose to index.
-
-You can install and connect Mastermind without initializing a project. `mastermind init` is only the convenience command for enabling the complete repository workflow.
+This guide takes a clean machine to a local index, a change-impact report, and
+an optional MCP connection. For exact flags and schemas, use the
+[technical reference](reference/mmcg.md).
 
 ## Requirements
 
-- Node.js 24+ for the npm package
-- Claude Code, Codex, Cursor, Continue, or another MCP stdio client
-- Git for baseline-aware change and audit commands
+| Install path | Requirement |
+|---|---|
+| npm, recommended | Node.js 24+ |
+| Cargo | Rust 1.96+ |
+| Baseline-aware commands | Git |
+| MCP | Claude Code, Codex, Cursor, Continue, or another stdio client |
 
-Rust is not needed for npm installation. Source builds require Rust 1.96+.
+The npm package includes native binaries for supported macOS, Linux, and
+Windows targets. It does not compile Rust during installation.
 
-## Install the CLI
+## 1. Install the CLI
 
-Global installation is simplest when you use Mastermind across repositories:
+Global installation:
 
 ```bash
 npm install -g @xcraftmind/mastermind
 mastermind --version
 ```
 
-For a version pinned to one repository:
+Repository-pinned installation:
 
 ```bash
 npm install -D @xcraftmind/mastermind
 npx mastermind --version
 ```
 
-## Connect an AI client
+Cargo installation exposes the same binary as `mmcg`:
 
-`mastermind setup` previews a redacted plan. Add `--write` to apply it.
+```bash
+cargo install mmcg --version 2.0.0 --locked
+mmcg --version
+```
 
-| Client | User-scope command | Notes |
-|---|---|---|
-| Claude Code | `mastermind install` | Installs skills, subagents, and user-scope MCP |
-| Codex | `mastermind install --client codex` | Installs skills and user-scope MCP |
-| Cursor | `mastermind setup cursor --scope user --write` | User and project scopes supported |
-| Continue | `mastermind setup continue --scope user --write` | Owns one `mastermind.yaml` file |
-| Generic | See [generic MCP setup](integrations/generic-mcp.md) | Requires an explicit config path |
+## 2. Index a repository
 
-Client guides document removal, project scope, backups, and the exact config shape:
+```bash
+cd your-repository
+mastermind index .
+mastermind status
+```
+
+The index is `.mastermind/mmcg.db`. Source discovery follows Git and `.ignore`
+rules and skips build/vendor directories. The first run parses supported files;
+later runs skip unchanged files.
+
+```bash
+mastermind index .          # incremental refresh
+mastermind index . --force  # full reparse
+mastermind watch            # long-running incremental refresh
+```
+
+Do not commit the database. `mastermind init` adds the normal ignore rule, but
+an index created directly may require this repository-specific entry:
+
+```gitignore
+.mastermind/
+```
+
+## 3. Get the first useful result
+
+```bash
+mastermind map .
+mastermind impact --since main
+mastermind temporal --since main
+mastermind ui --since main
+```
+
+- `map` summarizes components, entry points, dependencies, hotspots, and
+  cycles.
+- `impact` connects the current Git diff to changed symbols, callers,
+  component crossings, and candidate tests.
+- `temporal` compares architecture at the baseline and indexed worktree.
+- `ui` serves the same bounded snapshot in local read-only Mastermind Lens.
+
+Refresh the index before trusting a result after source changes. Stale,
+truncated, or work-limited analysis fails closed or is labelled partial; it is
+never presented as a clean review.
+
+## 4. Connect an AI client
+
+CLI use does not require MCP. If you want an agent to query the graph, choose
+one setup path:
+
+| Client | Command |
+|---|---|
+| Claude Code | `mastermind install` |
+| Codex | `mastermind install --client codex` |
+| Claude Code + Codex | `mastermind install --client all` |
+| Cursor | `mastermind setup cursor --scope user --write` |
+| Continue | `mastermind setup continue --scope user --write` |
+| Generic stdio client | [Generic MCP guide](integrations/generic-mcp.md) |
+
+`mastermind setup` previews a redacted plan when `--write` is absent. Client
+guides describe project scope, config ownership, backups, updates, and removal:
 
 - [Claude Code](integrations/claude-code.md)
 - [Codex](integrations/codex.md)
@@ -51,160 +107,78 @@ Client guides document removal, project scope, backups, and the exact config sha
 - [Continue](integrations/continue.md)
 - [Generic MCP](integrations/generic-mcp.md)
 
-No repository and no `mastermind init` are required for this step.
-
-## Install workflow adapters
+Verify installed workflow files and MCP configuration:
 
 ```bash
-mastermind install --client all
+mastermind doctor --workflow --client all
 ```
 
-This installs Mastermind-owned skills for Claude and Codex, Claude subagents,
-and both user-scope MCP registrations. Use `mastermind install` or
-`mastermind install --client codex` for one client. Cursor and Continue expose
-the MCP tools through `mastermind setup`; Mastermind does not claim a native
-workflow-extension format for those clients.
-
-The installer owns only artifacts recorded in a per-client manifest. Updates
-replace each owned skill directory atomically, remove retired owned artifacts,
-preserve unrelated user files, and roll back a partial client update.
-Doctor hashes every owned artifact, so a locally modified or truncated skill is
-reported as drift rather than accepted because the path merely exists.
+## Optional: export review evidence
 
 ```bash
-mastermind list
+mastermind review export --since main --out mastermind-review
+```
+
+The new directory contains standalone HTML, SARIF, a Markdown summary, a
+revision/evidence manifest, and a pinned GitHub Actions workflow. The exporter
+does not overwrite an existing path.
+
+## Optional: enable the task workflow
+
+You do not need `mastermind init` for indexing, CLI analysis, Lens, or MCP.
+Run it only when the repository should use Mastermind's task artifacts and
+project context:
+
+```bash
+mastermind init --no-claude
+mastermind doctor
+```
+
+Omit `--no-claude` only when you intend to let the configured Claude CLI draft
+repository context from source content. Existing `CONTEXT.md` and `CLAUDE.md`
+are preserved unless `--force` is supplied.
+
+The task workflow has three depths:
+
+| Mode | Use for | Task spec |
+|---|---|---|
+| Direct | Small, reversible changes | None |
+| Verified | Normal multi-file or delegated work | Required |
+| Strict | Auth, billing, migrations, public API, data loss, supply chain, difficult rollback | Required with risk and review evidence |
+
+Read [Workflow](workflow.md) before using `new-spec`, `verify-spec`, or
+`run-task`.
+
+## State and network behavior
+
+| Path | Scope | Contents | Commit? |
+|---|---|---|---|
+| `.mastermind/mmcg.db` | Repository | Generated graph and local scratchpad | No |
+| `.mastermind/tasks/` | Repository | Optional specs, reports, audits, state | Project decision |
+| `CONTEXT.md`, `CLAUDE.md` | Repository | Optional human/agent guidance | Project decision |
+| `~/.mastermind/` | User | Optional style profile | No |
+| Client config and workflow directories | User or repository | MCP registration and installed adapters | Depends on selected scope |
+
+Indexing, queries, Lens, policy evaluation, fact import, and review export run
+locally. The commands that may invoke an external model are explicit:
+
+- `mastermind init` without `--no-claude`;
+- `mastermind miner profile --deep`.
+
+## Update or remove
+
+```bash
+npm install -g @xcraftmind/mastermind@latest
 mastermind update --client all
 mastermind doctor --workflow --client all
 ```
 
-## Use the codegraph without project initialization
+Removal is scope-specific and dry-run-first. Read the relevant client guide and
+inspect the printed plan before adding a destructive flag.
 
-From any supported code repository:
+## Next
 
-```bash
-cd your-project
-mastermind index .
-mastermind status
-mastermind map .
-```
-
-This creates `.mastermind/mmcg.db`. It does not create task specs, `CONTEXT.md`, or a workflow `CLAUDE.md`.
-
-Refresh the index after edits:
-
-```bash
-mastermind index .       # incremental
-mastermind index . --force
-mastermind watch         # continuous refresh
-```
-
-Analyze the current worktree against a baseline:
-
-```bash
-mastermind impact --since main
-mastermind temporal --since main
-mastermind review export --since main --out mastermind-review
-```
-
-The review export is a portable PR artifact: open `mastermind-review/index.html`
-without a server, upload `mastermind-review/mastermind.sarif` to code scanning,
-or copy its pinned `mastermind-review.yml` into `.github/workflows/`.
-
-## Build a personal style profile without project initialization
-
-```bash
-mastermind miner profile .
-```
-
-This idempotently adds the current repository to the user-global
-`~/.mastermind/style.db` and regenerates `~/.mastermind/style.md`. It does not
-require `mastermind init`. The profile is advisory: target-repository code and
-formatter/linter policy, the approved task, product behavior, and security take
-precedence. A normal re-mine preserves manual overrides and the qualitative
-`Design patterns & tendencies` section. Deterministic code-shape observations
-are diagnostic evidence, not direct instructions for generated code.
-
-Use `/mastermind-style-deep` in a supported workflow client for an
-evidence-backed qualitative portrait. `mastermind miner profile --deep` remains
-a compatibility path that explicitly sends bounded added-line and commit
-samples to `claude -p` and replaces that interpreted section.
-
-## Enable the complete repository workflow
-
-```bash
-mastermind init
-mastermind doctor
-```
-
-`init` scaffolds `.mastermind/`, builds the index, and creates project context
-when missing. When invoked through the npm package, it also reconciles the
-Claude workflow bundle unless `--no-global` is supplied. Existing `CONTEXT.md`
-and `CLAUDE.md` files are preserved unless `--force` is used.
-
-Useful opt-outs:
-
-```bash
-mastermind init --no-claude  # do not draft context through Claude Code
-mastermind init --no-index   # scaffold without indexing
-mastermind init --no-global  # do not update ~/.claude
-mastermind init --no-seed-style # do not enrich the user-global style profile
-```
-
-## Choose a workflow depth
-
-Most small changes do not need a task spec:
-
-```bash
-mastermind impact --since main
-# implement and test
-mastermind impact --since main
-```
-
-Use the default verified contract for normal multi-file or delegated work:
-
-```bash
-mastermind new-spec "Add account recovery"
-mastermind verify-spec .mastermind/tasks/001-add-account-recovery/spec.md
-# approve Scope and Acceptance Criteria
-mastermind run-task .mastermind/tasks/001-add-account-recovery/spec.md --pre-only
-# hand spec.md to the implementation agent; it writes executor-report.md
-mastermind run-task .mastermind/tasks/001-add-account-recovery/spec.md --post-only
-```
-
-Use `--mode strict` for auth, billing, migrations, public APIs, data-loss,
-supply-chain, or difficult rollback. `lite` and `standard` remain compatible
-with old task files but are not recommended for new work.
-
-`run-task` stores lifecycle state beside each canonical spec as
-`<task>/state.json`. The executor owns only `<task>/executor-report.md`; the
-controller owns state, `audit.md`, lesson candidates, release-note eligibility,
-and the initial `<task>/history-review.md`. After semantic review, mark Context
-and Lesson there as `updated` or `not applicable` and replace the generated
-reason. The default handoff is client-neutral. `--exec` is a legacy Claude CLI
-convenience.
-
-## State and privacy
-
-| Location | Contains | Commit it? |
-|---|---|---|
-| `~/.claude/` | Installed Claude agents, skills, ownership manifest | No |
-| `~/.codex/` | Installed Codex skills and ownership manifest | No |
-| User client config | MCP registration | No |
-| `.mastermind/mmcg.db` | Local codegraph and scratchpad | No |
-| `.mastermind/tasks/` | Optional specs, reports, audits, history reviews, state, and lessons | Local by default; opt in explicitly |
-| `CONTEXT.md`, `CLAUDE.md` | Optional repository guidance | Your choice |
-
-The index is generated from local source files and stays local. `mastermind init`
-creates ignore rules for `.mastermind/`; to share selected history, explicitly
-negate those paths after the generated `*` rule and remove any broader root
-`.mastermind/` ignore, or version the desired artifacts elsewhere. `CONTEXT.md`
-is outside `.mastermind/` and can be shared normally.
-
-## Next steps
-
-- Run `mastermind map .` to learn a repository.
-- Run `mastermind demo hallucinated-symbol` for a zero-setup audit example.
-- Run `mastermind impact --since main` before submitting a change.
-- Run `mastermind temporal --since main` when architecture drift matters.
-- Read [How the workflow works](workflow.md) to use checked task specs.
-- Add [verifiable audits](github-action.md) to CI.
+- [Documentation index](README.md)
+- [CLI and MCP reference](reference/mmcg.md)
+- [Benchmarks](benchmarks.md)
+- [GitHub Action](github-action.md)

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,21 +1,54 @@
 # Mastermind verifiable audit Action
 
-The Action produces schema-v3 audit envelopes and verifies them against exact repository snapshot inputs. It is designed for a two-workflow boundary: untrusted pull-request analysis has no secrets or OIDC, while a later `workflow_run` publication workflow obtains narrowly separated permissions only after independent verification.
+The Docker Action creates schema-v3 audit envelopes for an exact repository
+snapshot. The recommended deployment separates untrusted pull-request analysis
+from privileged publication.
+
+| Stage | Trigger | Authority | Executes PR code |
+|---|---|---|---|
+| Analyze | `pull_request` | `contents: read`; no secrets or OIDC | Yes |
+| Verify | `workflow_run` | Read-only GitHub metadata and artifact access | No |
+| Attest | verified result | OIDC and attestations write only | No |
+| Publish | verified result | Pull-request comment write only | No |
+
+Start from
+[`mastermind-audit-pr.yml`](examples/mastermind-audit-pr.yml) and
+[`mastermind-audit-publish.yml`](examples/mastermind-audit-publish.yml).
 
 ## What each proof means
 
-- Content integrity means the manifest's Mastermind Canonical JSON v1 bytes match its SHA-256 digest. Anyone who can replace both the manifest and digest can create another internally consistent envelope.
-- Provenance authenticity means a detached Ed25519 signature verified with the configured public key and its recomputed key ID is trusted and not revoked. It proves control of that key only; it provides neither signer identity beyond policy, signing time, nor pre/post-compromise distinction.
-- Policy acceptance means every configured independent trust anchor passed. A repository snapshot anchor requires exact `owner/repo`, full baseline and head OIDs, trusted-root recomputation, and `worktree_clean:true`. A signature anchor requires the signature, public key, and a trusted non-revoked key-ID allowlist. Partial or empty policy fails closed with `incomplete_trust_anchor` or `no_trust_anchor`.
-- GitHub artifact attestation over the deterministic verified archive/statement means publication-workflow verification provenance. It does not prove that PR analysis ran in a trusted environment or that findings are true.
+- **Content integrity:** the Mastermind Canonical JSON v1 bytes match their
+  SHA-256 digest. Replacing both the manifest and digest can still create a
+  different internally consistent envelope.
+- **Provenance authenticity:** a detached Ed25519 signature validates under a
+  trusted, non-revoked key ID. This proves control of that key, not signer
+  identity, signing time, or whether signing preceded key compromise.
+- **Policy acceptance:** every configured trust anchor passes. A repository
+  anchor requires exact `owner/repo`, full baseline and head OIDs, trusted-root
+  recomputation, and `worktree_clean:true`. A signature anchor requires the
+  signature, public key, and a trusted non-revoked key-ID allowlist. Partial or
+  empty policy fails with `incomplete_trust_anchor` or `no_trust_anchor`.
+- **GitHub artifact attestation:** the publication workflow verified the
+  deterministic archive and statement. This does not prove that PR analysis
+  ran in a trusted environment or that its findings are correct.
 
-`--integrity-only` is an explicitly labelled diagnostic. It sets authenticity and policy to `not_evaluated`; the Docker Action, privileged `pr-comment`, and publication workflow never use it.
+`--integrity-only` is a diagnostic. It sets authenticity and policy to
+`not_evaluated`; the Docker Action, privileged `pr-comment`, and publication
+workflow do not use it.
 
 ## Envelope and signature contract
 
-The envelope digest covers the canonical manifest, not pretty-printed storage. Canonical JSON uses UTF-8, sorted object keys, array order, minimal JSON string escaping, explicit i64/u64 integers only, and no trailing newline. Strict readers reject duplicate/unknown fields, floats, unknown schemas, algorithms, or canonicalization identifiers.
+The envelope digest covers the canonical manifest, not pretty-printed storage.
+Canonical JSON uses UTF-8, sorted object keys, array order, minimal JSON string
+escaping, explicit i64/u64 integers only, and no trailing newline. Strict
+readers reject duplicate or unknown fields, floats, and unknown schemas,
+algorithms, or canonicalization identifiers.
 
-The manifest binds repository identity, full baseline and HEAD, clean-worktree state, tool/config/index metadata, spec and executor-report paths and digests, normalized name/status entries, binary diff digest, verdict, file scope, claims, discrepancies, snapshot drift, logical mmcg queries, recorded verify commands, and summary.
+The manifest binds repository identity, full baseline and HEAD, clean-worktree
+state, tool/config/index metadata, spec and executor-report paths and digests,
+normalized name/status entries, binary diff digest, verdict, file scope,
+claims, discrepancies, snapshot drift, logical mmcg queries, recorded verify
+commands, and summary.
 
 Detached signatures sign a domain-separated canonical statement containing:
 
@@ -30,7 +63,11 @@ canonicalization = mastermind-cjson-v1
 manifest_digest = sha256:<manifest digest>
 ```
 
-Key files contain exactly one base64 line. The private file encodes a 32-byte Ed25519 seed and must have mode 0600 on Unix; the public file encodes 32 bytes. Keep trusted and revoked key-ID allowlists in independently reviewed policy. Rotation is the operator's responsibility: add the new trusted ID, deploy verifiers, rotate signing, then revoke the old ID while retaining the historical policy needed to verify old evidence.
+Key files contain one base64 line. The private file encodes a 32-byte Ed25519
+seed and must have mode `0600` on Unix; the public file encodes 32 bytes. Keep
+trusted and revoked key-ID allowlists in independently reviewed policy. For
+rotation, add the new trusted ID, deploy verifiers, rotate signing, then revoke
+the old ID while retaining the policy needed to verify historical evidence.
 
 ## Local commands
 
@@ -56,7 +93,8 @@ mastermind audit verify audit.bundle.json \
   --trusted-key-id sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ```
 
-The snapshot and signature modes can be supplied together; every supplied policy must pass. A present signature is never ignored.
+Snapshot and signature modes can be supplied together; every supplied policy
+must pass. A present signature is never ignored.
 
 ## Action inputs and output
 
@@ -69,7 +107,9 @@ The repository-root `action.yml` defines a Docker Action with these inputs:
 - `expected-head`: full lowercase head OID;
 - `require-clean-worktree`: must remain `true` for publication.
 
-It outputs the verified bundle directory and aggregate result JSON path. Inputs are passed as data and never evaluated, sourced, or rendered into shell syntax.
+The Action outputs the verified bundle directory and aggregate result JSON
+path. Inputs are passed as data; they are not evaluated, sourced, or rendered
+into shell syntax.
 
 The Action audits only canonical task folders changed between `since` and
 `HEAD`. Every selected task must include `spec.md` and a valid
@@ -80,15 +120,35 @@ prevents an empty report from producing publishable evidence.
 
 ## Copyable workflows and trusted verifier
 
-Start from `docs/examples/mastermind-audit-pr.yml` and `docs/examples/mastermind-audit-publish.yml`. The unprivileged PR workflow uses the Action from its already checked-out PR tree; this executes untrusted code but receives no secrets, OIDC, or write permission. The privileged workflow contains its strict schema-v3 verifier inline, so the verifier implementation and identity are bound to the independently allowlisted trusted workflow blob. Executable examples contain no unresolved Action or verifier placeholder. External Actions must remain pinned to their audited 40-character commits.
+The unprivileged PR workflow uses the Action from its checked-out PR tree. That
+executes untrusted code but receives no secrets, OIDC, or write permission. The
+privileged workflow contains its strict schema-v3 verifier inline, so the
+verifier implementation and identity are bound to the independently allowlisted
+trusted workflow blob. The examples contain no unresolved Action or verifier
+placeholder. External Actions remain pinned to audited 40-character commits.
 
-The PR workflow triggers only on `pull_request`, checks out the exact head with credentials disabled, and has only `contents: read`. It uploads exactly one attempt-specific artifact. Uploaded PR numbers, SHAs, workflow strings, and digests remain hostile claims.
+The PR workflow triggers only on `pull_request`, checks out the exact head with
+credentials disabled, and has only `contents: read`. It uploads one
+attempt-specific artifact. Uploaded PR numbers, SHAs, workflow strings, and
+digests remain hostile claims.
 
-The publication workflow has no checkout. Its read-only verify job keys API lookups to the source run ID and attempt, checks repository ID/name, event, conclusion, workflow path/blob, independent PR/base/head association, and exactly one server-owned artifact ID/digest/size. It caps extraction at 64 MiB total, 16 MiB per regular file, 256 files, and 240-byte relative paths; links, devices, traversal, nested archives, and extra names are rejected. It then runs only the trusted verify-only implementation and creates a deterministic statement/archive.
+The publication workflow has no checkout. Its read-only verify job keys API
+lookups to the source run ID and attempt, then checks repository ID/name, event,
+conclusion, workflow path/blob, independent PR/base/head association, and one
+server-owned artifact ID/digest/size. Extraction is capped at 64 MiB total,
+16 MiB per regular file, 256 files, and 240-byte relative paths. Links, devices,
+traversal, nested archives, and extra names are rejected. Only the trusted
+verify implementation runs before the deterministic statement/archive is
+created.
 
-The attestation job alone has `id-token: write` and `attestations: write`. The publication job alone has `pull-requests: write`, independently rechecks the PR head and artifact identity, and updates at most one constant-marker comment owned by `github-actions[bot]`. Neither job executes commands stored in an envelope.
+Only the attestation job has `id-token: write` and `attestations: write`. Only
+the publication job has `pull-requests: write`; it rechecks PR head and artifact
+identity, then updates at most one constant-marker comment owned by
+`github-actions[bot]`. Neither job executes commands stored in an envelope.
 
-Treat all `workflow_run` downloads as hostile until this chain completes. If GitHub cannot independently return the executed workflow blob, PR association, server artifact digest, or exact run attempt, fail closed.
+Treat every `workflow_run` download as hostile until this chain completes. If
+GitHub cannot independently return the workflow blob, PR association, server
+artifact digest, or exact run attempt, fail closed.
 
 ## Updating pins
 
@@ -104,4 +164,10 @@ Never shorten a commit or pin a mutable tag such as `v7`, `main`, or `master`.
 
 ## GitHub plan limitations
 
-Artifact attestation availability and verification behavior depend on repository visibility and the organization's GitHub plan and policy. In particular, private/internal repository support and API access can differ from public repositories. Confirm current GitHub documentation and organization settings before treating attestations as a required release gate. The local schema-v3 verifier performs no network lookup; GitHub issuer/workflow/repository/ref verification remains the responsibility of the trusted publication workflow and GitHub tooling.
+Artifact attestation availability and verification behavior depend on
+repository visibility and the organization's GitHub plan and policy.
+Private/internal support and API access can differ from public repositories.
+Confirm current GitHub documentation and organization settings before making
+attestations a required release gate. The local schema-v3 verifier performs no
+network lookup; the trusted publication workflow and GitHub tooling remain
+responsible for issuer, workflow, repository, and ref verification.

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,15 +1,11 @@
 # Claude Code integration
 
-Claude Code supports project-local JSON and user-scope registration through its native MCP CLI.
+Claude Code supports project-local `.mcp.json` configuration and user-scope
+registration through `claude mcp`.
 
-## Setup
+## User scope
 
-```text
-mastermind setup <claude|cursor|codex|continue|generic> \
-  --scope <project|user> [--root .] [--config PATH] [--write] [--remove] [--force]
-```
-
-Install and index Mastermind, then preview user registration:
+Install Mastermind, index the repository, and preview registration:
 
 ```bash
 npm install -g @xcraftmind/mastermind
@@ -24,9 +20,13 @@ The preview resolves the trusted current Mastermind command and shows only a red
 mastermind setup claude --scope user --write
 ```
 
-User scope uses the bounded native `claude mcp` contract. Mastermind compares the exact trimmed `Command:` and `Args:` fields, fails closed if inspection output is truncated, and rejects a changed executable identity before any later inspect or mutation. The process is invoked without a shell, limited to ten seconds, and its raw output is never printed.
+User scope uses the bounded native `claude mcp` contract. Mastermind compares
+the exact trimmed `Command:` and `Args:` fields, rejects truncated inspection
+output, and rechecks executable identity before later inspection or mutation.
+The process runs without a shell, has a ten-second limit, and does not print raw
+output.
 
-## Project-local registration
+## Project scope
 
 ```bash
 npm install -D @xcraftmind/mastermind
@@ -34,23 +34,31 @@ mastermind setup claude --scope project --root .          # dry-run
 mastermind setup claude --scope project --root . --write
 ```
 
-Project scope safely merges the canonical `mmcg` entry into `.mcp.json` while preserving unrelated root fields and servers. The legacy spelling `--project . --write-mcp` remains compatible.
+Project scope merges the canonical `mmcg` entry into `.mcp.json` while
+preserving unrelated root fields and servers. The legacy spelling
+`--project . --write-mcp` remains compatible.
 
-## Updating and removing
+## Update or remove
 
-A matching entry is an idempotent no-op. A customized entry is refused unless `--force` is supplied; `--force` never implies `--write`. Before forced file-backed replacement or removal, the old bytes are stored privately under `~/.mastermind/setup-backups/`.
+A matching entry is an idempotent no-op. A customized entry requires `--force`;
+`--force` never implies `--write`. Before forced file-backed replacement or
+removal, Mastermind stores the previous bytes under
+`~/.mastermind/setup-backups/`.
 
 ```bash
 mastermind setup claude --scope project --root . --remove          # dry-run
 mastermind setup claude --scope project --root . --remove --write
 ```
 
-## Verification
+## Verify
 
 ```bash
 mastermind doctor
 ```
 
-Doctor parses supported configuration locations as bounded data, rejects symlinked config files or existing path ancestors, reports only client labels and structural statuses, and never executes commands read from configuration. Its separate MCP handshake starts only the trusted current Mastermind binary.
+Doctor parses supported configuration locations as bounded data, rejects
+symlinked config files or existing path ancestors, and reports only client
+labels and structural status. It does not execute commands from configuration;
+the separate MCP handshake starts only the trusted current Mastermind binary.
 
 Restart Claude Code after changing registration.

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -1,15 +1,9 @@
 # Codex CLI integration
 
-Codex setup is supported at user scope through the native `codex mcp` command. Project scope is intentionally unsupported.
+Mastermind registers with Codex at user scope through `codex mcp`. Project
+scope is not supported.
 
-## Setup
-
-```text
-mastermind setup <claude|cursor|codex|continue|generic> \
-  --scope <project|user> [--root .] [--config PATH] [--write] [--remove] [--force]
-```
-
-Install and index Mastermind, then preview registration:
+## Install and register
 
 ```bash
 npm install -g @xcraftmind/mastermind
@@ -48,22 +42,32 @@ Apply the native registration explicitly:
 mastermind setup codex --scope user --write
 ```
 
-`mastermind setup codex --scope project` is rejected before configuration reads or subprocesses. Codex is resolved only from absolute `PATH` entries outside the current repository and invoked without a shell. Its JSON inspection must contain the exact stdio command and ordered arguments, truncated output fails closed, and executable identity is rechecked before every inspect or mutation within the ten-second bound.
+`mastermind setup codex --scope project` is rejected before configuration reads
+or subprocesses. Mastermind resolves Codex only from absolute `PATH` entries
+outside the current repository and invokes it without a shell. JSON inspection
+must contain the exact stdio command and ordered arguments. Truncated output is
+rejected, and executable identity is rechecked before every inspection or
+mutation within the ten-second bound.
 
-## Updating and removing
+## Update or remove
 
-A matching native entry is an idempotent no-op. A customized entry requires `--force`; `--force` never implies `--write`.
+A matching native entry is an idempotent no-op. A customized entry requires
+`--force`; `--force` never implies `--write`.
 
 ```bash
 mastermind setup codex --scope user --remove          # dry-run
 mastermind setup codex --scope user --remove --write
 ```
 
-## Verification
+## Verify
 
 ```bash
 mastermind doctor
 mastermind doctor --workflow --client codex
 ```
 
-Doctor recognizes only the `[mcp_servers.mmcg]` table with a string `command` and ordered string `args` in `~/.codex/config.toml`. It parses the file as TOML, including normal quoting, comments, and multiline arrays, while rejecting malformed types, duplicate keys, and symlinked config ancestry. Doctor never executes Codex or a configured command. The old YAML configuration instructions are not supported.
+Doctor recognizes only the `[mcp_servers.mmcg]` table with a string `command`
+and ordered string `args` in `~/.codex/config.toml`. It parses normal TOML
+quoting, comments, and multiline arrays, while rejecting malformed types,
+duplicate keys, and symlinked config ancestry. Doctor does not execute Codex or
+a configured command. The old YAML configuration shape is unsupported.

--- a/docs/integrations/continue.md
+++ b/docs/integrations/continue.md
@@ -1,15 +1,13 @@
 # Continue integration
 
-Continue setup uses one Mastermind-owned YAML document at `.continue/mcpServers/mastermind.yaml` for project scope or `~/.continue/mcpServers/mastermind.yaml` for user scope.
+Mastermind owns one standalone Continue YAML document:
 
-## Setup
+| Scope | Path |
+|---|---|
+| Project | `.continue/mcpServers/mastermind.yaml` |
+| User | `~/.continue/mcpServers/mastermind.yaml` |
 
-```text
-mastermind setup <claude|cursor|codex|continue|generic> \
-  --scope <project|user> [--root .] [--config PATH] [--write] [--remove] [--force]
-```
-
-Install and index Mastermind, then preview the selected owned file:
+## Preview and apply
 
 ```bash
 npm install -g @xcraftmind/mastermind
@@ -38,21 +36,30 @@ mcpServers:
       - serve
 ```
 
-The `command` and `args` follow the detected install mode. On Windows, global, npx, and project-local npm launchers use `cmd.exe /d /s /c` so Continue can execute npm's `.cmd` shims. Mastermind does not merge this entry into Continue's general JSON configuration.
+The `command` and `args` follow the detected install mode. On Windows, global,
+npx, and project-local npm launchers use `cmd.exe /d /s /c` so Continue can
+execute npm's `.cmd` shims. Mastermind does not merge this entry into Continue's
+general JSON configuration.
 
-## Updating and removing
+## Update or remove
 
-A canonical owned document is an idempotent no-op and can be removed safely. Customized content is refused unless `--force` is supplied; `--force` never implies `--write`. Before a forced change, the old bytes are backed up privately under `~/.mastermind/setup-backups/`.
+A canonical owned document is an idempotent no-op and can be removed safely.
+Customized content requires `--force`; `--force` never implies `--write`.
+Before a forced change, Mastermind stores the previous bytes under
+`~/.mastermind/setup-backups/`.
 
 ```bash
 mastermind setup continue --scope project --root . --remove          # dry-run
 mastermind setup continue --scope project --root . --remove --write
 ```
 
-## Verification
+## Verify
 
 ```bash
 mastermind doctor
 ```
 
-Doctor parses the owned YAML as bounded data, rejects symlinked files or existing path ancestors, compares the full standalone document structurally with the trusted current entry, and never executes its configured command. Reload Continue after applying a change. The former experimental JSON instructions are not supported.
+Doctor parses the owned YAML as bounded data, rejects symlinked files or
+existing path ancestors, and compares the full document with the trusted
+current entry. It does not execute the configured command. Reload Continue
+after applying a change. The former experimental JSON shape is unsupported.

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,15 +1,9 @@
 # Cursor integration
 
-Cursor supports project MCP configuration at `.cursor/mcp.json` and user configuration at `~/.cursor/mcp.json`.
+Cursor reads `.cursor/mcp.json` at project scope and `~/.cursor/mcp.json` at
+user scope.
 
-## Setup
-
-```text
-mastermind setup <claude|cursor|codex|continue|generic> \
-  --scope <project|user> [--root .] [--config PATH] [--write] [--remove] [--force]
-```
-
-Install and index Mastermind, then preview the selected target:
+## Preview and apply
 
 ```bash
 npm install -g @xcraftmind/mastermind
@@ -25,21 +19,26 @@ mastermind setup cursor --scope project --root . --write
 mastermind setup cursor --scope user --write
 ```
 
-The setup engine preserves unrelated root fields and MCP servers, rejects duplicate JSON keys and unsafe paths, and does not write without `--write`.
+The setup engine preserves unrelated root fields and MCP servers, rejects
+duplicate JSON keys and unsafe paths, and does not write without `--write`.
 
-## Updating and removing
+## Update or remove
 
-A canonical entry is an idempotent no-op. Customized replacement or removal requires `--force`, which does not imply `--write`. Forced file-backed changes save the previous bytes privately under `~/.mastermind/setup-backups/`.
+A canonical entry is an idempotent no-op. Customized replacement or removal
+requires `--force`, which does not imply `--write`. Forced file-backed changes
+save the previous bytes under `~/.mastermind/setup-backups/`.
 
 ```bash
 mastermind setup cursor --scope project --root . --remove          # dry-run
 mastermind setup cursor --scope project --root . --remove --write
 ```
 
-## Verification
+## Verify
 
 ```bash
 mastermind doctor
 ```
 
-Doctor treats Cursor configuration as bounded data, reports only structural status, and never executes the configured command. Restart Cursor after applying a change. Keep `.mastermind/` out of version control.
+Doctor treats Cursor configuration as bounded data, reports only structural
+status, and does not execute the configured command. Restart Cursor after
+applying a change. Keep `.mastermind/` out of version control.

--- a/docs/integrations/generic-mcp.md
+++ b/docs/integrations/generic-mcp.md
@@ -1,6 +1,8 @@
 # Generic MCP client integration
 
-`mastermind serve` is a standard [MCP](https://modelcontextprotocol.io) stdio server. Any MCP-capable client can connect to it.
+`mastermind serve` is an [MCP](https://modelcontextprotocol.io) stdio server.
+Use this guide when a client is not covered by the dedicated Claude Code,
+Codex, Cursor, or Continue setup commands.
 
 ## Server spec
 
@@ -9,27 +11,28 @@
 | transport | stdio |
 | command | `mastermind serve` |
 | protocol | MCP 2025-11-25; legacy 2024-11-05 |
-| tools | 27: 26 read-only, 1 additive local write (see below) |
+| tools | 28: 27 read-only, 1 additive local write (see below) |
 | resources | none |
 | prompts | none |
 
-Current clients receive behavior annotations and structured results after the initialized notification; legacy clients retain content-only results. Input frames are limited to 1 MiB and serialized result payloads to 8 MiB.
+Current clients receive behavior annotations and structured results after the
+initialized notification; legacy clients retain content-only results. Input
+frames are limited to 1 MiB and serialized result payloads to 8 MiB.
 
-## Safe setup
+## Preview and apply
 
-```text
-mastermind setup <claude|cursor|codex|continue|generic> \
-  --scope <project|user> [--root .] [--config PATH] [--write] [--remove] [--force]
-```
-
-Generic setup always requires an explicit JSON path:
+Generic setup requires an explicit JSON path:
 
 ```bash
 mastermind setup generic --scope project --config ./mcp.json        # dry-run
 mastermind setup generic --scope project --config ./mcp.json --write
 ```
 
-The command preserves unrelated root fields and MCP servers. Customized replacement or removal requires `--force`; `--force` never implies `--write`, and old bytes are backed up privately under `~/.mastermind/setup-backups/` before a forced mutation. `mastermind doctor` treats configuration as bounded data and never executes a configured command.
+The command preserves unrelated root fields and MCP servers. Customized
+replacement or removal requires `--force`; `--force` never implies `--write`.
+Before a forced mutation, Mastermind stores previous bytes under
+`~/.mastermind/setup-backups/`. `mastermind doctor` treats configuration as
+bounded data and does not execute a configured command.
 
 ## Config snippet
 
@@ -68,7 +71,7 @@ The `--index` flag is global and must come before `serve`.
 - Relationships and architecture: `mmcg_callers`, `mmcg_callees`,
   `mmcg_imports`, `mmcg_imported_by`, `mmcg_impact`, `mmcg_api_surface`,
   `mmcg_centrality`, `mmcg_dependency_cycles`, `mmcg_unreferenced`,
-  `mmcg_semantic`, `mmcg_facts`, `mmcg_map`, `mmcg_temporal`.
+  `mmcg_semantic`, `mmcg_facts`, `mmcg_team_map`, `mmcg_map`, `mmcg_temporal`.
 - Change analysis: `mmcg_symbols_changed_since`, `mmcg_change_class`,
   `mmcg_change_impact`, `mmcg_test_impact`, `mmcg_recent_changes`.
 - Workflow state: `mmcg_tasks`, `mmcg_history`, `mmcg_status`, `mmcg_scratchpad_read`, and the
@@ -78,7 +81,7 @@ The standard MCP `tools/list` response is the schema source of truth. See the
 [technical reference](../reference/mmcg.md#mcp-tools) for arguments, limits,
 and precision caveats.
 
-## Starting the server manually
+## Start the server manually
 
 ```bash
 mastermind serve

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -1,10 +1,33 @@
 # mmcg — Mastermind Codegraph
 
-This is the exhaustive technical reference for the mmcg engine. For the shortest path to a working installation, start with [Getting started](../getting-started.md); for the product overview, return to the [Mastermind README](../../README.md).
+This is the exhaustive contract for the `mmcg` engine. Start with
+[Getting started](../getting-started.md) for installation or the
+[project README](../../README.md) for the product overview.
 
-A small Rust binary that builds a structural index of a codebase (Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, C/C++). It serves the graph over **MCP** (26 read-only tools plus one additive local scratchpad write), but MCP is only one surface. The same binary provides spec gates (`verify-spec` / `audit-spec`), project setup (`init` / `doctor`), and the user-global style miner.
+`mmcg` is a Rust binary that builds a local structural index for Python,
+TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++.
+It exposes the same indexed state through CLI, Lens, and MCP. The MCP surface
+contains 28 tools: 27 read-only queries and one additive local scratchpad write.
+The binary also provides spec gates, client setup, evidence ingestion, review
+export, and style mining.
 
-> Installed via npm (`@xcraftmind/mastermind`)? The command is **`mastermind`** — the same binary. The `mmcg` name used throughout this doc is the cargo-installed alias (`cargo install mmcg`).
+> npm installs the command as both `mastermind` and `mmcg`. Cargo installs
+> `mmcg`. Examples below use `mmcg`; the command surface is identical.
+
+## Reference map
+
+| Need | Section |
+|---|---|
+| Supported syntax and known extraction gaps | [What it indexes](#what-it-indexes) |
+| Installation and commands | [Build from source](#build-from-source), [CLI usage](#cli-usage) |
+| Compiler-resolved enrichment | [SCIP semantic overlay](#optional-scip-semantic-overlay) |
+| External revision-bound evidence | [Fact-ingestion SDK](#declarative-fact-ingestion-sdk) |
+| Multi-repository local view | [Local team graph](#local-team-graph) |
+| Base-versus-head architecture | [Temporal graph](#temporal-graph-mmcg-temporal) |
+| Local review UI and portable evidence | [Lens](#mastermind-lens-mmcg-ui), [review package](#pr-evidence-package-mmcg-review-export) |
+| Architecture rules | [Policy as code](#architecture-policy-as-code-mmcg-policy-check) |
+| MCP protocol and tool schemas | [MCP server](#mcp-server-usage), [MCP tools](#mcp-tools) |
+| Bounds and precision caveats | [Work budgets](#work-budgets-timeouts-and-cancellation), [limitations](#limitations) |
 
 ## What it indexes
 
@@ -63,13 +86,20 @@ These directories are always skipped: `.git`, `.mastermind`, `.venv`, `venv`,
 `__pycache__`, `node_modules`, `target`, `dist`, `build`, `.tox`, `.pytest_cache`,
 `.mypy_cache`, `.ruff_cache`, `.next`, `.turbo`, `.cache`.
 
-## Why a custom indexer
+## Design scope
 
-The Mastermind workflow needs structural queries every few seconds (planner deciding blast radius, executor checking callers before edits). Grep/Read each costs hundreds of tokens; mmcg returns the same info in dozens. Multiplied across a workflow run, the difference is between affordable and not.
+The default index is intentionally smaller than a compiler database. It uses
+Tree-sitter so a mixed-language repository can be indexed locally without
+installing each language toolchain. SQLite gives CLI, MCP, and Lens a shared
+bounded query surface instead of repeatedly rescanning source text.
 
-mmcg is intentionally narrow:
-- Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++ — extend by adding a parser, not by depending on multi-language toolchains
-- 27 MCP tools: 26 read-only structural/semantic/evidence tools plus `mmcg_scratchpad_append`, which makes an additive write to the gitignored local index
+- Ten language families share one source-discovery and storage contract.
+- Optional SCIP facts add compiler-resolved evidence without replacing the
+  syntactic graph.
+- External producers submit validated facts; they cannot execute inside the
+  process or write SQLite.
+- MCP exposes 28 bounded tools: 27 read-only queries and the additive,
+  gitignored `mmcg_scratchpad_append` write.
 
 ## Performance model
 
@@ -84,7 +114,9 @@ is incremental. Use `mmcg index . --force` for a cold parse measurement and
 record the emitted file/symbol/edge counts with the timing; do not compare a
 cold run with an incremental no-op. Maintainers can run `just benchmark-index`
 for a reproducible synthetic cold/warm/incremental report including peak process
-RSS. It is an evidence tool, not a machine-independent CI threshold.
+RSS. See [Indexing benchmarks](../benchmarks.md) for current measurements,
+parameters, ranges, and limitations. The benchmark is a regression aid, not a
+machine-independent CI threshold.
 
 ## Build from source
 
@@ -891,25 +923,79 @@ subprocess never reaches it. The watchdog is what covers those paths.
   and possibly inaccurate", never just "more available"; narrow with
   `language` and retry.
 
-## Limitations (honest)
+## Limitations
 
-- **Ten language families.** Python (`.py`, `.pyi`), TS/TSX (`.ts`, `.tsx`), JS/JSX (`.js`, `.jsx`, `.mjs`, `.cjs`), Vue SFC (`.vue`), Rust (`.rs`), C# (`.cs`), Go (`.go`), Java (`.java`), PHP (`.php`, `.phtml`), C/C++ (`.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.hh`, `.hxx`, `.ipp`, `.tpp`). Extension matching is case-insensitive. Other extensions are skipped and appear in the bounded diagnostics sample.
-- **Call resolution is name-based, not type-based.** `obj.foo()` records a call to "foo" with literal path "obj.foo" — but `obj` isn't resolved to a type, so cross-file precision is best-effort.
-- **No cross-file symbol resolution.** Edges store `to_name` and `to_path` (strings), not `to_id`. Searching "callers of foo" finds *every* call to "foo" anywhere — even unrelated ones in different modules. The `to_path` column reduces ambiguity for imports specifically (use `mmcg_imported_by` with `match: path`).
-- **Default path-based queries reflect literal source text, not semantic FQN.** When you index code with `use foo::bar::Baz` and `mmcg_imported_by --query "foo::bar::Baz" --match path` you'll get that file. But if another file imports the same type via `use crate::Baz` (re-exported), it stores `to_path = "crate::Baz"` and won't match the FQN query. **Use `match: name` for "find all syntactic consumers"**; reserve `match: path` for "find this exact import spelling". When the language's SCIP producer resolves the re-export, import its artifact and use `mmcg_semantic` for the compiler identity; this does not rewrite the literal Tree-sitter import edge.
-- **`to_type` for member-call detection uses a capital-letter heuristic in TS/JS/Python.** `Class.method()`, `JSON.parse()`, `Foo.bar.baz()` correctly emit `to_type = "Class"` / `"JSON"` / `"Foo"` (rightmost capitalized receiver). For Rust, `to_type` is unambiguous via the `scoped_identifier` AST node — no heuristic needed. The heuristic misses calls on uppercase-named variables (e.g. `const FOO = new Bar(); FOO.method()` won't emit `to_type=FOO`) but matches the common convention used in idiomatic JS/TS/Python code.
-- **JSX component usage is resolved by the uppercase-tag convention.** `<Button />` and `<Select.Option />` emit `calls` edges from the containing component; `<div>` and `<section>` do not, because a syntactic parser cannot otherwise tell a component from a host element. A component deliberately named in lowercase is invisible, and a capitalized host element in a custom renderer would be counted. `mmcg_callers` on a component therefore answers "who renders this", which is the frontend equivalent of "who calls this".
-- **Variable-declared functions are named after their binding.** `const Card = () => …`, `const Card = function () {…}`, and one level of wrapper call (`memo(…)`, `forwardRef(…)`, `styled(…)`) become `function` symbols named `Card`, with the inner parameters as the signature so a changed props contract still reports as `signature_changed`. Wrapper unwrapping stops at one level: `memo(forwardRef(() => …))` finds no inner function and produces no symbol. A non-function value that merely receives a callback (`const x = compute(() => 1)`) is captured as a function symbol — a known over-capture of the same heuristic.
-- **A Vue SFC is indexed as one component named after its file.** `MyCard.vue` defines `MyCard` (kind `component`), owning every symbol from its `<script>` block with `.vue`-absolute line numbers — the script is re-parsed with the real TypeScript or JavaScript grammar, chosen by `lang`, so it is not a weaker approximation. Template usage emits `calls` edges from the component. Both `<my-widget />` and `<MyWidget />` normalize to `MyWidget`, matching Vue's own resolution, so a search for the kebab spelling finds nothing. What stays invisible: expressions inside template attributes, and components auto-imported by build tooling rather than by an `import` statement.
-- **`disciplines` classifies only what a path can establish.** `mmcg_change_impact` reports `frontend` for component and stylesheet file types (`.tsx`, `.jsx`, `.vue`, `.css`, `.scss`, `.sass`, `.less`), `qa` for the same test-file naming convention the test projection already uses, and `migration` for a `.sql` file or a path component named `migrations`, `migration`, or `migrate` — which covers the Django, Rails, Prisma, and Flyway layouts without guessing at a repository that keeps them elsewhere. A detected `migration` is a strict-mode trigger, not a statement about whether the migration is destructive. A file can belong to both. Everything else is returned under `unclassified` rather than guessed — a queue consumer, a migration, or an auth boundary in a plain `.ts` file has no path-level signal, and inventing one would be a confident answer without evidence. The block proposes an evidence set for routing; it is not a statement about what the change does.
-- **Watcher doesn't index brand-new directories deeply on the first event.** If you `mkdir -p foo/bar/baz` and add files inside, the watcher catches each file event individually. No special handling — just slower for big batch additions.
-- **Schema migration rebuilds derived graph tables.** When mmcg's schema version changes (v1→v2, etc.), symbols/files/edges and task-spec search are dropped on open; repository identity, project-history search, and scratchpad entries are retained so an in-place `mmcg index .` can safely repopulate the graph.
-- **`mmcg_unreferenced` filters known framework patterns since 0.7.0.** The query excludes symbols decorated with pytest fixtures / parametrize / mark, web-framework route decorators (`.route` / `.get` / `.post` / `.put` / `.delete` / `.patch` / `.websocket`), JIT decorators (`triton.jit` / `numba.jit` / `nb.njit`), task queues (`celery.task` / `shared_task`), CLI (`click.command` / `click.group`), Rust attributes (`#[test]`, `#[tokio::main]`, `#[async_std::test]`), C# test/web/benchmark attributes (xUnit `[Fact]`/`[Theory]`, NUnit `[Test]`/`[SetUp]`, MSTest `[TestMethod]`, ASP.NET `[HttpGet]`/`[HttpPost]`/`[Route]`, BenchmarkDotNet `[Benchmark]`), and (since 0.9.0) Java/PHP frameworks: JUnit `@Test`/`@ParameterizedTest`/`@BeforeEach`, Spring `@GetMapping`/`@PostMapping`/`@Bean`/`@Scheduled`, PHPUnit `#[Test]`/`#[DataProvider]`, Symfony `#[Route]`/`#[AsCommand]`, Livewire `#[On]`. Also filters `test_*` functions in `*test*` / `*spec*` paths (pytest convention). Remaining false-positive classes that mmcg can't see: (a) entry points like `main` or framework-registered handlers without a recognized decorator; (b) dynamic dispatch — trait objects, duck-typed calls, JS reflection; (c) cross-language calls (TS subprocess invoking Python); (d) runtime registration via dict / list (`HANDLERS = {"foo": foo}`); (e) gtest-style C++ macro tests (`TEST(Suite, Name)` — macros invisible to tree-sitter); (f) Go test functions (`TestXxx(*testing.T)` convention — `testing` import is the closest signal, but we don't filter on imports). Review every hit manually before deleting. The tool is "candidates to investigate", not "safe to delete".
-- **`mmcg_api_surface` is empirical, not declared.** It returns symbols that are *currently* called from outside the prefix — independent of language-level visibility (`pub`/`export`/no-underscore). A symbol declared `pub` with no external callers won't appear; a private symbol leaked through a public re-export and called externally will. Useful for "what does the rest of the codebase actually rely on?", not for "what's the public API contract?".
-- **`mmcg_recent_changes` reflects index mtime, not git history.** If you re-index after rewriting history (rebase, amend, force-push) every touched file appears as "recent". Use `git log --since=...` for git truth; use this tool for "what has my watcher seen lately".
-- **C# partial classes** are stored as one symbol per file under an indexed namespace parent. `mmcg_search` collapses declarations only when name, kind, and namespace identity all match, returning a `locations` array; set `collapse_partials: false` to opt out. Legacy/malformed rows without namespace identity remain separate rather than risk merging unrelated types. `mmcg_callers` / `mmcg_callees` / `mmcg_impact` / `mmcg_outline` are unaffected: they resolve by name. Non-partial classes with colliding names across namespaces are *not* collapsed.
-- **Python module-level constants** (`MAX_RETRIES = 5`, `__all__ = [...]`, `HOST, PORT = ...`) are captured as `kind="constant"` since 0.14.0. Scoping is strict — only DIRECT children of the module node count; assignments inside `if` / `for` / `try` / class bodies / function bodies are not constants. `mmcg_unreferenced` **excludes constants by default** because the call/import graph doesn't track value-reads — every constant would otherwise appear as dead. Opt-in with `kind=constant` to surface unused constants explicitly. `mmcg_callers MAX_RETRIES` still works for the cases where a constant is referenced via `import` (`from foo import MAX_RETRIES` produces an `imports` edge) or attribute access (`foo.MAX_RETRIES` produces a `calls` edge to leaf `MAX_RETRIES`). Other languages: not extracted (TS/Rust/Go/etc. constants are typed declarations through different AST shapes — file a request if you need them).
-- **C/C++ Tree-sitter is best-effort.** The default C/C++ extractor has no preprocessor, template instantiation, or semantic analysis. Concretely: (a) **macros are invisible** — `TEST(Suite, Name) { ... }` is seen as a call to `TEST`, not as a function definition, so gtest/Catch2 test bodies don't appear in `mmcg_search` and calls inside macro arguments may be lost; (b) **templates** record the template name but not instantiations (`vector<int>` doesn't create a `vector<int>` symbol); (c) **header/source split** produces two symbol rows (`void Foo::bar()` declared in `.h` and defined in `.cpp` = two `bar` hits); (d) **ADL/overload resolution** isn't performed (`swap(a, b)` records `swap` without knowing which namespace it resolves to); (e) **`#include` file resolution** tries exact repository-relative, source-relative, then deterministic suffix matches for map/cycle edges. It can over-approximate when several headers share a basename and it does not parse the included contents. A `scip-clang` artifact imported through `mmcg enrich --scip` can add compiler-resolved identities and references, while the syntactic graph remains the fallback. mmcg uses one `tree-sitter-cpp` grammar for both `.c` and `.cpp` files — rare C-only code that uses C++ keywords as identifiers (e.g. a variable named `new`) may mis-parse.
+### Language and extraction coverage
+
+- Supported extensions are listed in [Language coverage](#language-coverage).
+  Matching is case-insensitive. Other extensions are skipped and reported in a
+  bounded diagnostics sample.
+- A Vue SFC becomes one component named after the file. Its script uses the
+  TypeScript or JavaScript grammar and retains `.vue`-absolute lines. Template
+  tags emit calls, but template expressions and build-tool auto-imports do not.
+  Kebab-case and PascalCase tags normalize to PascalCase.
+- Python module constants are direct module-child assignments only. Assignments
+  inside control flow, classes, or functions are not constants. Constants are
+  excluded from `mmcg_unreferenced` by default because value reads are not a
+  general edge type; request `kind=constant` explicitly.
+- C/C++ parsing has no preprocessor, template instantiation, ADL, or overload
+  resolution. Macros such as `TEST(Suite, Name)` are calls, not definitions.
+  Header declarations and source definitions remain separate rows. Include
+  resolution tries exact repository-relative, source-relative, then
+  deterministic suffix matches and may over-approximate duplicate basenames.
+  One `tree-sitter-cpp` grammar handles C and C++; unusual C identifiers that
+  are C++ keywords can mis-parse. SCIP can add resolved evidence separately.
+
+### Symbol and edge identity
+
+- Calls resolve by name, not receiver type. `obj.foo()` records `to_name=foo`
+  and literal `to_path=obj.foo`; it does not establish the type of `obj`.
+- Default edges store `to_name` and `to_path`, not a resolved cross-file
+  `to_id`. A callers query can therefore combine unrelated same-name symbols.
+- Import `match: path` compares literal source spelling. A re-exported
+  `crate::Baz` does not match `foo::bar::Baz`. Use `match: name` for broad
+  syntactic consumers or a SCIP overlay for compiler identity.
+- TS, JS, and Python member calls use the rightmost capitalized receiver as
+  `to_type`. Rust scoped identifiers do not need this heuristic. Uppercase
+  variable names can produce false type hints.
+- JSX calls follow the uppercase component convention. `<Button />` is a call;
+  `<div>` is not. Lowercase custom components are missed and capitalized host
+  elements in custom renderers can be counted.
+- Variable-declared functions use their binding name. One wrapper layer such as
+  `memo(...)`, `forwardRef(...)`, or `styled(...)` is unwrapped. Nested wrappers
+  can be missed; a non-function assignment that receives a callback can be
+  over-captured.
+- C# partial declarations collapse only when name, kind, and full namespace
+  identity match. Legacy rows without namespace identity stay separate.
+  Callers, callees, impact, and outline remain name-based.
+
+### Heuristic query semantics
+
+- `disciplines` derives only path-level signals. Frontend extensions, test
+  naming, and migration paths can trigger a discipline; everything else is
+  `unclassified`. A migration signal indicates review depth, not destructive
+  behavior.
+- `mmcg_api_surface` is empirical: it returns symbols currently referenced from
+  outside a prefix, regardless of declared visibility. It is not a language
+  public-API declaration query.
+- `mmcg_recent_changes` reports index timestamps, not Git history. After a
+  rebase or forced re-index, use `git log --since=...` for Git truth.
+- `mmcg_unreferenced` suppresses recognized framework entry points:
+  pytest fixtures/marks, common web routes, JIT/task/CLI decorators, Rust test
+  attributes, C# test/web/benchmark attributes, JUnit/Spring annotations, and
+  PHPUnit/Symfony/Livewire attributes. It also filters `test_*` functions in
+  test/spec paths. It cannot reliably see undecorated entry points, dynamic
+  dispatch, cross-language calls, runtime registries, C++ macro tests, or Go's
+  `TestXxx` convention. Treat every result as a candidate to inspect, never as
+  authorization to delete code.
+
+### Operational behavior
+
+- A watcher observes files created inside a new deep directory individually;
+  it does not rescan the entire new subtree as one special event.
+- A schema-version change rebuilds derived graph and task-search tables.
+  Repository identity, project-history search, and scratchpad entries are
+  retained so `mmcg index .` can repopulate the graph in place.
 
 ## CI
 

--- a/docs/team-graph.md
+++ b/docs/team-graph.md
@@ -1,16 +1,23 @@
 # Local team graph
 
-Mastermind can federate several existing local indexes into one bounded,
-read-only architecture view. It does not copy repositories into a central
-database and it does not infer cross-repository calls. Each repository remains
-independently indexed; the team manifest declares the relationships that are
-known outside source-level static analysis.
+A team graph combines several existing local indexes into one bounded,
+read-only architecture view. Each repository stays independently indexed.
+Mastermind neither copies repositories into a central database nor infers
+cross-repository calls; the manifest declares those relationships.
 
 The public v1 schema is
 [`schemas/mastermind-team-v1.schema.json`](../schemas/mastermind-team-v1.schema.json),
 with API identifier `mastermind-team/v1`.
 
-## Lock and query
+## Prerequisites
+
+Each member repository must have:
+
+- a clean, current Git revision;
+- a fresh `.mastermind/mmcg.db` created by `mastermind index .`;
+- a stable local root and index path available to the querying process.
+
+## Define, lock, and query
 
 Create a draft manifest. Paths may be absolute or relative to the manifest.
 
@@ -48,7 +55,7 @@ mastermind team lock team.json --output team.lock.json
 mastermind team map team.lock.json > team-map.json
 ```
 
-`team lock` writes canonical roots/index paths plus the credential-free
+`team lock` writes canonical root and index paths plus the credential-free
 repository identity, exact Git revision, and a domain-separated digest of the
 SQLite database and active WAL bytes. Its JSON result also prints the exact
 `manifest_sha256` value to use as `MMCG_TEAM_MANIFEST_SHA256`. `team map`
@@ -97,6 +104,5 @@ declared edge is evidence supplied by the manifest owner, not compiler- or
 runtime-resolved proof. Keep the lock file under normal code-review ownership
 and regenerate it whenever a member repository or its index changes.
 
-This is the local-first foundation for a future shared/team service. It does
-not yet provide remote repository discovery, distributed locking, access
-control, or a hosted graph.
+Version 1 does not provide remote repository discovery, distributed locking,
+access control, or a hosted graph.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,256 +1,168 @@
-# How the Mastermind workflow works
+# Workflow
 
-Mastermind separates structural evidence from agent judgment. The codegraph
-answers what exists and what a change can affect; the workflow adds only as
-much ceremony as the risk justifies.
+Mastermind separates repository facts from agent judgment. The codegraph
+establishes what exists and what a diff can affect; task artifacts record scope,
+claims, checks, and review decisions. Use only the depth justified by the risk.
 
-## Choose one mode
+## Choose a mode
 
-| Mode | Use it for | Required artifact |
+| Mode | Use for | Required artifacts |
 |---|---|---|
-| **Direct** | Small, reversible, clearly scoped work | None. Use `map`, `impact`, and tests as needed. |
-| **Verified** | Normal multi-file or delegated work | A compact task spec with goals, scope, acceptance criteria, and verification. |
-| **Strict** | Auth, billing, migrations, public APIs, data-loss, supply-chain, or difficult rollback | A verified spec plus risk, evidence, rollback, and independent review. |
+| **Direct** | Small, reversible, clearly scoped work | None |
+| **Verified** | Normal multi-file or delegated work | Spec, executor report, audit, task state |
+| **Strict** | Auth, billing, migrations, public API, data loss, supply chain, hard rollback | Verified artifacts plus risk, rollback, and independent review evidence |
 
-Direct mode works after `mastermind index .`; it does not require
-`mastermind init` or a task folder. `lite` and `standard` task modes remain
-readable for compatibility, but new tasks should use `verified` or `strict`.
+`lite` and `standard` remain readable for compatibility. New task specs should
+use `verified` or `strict`.
 
-## Direct workflow
+## Direct
 
 ```bash
 mastermind index .
-mastermind map .
 mastermind impact --since main
-mastermind temporal --since main
-# implement the change
+# implement the change and run focused + repository-required checks
 mastermind impact --since main
-# run focused tests and the repository-required gate
-# review the comment delta with `mastermind-comment-audit`
 ```
 
-This is the normal path for a small fix. Mastermind supplies structural facts;
-your coding client performs the edit and reports the checks it actually ran.
+Direct work has no task folder or controller state. The implementation and
+verification record live in the normal commit/PR. Use this path when rollback
+is easy and the change does not need delegated ownership.
 
-## Verified workflow
+## Verified
 
-Create the contract:
+### 1. Create and verify the contract
 
 ```bash
-mastermind new-spec "Add account recovery"        # verified is the default
+mastermind new-spec "Add account recovery"
 mastermind verify-spec .mastermind/tasks/001-add-account-recovery/spec.md
-# review Scope and Acceptance Criteria, then approve the task
+```
+
+Review the scope, acceptance criteria, and verification commands before
+approval. Then record the baseline:
+
+```bash
 mastermind run-task .mastermind/tasks/001-add-account-recovery/spec.md --pre-only
 ```
 
-The task folder owns five workflow artifacts:
+### 2. Implement against the approved spec
 
-| Artifact | Owner | Purpose |
-|---|---|---|
-| `spec.md` | Planner | Goals, scope, acceptance criteria, and verification contract |
-| `executor-report.md` | Executor | Files changed, claims, defects, and observed command results |
-| `audit.md` | Controller | Mechanical comparison of the report, spec, index, and real diff |
-| `state.json` | Controller | One task-local lifecycle record |
-| `history-review.md` | Controller, then planner | Explicit Context/Lesson disposition after semantic review |
+Give `spec.md` to the implementation agent. The executor may change only the
+approved product files and must write `executor-report.md`. It must not edit
+`state.json`, `audit.md`, or controller-owned history files.
 
-`verify-spec` is read-only. `run-task --pre-only` is intentionally later: it
-records that the contract was approved and captures the git baseline. After
-that transition, hand `spec.md` to the implementation agent in any coding
-client. The executor must write `executor-report.md`; it must not update
-`state.json`. Then run:
+### 3. Audit the real diff
 
 ```bash
 mastermind run-task .mastermind/tasks/001-add-account-recovery/spec.md --post-only
 ```
 
-Post-flight fails closed when the report is missing or malformed. A `held`
-verdict writes `audit.md`, marks the task complete, writes release notes under
-`.mastermind/releases/`, and creates a pending `history-review.md` without
-inventing a decision or lesson.
-`drift` or `broken` keeps the task blocked for planner review. A completed task
-is idempotent unless `--post-only` explicitly requests another audit.
+Post-flight compares the approved spec, executor claims, current index, and Git
+diff. Uncommitted and untracked files count because this gate normally runs
+before commit.
 
-Mechanical `drift` and `broken` findings create a lesson `candidate` with
-provenance and evidence — **one per task**, keyed on the task alone. A later
-failure on the same task refreshes that entry to the newest observation and
-raises its `Occurrences` count rather than filing a sibling, so an
-iterate-until-green loop leaves one reviewable record instead of a pile of
-near-identical ones. It becomes reusable guidance only after semantic review
-supplies the actual lesson and changes its status to `active`, `resolved`, or
-`superseded`; once reviewed, later mechanical noise never rewrites it. A successful task may still produce a
-durable lesson; a failed audit does not automatically prove one.
+| Verdict | Meaning | Next action |
+|---|---|---|
+| `held` | Mechanical contract is satisfied | Perform semantic review and delivery gates |
+| `drift` | Work differs from the approved contract | Planner reviews and updates or rejects the drift |
+| `broken` | Required evidence or behavior is missing | Executor fixes the change before another audit |
 
-`run-task --exec` is a legacy convenience that shells out to `claude -p`.
-Normal handoff plus `--post-only` is client-neutral and works with Claude Code,
-Codex, Cursor, Continue, or another client.
+Post-flight fails closed when the executor report is absent or malformed.
 
-## Strict workflow
+## Strict
 
 ```bash
 mastermind new-spec "Rotate signing keys" --mode strict
 ```
 
-Strict mode uses the same controller and artifacts, but adds only material
-risk controls: alternatives, evidence ledger, rollback/migration, a design
-critic, and a read-only independent auditor. Security review is required when
-the change crosses auth, secrets, permissions, agent/tool boundaries, or the
-supply chain.
+Strict uses the same state machine and adds the evidence that high-risk work
+needs: explicit alternatives, threat/failure cases, rollback or migration,
+design criticism, and independent review. A security review is required when
+the change crosses authentication, authorization, secrets, tool permissions,
+agent delegation, or the supply chain.
 
-## Review the comment delta
+Strict is not a larger template for ordinary work. If no material failure mode
+or difficult rollback exists, Verified is the clearer contract.
 
-Comment discipline is asked of the implementation agent, but an agent optimizing
-for acceptance criteria drops it first, and the mechanical contract cannot see
-it: post-flight proves that a file changed, not that the change stopped
-narrating itself. So the rule is verified by a reader.
+## Task artifacts and ownership
 
-`mastermind-comment-audit` (skill, portable) and `mastermind-comment-auditor`
-(Claude subagent) review only the comments a change added, modified, or deleted.
-They are read-only: findings carry the comment verbatim, the code line that
-already says it, and what would be lost — and the report names what it kept, so
-a reviewer that flags nothing is reporting a clean result rather than failing.
-Deleted rationale is reported too; a rename that takes a non-obvious `why` with
-it is a regression no write-time rule catches.
+Each canonical task lives under `.mastermind/tasks/<NNN>-<slug>/`.
 
-Two entry points, because Direct work has no controller:
+| Artifact | Writer | Contract |
+|---|---|---|
+| `spec.md` | Planner | Goal, scope, acceptance criteria, verification, mode-specific risk evidence |
+| `executor-report.md` | Executor | Changed files, observed checks, claims, defects, and gaps |
+| `audit.md` | Controller | Mechanical comparison of spec, report, index, and diff |
+| `state.json` | Controller | One task-local lifecycle record |
+| `history-review.md` | Controller, then planner | Explicit Context and Lesson disposition after semantic review |
 
-- **Verified and strict:** after `run-task --post-only`, as input to semantic
-  review. Post-flight prints the reminder with the recorded baseline on `held`
-  and `drift`, and withholds it on `broken` — the executor still has to iterate,
-  so that comment delta is not the one a reviewer would judge.
-- **Direct:** invoke it against the branch point once the change is finished.
-  This is the only review Direct work gets.
+A held audit may also write a release-note candidate under
+`.mastermind/releases/`. Markdown remains the durable source of truth;
+`state.json` and the SQLite history index are coordination/retrieval layers.
 
-A comment audit produces no `held` / `drift` / `broken` verdict and never
-substitutes for the contract audit.
+## What the gates prove
 
-## Review a UI change
+Pre-flight checks:
 
-The codegraph indexes React components (including arrow and `memo`/`forwardRef`
-forms) and Vue single-file components, and treats `<Button />` and
-`<base-button />` as call edges. That makes two frontend questions structural
-rather than a matter of opinion: does this component already exist and who
-renders it, and did a props contract change without its callers.
+- mandatory sections and mode requirements;
+- referenced files and indexed symbols;
+- pre-edit caller-count snapshots;
+- literal FIND blocks when supplied;
+- declared verification commands.
 
-`mastermind-component-research` answers them before the change is written —
-reinvention is the most expensive frontend mistake, and it is invisible in a
-diff. `mastermind-frontend-audit` (skill) and `mastermind-frontend-auditor`
-(Claude subagent) check the finished change: a component nothing renders, a
-required prop added while callers stay on the old contract, a duplicate of an
-existing component, and a raw value shadowing a design token.
+Post-flight checks:
 
-Neither judges whether the result looks right. That half is handled by naming
-it instead of pretending to check it.
+- actual changed files against approved scope;
+- required report shape and executed-command claims;
+- planned tests and zero-test/vacuous claims;
+- symbol removal or signature drift;
+- index and snapshot consistency.
 
-`mastermind-design-intake` converts a handoff into a contract that can fail:
-the design source is recorded, mapped components are confirmed against the
-repository, and acceptance criteria carry token names rather than resolved
-values. An element missing from a design tool's code mapping is not evidence the
-component is missing from the codebase — coverage is partial, and assuming
-otherwise is how a fourth `Button` gets written. Whatever stays a visual
-judgement is parked in its own section rather than smuggled into criteria a
-mechanical gate would wave through.
+They do not prove runtime behavior, product quality, visual correctness,
+security, or architectural soundness. Those require tests and human/domain
+review.
 
-`mastermind-browser-verification` decides what a browser check leaves behind.
-The accessibility tree is evidence because it is text that can be quoted and
-compared; a screenshot is for a human to look at. Console errors and failed
-requests are mechanical failures. Viewports and colour scheme are a recorded
-checklist, and an item that was not checked is written as not checked — an
-omitted line reads as a pass.
+## Optional review disciplines
 
-## Review whether the tests prove the change
+Load a discipline because the changed paths or risk require it, not because a
+large checklist looks thorough.
 
-A green suite proves the assertions present passed. It does not prove the change
-is covered, and it does not prove those assertions were checking what changed —
-different claims, and only the first runs automatically.
+| Need | Before implementation | After implementation |
+|---|---|---|
+| Unknown code structure | `mastermind-codegraph-research` | — |
+| Service/state/retry boundary | `mastermind-runtime-research` | `mastermind-architecture-review` |
+| UI component reuse and callers | `mastermind-component-research` | `mastermind-frontend-audit` + browser verification |
+| Test relevance | `mastermind-test-impact` | `mastermind-test-audit` |
+| Security/tool boundary | `mastermind-security-research` | `mastermind-agent-security-review` |
+| Changed comments | — | `mastermind-comment-audit` |
+| Product prose to task contract | `mastermind-product-intake` | — |
 
-The controller already establishes part of this: `vacuous_test_claim` means a
-verification command provably ran zero tests, and `missing_test` means a planned
-test is absent. `mastermind-test-audit` (skill) and `mastermind-test-auditor`
-(Claude subagent) cover what it cannot. `mmcg_test_impact` classifies candidates
-as `direct`, `transitive`, or `heuristic`, and the classification is the point:
-a `heuristic` candidate is a filename that matched, not evidence the code ran.
-A changed symbol with no `direct` candidate is uncovered behaviour.
+The installed [skill catalog](../skills/README.md) defines each contract. These
+reviews are read-only and do not replace the controller audit.
 
-Two findings need reading rather than a query. A test can be green, on-topic,
-and still exercise a wrapper or a retired entry point the real caller no longer
-uses — that is a pass about a path nobody runs. And an assertion edited in the
-same diff as the implementation it checks has stopped being an independent check;
-sometimes the contract genuinely moved, sometimes that is how a regression ships
-green, and the review reports the pair rather than deciding silently.
+## History and lessons
 
-Coverage is still not correctness. A `direct` test proves the code ran, not that
-the expected value is right, and flakiness and ordering are invisible here.
+Mechanical drift may create one lesson candidate per task. A candidate records
+the observed failure; it is not reusable guidance until semantic review writes
+the actual lesson and changes its status. Repeated failures refresh the same
+candidate instead of creating duplicates.
 
-## Research a service change before designing it
+After a held audit, review `history-review.md` and mark Context and Lesson as
+`updated` or `not applicable` with a concrete reason. This prevents a successful
+diff from silently becoming an invented architectural decision.
 
-`mastermind-architecture-review` reconstructs the runtime path and judges the
-design. `mastermind-runtime-research` runs first and answers something narrower:
-who already depends on what is about to change, who writes the state it touches,
-and which boundaries it crosses.
+## Client model
 
-Its most important output is the gap list. The graph is syntactic, so a queue
-producer and its consumer are two static islands with no edge between them, a
-framework-registered handler has no caller, and a DI-resolved implementation is
-reached by a name the source never spells. `mmcg_callers` returning nothing on a
-handler means no static caller was found — not that nothing calls it. An
-architecture review built on "the graph showed no other callers", without the
-list of what the graph could not see, is confident about a question nobody asked.
+Planning, implementation, and post-flight are client-neutral. Claude Code and
+Codex can install the complete workflow bundle. Cursor, Continue, and generic
+MCP clients receive the graph tools but do not have a Mastermind-owned native
+workflow-extension format.
 
-`mmcg_api_surface` carries the other half: it reports the symbols under a prefix
-that the rest of the codebase actually reaches, independent of what is declared
-public. A module can export twenty symbols and have three real consumers. Those
-three are the contract a change has to keep working.
+`run-task --exec` is a legacy Claude CLI convenience. The portable path is an
+explicit handoff followed by `--post-only`.
 
-## Convert product writing into a contract
+## Related documentation
 
-A PRD is written to decide whether to build something; a task contract is
-written to check whether it was built. `mastermind-product-intake` converts the
-first into the second by sorting every statement into behaviour, constraint, and
-outcome.
-
-Only behaviour becomes acceptance criteria. A constraint qualifies once its
-measurement is named — unmeasured, it reads like rigour and checks nothing. An
-outcome never qualifies: "reduce support tickets by 30%" cannot fail on the day
-the change lands, and leaving it in the contract means a mechanical gate marks
-it satisfied while nobody has measured anything. Outcomes get their own section
-with the metric, the instrument, and who reads it.
-
-The intake also resolves product nouns to symbols — a feature that reads as new
-is usually mostly existing surface — and surfaces the cases the document never
-mentions: in-flight items, the empty state, partial failure, who is allowed.
-Answering those silently is how an executor's invention ships under a held
-audit.
-
-It does not write the PRD or validate the product assumption. There is no
-repository fact against which "users want this" can be checked, and this
-workflow does not pretend otherwise.
-
-## What the checks prove
-
-Pre-flight checks required sections, referenced paths, indexed symbols,
-snapshot drift, literal FIND blocks when present, and verification commands.
-Post-flight checks changed-file scope, removed or changed symbols, snapshot
-drift, planned tests, and executor claims.
-
-The graph is syntactic and bounded. Dynamic dispatch, reflection, re-exports,
-overloads, and cross-language calls can reduce precision. A held mechanical
-contract therefore still needs a short semantic check: did the implementation
-solve the original request, and do the tests demonstrate the acceptance
-criteria?
-
-## Client capabilities
-
-`mastermind install --client all` installs portable skills for Claude Code and
-Codex, plus spawnable subagent definitions for Claude Code. Codex receives the
-same workflow guidance as skills, but not Claude's native subagent runtime.
-Cursor and Continue use Mastermind through MCP; they do not receive a claimed
-native workflow bundle.
-
-Verify installed ownership and content hashes with:
-
-```bash
-mastermind doctor --workflow --client all
-```
-
-For signed, policy-bound CI evidence, see [Verifiable audits and GitHub
-Action](github-action.md).
+- [Getting started](getting-started.md)
+- [CLI and MCP reference](reference/mmcg.md)
+- [Verifiable GitHub Action](github-action.md)
+- [Contributing](../CONTRIBUTING.md)

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,191 +1,162 @@
-# Evals
+# Behavioral evaluations
 
-Adversarial test cases for the review subagents plus the planner, executor, and
-user-facing workflow skills.
+Adversarial regression cases for Mastermind agents and workflow skills. One case
+proves one expected behavior; suite pass rate is not a coverage or correctness
+metric.
 
-**This is not a coverage metric.** Each case is one regression scenario, not a guarantee.
+## Suite map
 
-## Files
+| File | Target | Expected result |
+|---|---|---|
+| `critic.jsonl` | Design critic | `rethink`, `revise`, or `ship` |
+| `auditor.jsonl` | Post-flight auditor | `held`, `drift`, or `broken` |
+| `intake.jsonl` | Prompt intake | `refined`, `passthrough`, or `ask` |
+| `workflow.jsonl` | Planner, executor, and portable skills | Required and forbidden signals |
+| `fixtures/` | Real Git histories for auditor cases | Exact planted change |
+| `scorecard.md` | Dated full-suite results | Environment and trust notes |
 
-- `critic.jsonl` — designs we want flagged (or cleanly passed); verdicts: `rethink`/`revise`/`ship`
-- `auditor.jsonl` — executor reports we want verified (or caught lying); verdicts: `held`/`drift`/`broken`
-- `intake.jsonl` — raw prompts the refiner should normalize; actions: `refined`/`passthrough`/`ask`
-- `workflow.jsonl` — planner/executor and product-skill contract regressions; each case names the exact prompt artifact it evaluates
-- `runner.py` — invokes the subagent via `claude -p`, asserts on verdict/action + key phrases
-- `ablation.py` — vanilla-vs-mastermind catch-rate study over the planted-defect auditor cases (does the codegraph + auditor contract beat plain `claude -p` + grep/read?); see [Ablation](#ablation)
-- `fixtures/` — real-git source trees used by auditor cases; see `fixtures/<name>/README.md`
-- `scorecard.md` — dated full-suite pass rates, trust conditions, and ablation status
+`runner.py` invokes `claude -p`. `test_runner.py` tests the deterministic
+parser, isolation, allowlist, and fixture machinery without calling a model.
 
 ## Run
 
-Needs `claude` CLI **and** `git` on PATH. Auth uses your Claude Code login (no API key, no per-token cost).
+Model-backed runs require authenticated `claude` and `git` executables:
 
 ```bash
-./evals/runner.py                                # all suites
-./evals/runner.py --suite critic                 # one suite
-./evals/runner.py --suite workflow               # planner/executor/product skills
-./evals/runner.py --case c-001-slop-rethink      # one case
-./evals/runner.py --model sonnet                 # default: opus
-./evals/runner.py --keep-fixtures                # don't delete tmp git repos (debug)
-./evals/runner.py --verbose-failures             # show bounded model output on failure
-bash evals/run-verified.sh --model sonnet        # deterministic gates, then all suites
+./evals/runner.py
+./evals/runner.py --suite critic
+./evals/runner.py --suite workflow
+./evals/runner.py --case c-001-slop-rethink
+./evals/runner.py --model sonnet
+./evals/runner.py --keep-fixtures
+./evals/runner.py --verbose-failures
 ```
 
-Each case takes ~30–60s (Opus). Auditor cases are slightly slower because the
-subagent actually runs `git diff`, `git log`, etc. on a real fixture repo.
+Run deterministic repository gates before every model-backed suite:
 
-## Auditor: real-git fixtures + live mmcg
+```bash
+bash evals/run-verified.sh --model sonnet
+```
 
-Auditor cases reference a fixture tree under `evals/fixtures/<name>/` rather than
-embedding a synthetic diff string. For each case the runner:
+Model-backed evals are hand-run, not ordinary CI. CI runs the deterministic
+harness contract through:
 
-1. Builds a tmp git repo
-2. Copies `fixtures/<name>/baseline/` → commits → tags `<baseline_ref>`
-3. Replaces the working tree with `fixtures/<name>/changes/<after_ref>/` → commits → tags `<after_ref>`
-4. Runs `mmcg index .` against the after-tree, leaving `.mastermind/mmcg.db` in the tmp repo
-5. Passes `--add-dir <tmp>` + `--mcp-config` (mmcg stdio server pointing at the index) to `claude -p`
-6. The auditor runs **real** `git diff <baseline>..<after>` AND calls live `mmcg_callers` / `mmcg_search` MCP tools against the after-tree index to compare against the spec's pre-edit snapshot
+```bash
+.venv/bin/python -m unittest evals/test_runner.py
+```
 
-This catches failure modes synthetic diffs miss: lazy auditors that trust the
-report, multi-file scope creep visible only in `git diff --name-only`, silent
-file deletions, snapshot drift where the symbol's caller count changed and the
-spec didn't acknowledge it.
+## Auditor fixture lifecycle
 
-The mmcg binary used is the in-tree `mcp/servers/mmcg/target/release/mmcg`
-when available (matches the SQL schema of the SDK in this checkout), falling
-back to whatever `mmcg` is on `$PATH`. Build it first with
-`cargo build --release --manifest-path mcp/servers/mmcg/Cargo.toml`.
+Each auditor case names `fixtures/<name>/`, a baseline tag, and an after tag.
+The runner:
 
-## Adding a case
+1. creates a temporary Git repository;
+2. commits the fixture baseline and tags it;
+3. replaces the tree with the named after-state, commits, and tags it;
+4. indexes the after-state with `mmcg`;
+5. gives the auditor the temporary repository and a live stdio MCP server;
+6. checks the structured audit verdict and required reasoning signals.
 
-### Critic case (no fixture)
+The auditor reads the real Git diff and codegraph. The JSONL case does not
+provide a synthetic diff. The runner prefers the in-tree release binary at
+`mcp/servers/mmcg/target/release/mmcg`, then falls back to `mmcg` on `PATH`.
+
+Build the matching binary before a model-backed auditor run:
+
+```bash
+cargo build --release --manifest-path mcp/servers/mmcg/Cargo.toml --locked
+```
+
+## Add a critic case
 
 ```jsonc
 {
   "id": "c-NNN-short-name",
-  "why": "what this catches — regression scenario or golden input",
-  "input": { /* domain-specific */ },
+  "why": "single regression scenario",
+  "input": {},
   "expect": {
-    "verdict": "rethink",           // prose regex match, case-insensitive word boundary
-    "contains": ["fabricated"],     // case-insensitive, all must be present
-    "not_contains": ["ship it"]     // none may be present
+    "verdict": "rethink",
+    "contains": ["required phrase"],
+    "not_contains": ["forbidden phrase"]
   }
 }
 ```
 
-### Auditor case (real git fixture)
-
-Verdict is checked against the **structured YAML tail** the auditor emits inside
-`<!-- mastermind:audit-begin --> … <!-- mastermind:audit-end -->` sentinels — not prose.
-If the auditor doesn't produce that block the case fails.
+## Add an auditor case
 
 ```jsonc
 {
   "id": "a-NNN-short-name",
-  "why": "what this catches",
-  "fixture": "fake-session",        // dir under evals/fixtures/
-  "baseline_ref": "baseline",       // tag name for the pre-edit commit
-  "after_ref": "scope-creep",       // tag name for the executor commit; also the changes/ subdir
-  "allow_no_mmcg": false,           // optional; default false — hard-fail if mmcg index missing
+  "why": "single planted defect",
+  "fixture": "fake-session",
+  "baseline_ref": "baseline",
+  "after_ref": "scope-creep",
+  "allow_no_mmcg": false,
   "input": {
     "spec_summary": "...",
-    "executor_report": "..."        // NO git_diff — auditor runs it itself
+    "executor_report": "..."
   },
   "expect": {
-    "verdict": ["drift", "broken"], // matched against structured verdict field, string OR list
-    "contains": ["config", "scope"],// secondary: prose phrases in reasoning
+    "verdict": ["drift", "broken"],
+    "contains": ["config", "scope"],
     "not_contains": ["contract held"]
   }
 }
 ```
 
-To add a new fixture variant: create `evals/fixtures/<name>/changes/<after_ref>/` with
-the full file tree at the after-commit. The runner overlays it on baseline (deletions
-work — files missing from the variant get removed in the second commit).
+Verdict assertions read the YAML block between
+`<!-- mastermind:audit-begin -->` and `<!-- mastermind:audit-end -->`. Missing
+or malformed structured output fails the case. Add a full after-tree under
+`fixtures/<name>/changes/<after_ref>/`; files absent from that tree are deleted
+in the generated commit.
 
-Rules:
-- **Adversarial** (something to catch) or **golden** (something to confirm passes) — nothing else
-- One scenario per case
-- Phrase-match assertions only — the runner doesn't use LLM-as-judge
-
-### Workflow case
-
-Workflow cases load the named repository artifact as the system prompt. This
-keeps the eval tied to the shipped skill or subagent instead of a copied prompt.
-The artifact set is exact and allowlisted. Workflow cases run from the system
-temporary directory in Claude safe mode with an empty tool set, so a changed
-prompt is evaluated as text and cannot operate on the maintainer's checkout.
+## Add a workflow case
 
 ```jsonc
 {
   "id": "w-NNN-short-name",
   "artifact": "skills/workflow/example/SKILL.md",
-  "input": {"prompt": "A self-contained scenario"},
+  "input": {"prompt": "self-contained scenario"},
   "expect": {
     "contains": ["required signal"],
-    "contains_any": [["equivalent phrase A", "equivalent phrase B"]],
+    "contains_any": [["equivalent A", "equivalent B"]],
     "not_contains": ["forbidden claim"],
     "code_comments": {"prefixes": ["//", "/*"], "min": 0, "max": 0}
   }
 }
 ```
 
-`code_comments` is optional. It counts comment markers outside quoted strings
-in fenced code blocks and can also require phrases in retained comments. Use it
-when the behavior under test is generated code, not merely advice about code.
+Workflow artifacts are allowlisted and loaded from the repository. Cases run
+from the system temporary directory in Claude safe mode with no tools, so the
+prompt under evaluation cannot operate on the maintainer checkout.
 
-## Intake suite
+## Case rules
 
-5 cases covering the refiner's core behaviors:
-
-| case | scenario | expected action |
-|---|---|---|
-| i-001 | vague client message with buried goal | `refined` — planner-ready prompt + NEEDS placeholders |
-| i-002 | already tight request with verb/deliverable/scope | `passthrough` — returned unchanged |
-| i-003 | genuinely ambiguous goal (multiple valid interpretations) | `ask` — 1-3 clarifying questions, no prompt |
-| i-004 | overbroad multi-intent bundle | `refined` — primary intent isolated, others marked out-of-scope |
-| i-005 | production database migration with risk signals | `refined` — strict mode, risk: high, rollback flagged as NEEDS |
-
-Each case asserts on the structured `<!-- mastermind:intake-begin --> ... <!-- mastermind:intake-end -->` YAML block the refiner emits. If the block is absent the case fails.
+- One adversarial or golden behavior per case.
+- Explain the regression in `why`; do not leak the expected answer into source
+  fixture files.
+- Use deterministic verdict and phrase assertions. The harness does not use an
+  LLM judge.
+- Use `code_comments` only when generated code, rather than prose advice, is
+  under test.
+- Run the focused case before the full suite and record full-suite results in
+  `scorecard.md`.
 
 ## Ablation
 
-`ablation.py` measures the **marginal value** of the codegraph + auditor contract:
-does the Mastermind auditor catch defects a strong *vanilla* agent misses? For each
-planted-defect auditor fixture it runs two conditions on the same git repo, scored
-with the same phrase signal as the suite:
+`ablation.py` compares planted-defect detection under two conditions on the
+same generated Git repository:
 
-- **vanilla** — plain `claude -p` with shell access (git/grep/read) and a neutral
-  senior-reviewer prompt. No mmcg, no auditor system prompt — the honest "Claude +
-  grep/read" baseline, so the delta isolates the codegraph + contract, not a strawman.
-- **mastermind** — the real auditor path (auditor subagent + live mmcg). Re-run
-  head-to-head with `--with-mastermind`; otherwise it compares against the auditor
-  suite's own result.
+- `vanilla`: a neutral reviewer with shell access, but no mmcg or Mastermind
+  auditor contract;
+- `mastermind`: the shipped auditor with the live codegraph.
 
-Golden (`held`) cases are excluded — nothing to catch. Record results in
-`scorecard.md`; keep full-suite results separate from targeted reruns.
+Golden `held` cases are excluded because there is no defect to catch.
 
 ```bash
-python evals/ablation.py                   # vanilla over all defect cases
-python evals/ablation.py --with-mastermind # both conditions, head-to-head
+python evals/ablation.py
+python evals/ablation.py --with-mastermind
 ```
 
-## When to run
-
-- Before editing any evaluated subagent or workflow skill
-- After editing them, to confirm behaviors still fire
-- When adding a new adversarial pattern as a regression test
-- After adding a fixture variant (smoke `--keep-fixtures` to inspect tmp repo)
-
-Not on every PR. Not in CI. Hand-run by the maintainer.
-
-The runner's parsing, allowlist, and input-isolation contract is deterministic
-and does run in CI via `python -m unittest evals/test_runner.py`.
-
-## Why no LLM-judge
-
-A judge model adds another non-deterministic layer. We assert on:
-1. Verdict label (`rethink` / `held` / etc.)
-2. Key phrases present / absent in reasoning
-
-If a case passes phrase matching but the reasoning is subtly wrong, that's not caught — accepted limitation.
+The score is phrase-based. It can miss subtly incorrect reasoning that happens
+to contain the expected signals; record that limitation with every result.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,10 +1,16 @@
-# MCP
+# MCP servers
 
-[Model Context Protocol](https://modelcontextprotocol.io) server configs.
+Mastermind ships one [Model Context Protocol](https://modelcontextprotocol.io)
+server.
 
-## Index
-
-### servers/
-| Server | Transport | Description |
+| Server | Transport | Surface |
 |---|---|---|
-| [`mmcg`](servers/mmcg/README.md) | stdio | Mastermind Codegraph — 27 MCP tools: 26 read-only structural/semantic/evidence tools plus one additive local scratchpad write, over a local SQLite index. Supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Truth layer for the Mastermind workflow. |
+| [`mmcg`](servers/mmcg/README.md) | stdio | 28 bounded tools over a local SQLite index: 27 read-only queries and one additive scratchpad write |
+
+The server supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#,
+Go, Java, PHP, and C/C++. It exposes structural, semantic, evidence, history,
+and workflow-state queries; it does not expose arbitrary SQL or executable
+plugin hooks.
+
+Start with the [generic MCP guide](../docs/integrations/generic-mcp.md) or the
+[complete technical reference](../docs/reference/mmcg.md#mcp-tools).

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -1,6 +1,6 @@
 ---
 name: mmcg
-description: Mastermind Codegraph — fast multi-language code indexer (Python + TypeScript/TSX + JavaScript/JSX + Vue SFC + Rust + C# + Go + Java + PHP + C/C++) exposed over MCP. Indexes symbols, calls, imports, and durable project history into a local SQLite database and exposes 25 bounded tools for AI coding agents.
+description: Mastermind Codegraph — local multi-language code indexer for Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Stores symbols, calls, imports, evidence, and project history in SQLite and exposes 28 bounded MCP tools.
 metadata:
   version: 2.0.0
   authors:
@@ -24,7 +24,10 @@ metadata:
 
 # mmcg — Mastermind Codegraph
 
-mmcg is the local structural engine inside [Mastermind](https://github.com/xcrft/mastermind). It indexes symbols, calls, and imports from a repository into SQLite, then exposes the graph through a CLI and MCP server.
+mmcg is the local structural engine inside
+[Mastermind](https://github.com/xcrft/mastermind). It indexes symbols, calls,
+imports, and evidence into SQLite, then exposes the same state through CLI,
+Lens, and MCP.
 
 Use it to answer questions such as:
 
@@ -34,7 +37,8 @@ Use it to answer questions such as:
 - What can the current worktree change affect?
 - Which tests are structurally connected to that change?
 
-The npm package exposes this binary as both `mastermind` and `mmcg`. Cargo installation uses the `mmcg` command.
+The npm package exposes this binary as both `mastermind` and `mmcg`. Cargo
+installation uses `mmcg`.
 
 ## Install
 
@@ -104,7 +108,7 @@ See the [client integration guides](https://github.com/xcrft/mastermind/tree/mai
 | Workflow gates | `verify-spec`, `audit-spec`, and `run-task` |
 | Local coordination | Bounded additive scratchpad and indexed project history |
 
-The MCP surface contains 26 read-only tools and one additive local scratchpad
+The MCP surface contains 27 read-only tools and one additive local scratchpad
 write. Results are bounded and return precision or truncation notes when the
 engine cannot prove completeness.
 
@@ -132,7 +136,9 @@ The default mmcg graph is syntactic, not a compiler or language server:
   detection, but included contents and compiler semantics are not expanded.
 - Dead-code and test-impact results are candidates to review, not deletion or test-skipping authorization.
 
-These trade-offs keep the index local, fast, portable, and easy for agents to query. The engine fails closed on stale index, root, Git snapshot, or work-limit conditions in change-impact workflows.
+This model keeps the default index local and independent of language
+toolchains. Change-impact workflows fail closed on stale index, root, Git
+snapshot, and work-limit conditions.
 
 `mmcg enrich --scip index.scip` is an optional second layer. It stores
 compiler-resolved facts separately, exposes them through `query semantic` and
@@ -170,11 +176,11 @@ cargo fmt --all -- --check
 cargo bench --bench indexer
 ```
 
-The index benchmark emits schema-v1 JSON for cold, warm, and 10%-incremental
-runs plus peak process RSS. Defaults are 1,000 synthetic Rust files with 20
-symbols each. Override them with `MMCG_BENCH_FILES`,
-`MMCG_BENCH_SYMBOLS_PER_FILE`, and `MMCG_BENCH_CHANGED_FILES`. Treat results as
-same-machine regression evidence, not a portable performance promise.
+The benchmark emits schema-v1 JSON for cold, warm, and 10%-incremental runs
+plus peak process RSS. See the
+[methodology and reference results](https://github.com/xcrft/mastermind/blob/main/docs/benchmarks.md).
+Treat results as same-machine regression evidence, not a portable performance
+promise.
 
 See [CONTRIBUTING.md](https://github.com/xcrft/mastermind/blob/main/CONTRIBUTING.md) for the repository-wide contribution guide.
 

--- a/npm/mastermind/README.md
+++ b/npm/mastermind/README.md
@@ -4,69 +4,116 @@
 [![CI](https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml/badge.svg)](https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/xcrft/mastermind/blob/main/LICENSE)
 
-**A local codegraph and verifiable workflow for AI coding agents.**
+Local codegraph and evidence-backed architecture review for AI coding agents.
 
-Mastermind gives Claude Code, Codex, Cursor, and Continue structural project
-maps, change and test impact, MCP code queries, and diff-backed implementation
-audits. Deterministic indexing and style mining stay local. Explicit
-agent-assisted modes disclose when they invoke the configured AI client with
-repository content or bounded samples.
+Mastermind indexes a repository into SQLite, connects a Git diff to affected
+callers, tests, components, policies, and external evidence, and exposes the
+same bounded snapshot through CLI, MCP, Lens, SARIF, and a standalone review
+package.
 
 ## Install
 
-Requires Node.js 24+. Prebuilt binaries are included for macOS, Linux, and
-Windows.
+Requires Node.js 24 or newer. The package selects a prebuilt native binary for
+macOS, Linux, or Windows; Rust is not required.
 
 ```bash
 npm install -g @xcraftmind/mastermind
+mastermind --version
 ```
 
-Connect your clients once:
+## First review
+
+```bash
+cd your-repository
+mastermind index .
+mastermind impact --since main
+mastermind ui --since main
+```
+
+`index` writes `.mastermind/mmcg.db`. The Lens server binds to loopback, reads
+the index without mutating it, and loads no remote frontend resources.
+
+Export a review that works without an installed binary:
+
+```bash
+mastermind review export --since main --out mastermind-review
+```
+
+The output contains standalone HTML, SARIF, a short Markdown summary, a
+revision/evidence manifest, and a pinned GitHub Actions workflow.
+
+## AI client setup
 
 ```bash
 mastermind install --client all
 mastermind setup cursor --scope user --write
 mastermind setup continue --scope user --write
+mastermind doctor --workflow --client all
 ```
 
-Global installation and client setup do not require a project or
-`mastermind init`.
+Setup commands preview by default and write only with `--write`. Mastermind
+supports Claude Code, Codex, Cursor, Continue, and generic MCP stdio clients.
+The MCP server exposes 28 bounded tools: 27 read-only queries and one additive
+write to the local gitignored scratchpad.
 
-## Use it in a repository
+## Capabilities
 
-```bash
-cd your-project
-mastermind index .
-mastermind map .
-mastermind impact --since main
-mastermind temporal --since main
-mastermind ui --since main
-mastermind miner profile .  # optional personal profile; no init required
-```
-
-Run `mastermind init` only when you want the complete spec-driven workflow.
-Small changes can use the codegraph directly without creating a task spec.
-
-## What it provides
-
-- Architecture maps plus runtime, state, retry, and compatibility reviews
-- Symbol search, callers, imports, cycles, and API surface
-- Changed symbols, affected callers, component crossings, and candidate tests
-- Base-vs-head component, boundary, cycle, centrality, ownership, and API drift
-- A local, read-only diff-first Lens UI backed by the same map and impact engine
-- Direct, verified, and strict task workflows based on change risk
-- Executor reports checked against the real Git diff and codegraph
-- SHA-256 and Ed25519 audit evidence with a pinned GitHub Action
-- An optional user-global style portrait used only as advisory planner/executor input
+- component maps, entry points, hotspots, centrality, and dependency cycles;
+- Git-aware changed symbols, blast radius, API drift, and candidate tests;
+- base-versus-head architecture, ownership, cycle, and hotspot drift;
+- architecture policy checks with text, JSON, or SARIF output;
+- SARIF, LCOV/Cobertura, JUnit, OpenTelemetry, CODEOWNERS, churn, and project
+  decision overlays;
+- optional compiler-resolved SCIP definitions and references;
+- revision-bound declarative facts with optional Ed25519 provenance;
+- bounded, pinned maps across several local repositories;
+- Direct, Verified, and Strict spec-driven workflow modes.
 
 Supported languages: Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust,
 C#, Go, Java, PHP, and C/C++.
 
+Supported binaries: macOS arm64/x64; Linux glibc and musl arm64/x64; Windows
+x64.
+
+## Evidence model
+
+The default Tree-sitter graph is syntactic and toolchain-free. Optional SCIP
+facts are compiler-resolved; imported runtime relationships are observed;
+team-manifest relationships are declared. Mastermind keeps that provenance
+visible and does not turn external evidence into unproven graph topology.
+
+Dynamic dispatch, reflection, generated code, dependency injection, re-exports,
+overloads, and cross-language calls may be incomplete. Candidate tests and
+unreferenced symbols are review inputs, not permission to skip tests or delete
+code. Stale indexes, collisions, work limits, and truncation are explicit.
+
+Deterministic indexing, MCP, Lens, policy checks, fact ingestion, and review
+export are local. Explicit agent-assisted initialization and deep style mining
+can send repository content through the configured AI client.
+
+## Performance
+
+On the published synthetic Rust benchmark, an Apple M3 Pro indexed 1,000 files
+and 20,000 functions in a 310 ms median cold run; an unchanged scan took 41 ms.
+A 10,000-file, 200,000-function corpus took 3.20 s cold and 353 ms unchanged.
+
+These are release-mode medians on one machine, not portable guarantees or
+competitor comparisons. See the
+[full methodology, ranges, and reproduction command](https://github.com/xcrft/mastermind/blob/main/docs/benchmarks.md).
+
 ## Documentation
 
-[Getting started](https://github.com/xcrft/mastermind/blob/main/docs/getting-started.md) ·
-[Client setup](https://github.com/xcrft/mastermind/tree/main/docs/integrations) ·
-[Workflow](https://github.com/xcrft/mastermind/blob/main/docs/workflow.md) ·
-[Technical reference](https://github.com/xcrft/mastermind/blob/main/docs/reference/mmcg.md)
+- [Getting started](https://github.com/xcrft/mastermind/blob/main/docs/getting-started.md)
+- [Client integrations](https://github.com/xcrft/mastermind/tree/main/docs/integrations)
+- [CLI and MCP reference](https://github.com/xcrft/mastermind/blob/main/docs/reference/mmcg.md)
+- [Workflow](https://github.com/xcrft/mastermind/blob/main/docs/workflow.md)
+- [Fact-ingestion SDK](https://github.com/xcrft/mastermind/blob/main/docs/fact-ingestion-sdk.md)
+- [Benchmarks](https://github.com/xcrft/mastermind/blob/main/docs/benchmarks.md)
 
-MIT — [source and license](https://github.com/xcrft/mastermind)
+The same binary is available from crates.io as
+[`mmcg`](https://crates.io/crates/mmcg). npm installs it as both `mastermind`
+and `mmcg`.
+
+## License
+
+MIT — [source and license](https://github.com/xcrft/mastermind).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,19 @@
 # Scripts
 
-Repo-level scripts, each documented at the top of its source.
+Repository validation, packaging, release, and smoke-test scripts. Run scripts
+from the repository root unless a section says otherwise.
+
+## Common entry points
+
+| Goal | Command |
+|---|---|
+| Full deterministic gate | `just check` |
+| Repository contracts only | `just validate` |
+| Native npm tarball smoke | `just npm-smoke-native` |
+| Index benchmark | `just benchmark-index` |
+
+The `just` recipes are the canonical developer interface. Call an individual
+script directly when diagnosing that script.
 
 ## `validate.py` — repository contract validator
 
@@ -19,7 +32,7 @@ npm, or model-backed test suites. CI executes it on every change.
 - npm package/version/platform shape, README badge alignment, and workflow-bundle staging parity;
 - answer-leak clues in adversarial eval fixture source trees.
 
-### Run locally
+### Run directly
 
 ```bash
 # One-time setup
@@ -30,7 +43,8 @@ python3 -m venv .venv
 .venv/bin/python scripts/validate.py
 ```
 
-Exit code is `0` on clean, `1` if any errors. Warnings don't fail the run.
+Exit code is `0` on clean and `1` when errors exist. Warnings do not fail the
+run.
 
 ### Boundaries
 
@@ -100,5 +114,5 @@ registries, not the workspace build:
   and `review` command surfaces.
 
 Both scripts retry registry propagation for a bounded period and fail the
-release workflow if the published version cannot be installed or exercised.
-They are release gates only: local validation never publishes a package.
+release workflow if the public version cannot be installed or exercised. They
+are release gates only; local validation never publishes a package.

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -447,14 +447,17 @@ MMCG_MCP_SRC = "mcp/servers/mmcg/src/mcp.rs"
 # but mmcg_xxx names are sufficiently distinctive.)
 MMCG_TOOL_LIST_DOCS: list[str] = [
     "docs/reference/mmcg.md",
+    "docs/integrations/generic-mcp.md",
 ]
 
 # Files that quote a tool *count* like "16 structural query tools" / "15 tools".
 # We extract counts and assert they all match the count derived from mcp.rs.
 MMCG_TOOL_COUNT_DOCS: list[str] = [
     "docs/reference/mmcg.md",
+    "docs/integrations/generic-mcp.md",
     "mcp/README.md",
     "mcp/servers/mmcg/README.md",
+    "npm/mastermind/README.md",
     "README.md",
 ]
 
@@ -1460,6 +1463,15 @@ def validate_portable_skill_semantics() -> list[Issue]:
         slug = skill_path.parent.name
         if f"[`{slug}`]" not in readme:
             issues.append(Issue(readme_path, "error", f"installed skill is missing from index: {slug}"))
+
+    agent_readme_path = REPO_ROOT / "agents/README.md"
+    agent_readme = agent_readme_path.read_text(encoding="utf-8")
+    for agent_path in sorted((REPO_ROOT / "agents/subagents").glob("*.md")):
+        slug = agent_path.stem
+        if f"[`{slug}`]" not in agent_readme:
+            issues.append(
+                Issue(agent_readme_path, "error", f"installed agent is missing from index: {slug}")
+            )
     return issues
 
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,11 +1,13 @@
 # Skills
 
-Skills used by the Mastermind workflow. Every skill in this tree is included in
-the installable workflow bundle.
+Portable workflow capabilities installed by Mastermind. Every `SKILL.md` in
+this tree is staged into the npm workflow bundle; `scripts/validate.py` fails if
+this index or the staged copy drifts.
 
-## Index
+Skills define task behavior. Claude Code-specific spawnable roles live under
+[`agents/`](../agents/).
 
-### workflow/
+## Workflow
 | Skill | Description |
 |---|---|
 | [`mastermind-task-planning`](workflow/mastermind-task-planning/SKILL.md) | Chooses Direct, Verified, or Strict and creates the lightest evidence-grounded delegation contract that fits the risk. |
@@ -25,40 +27,40 @@ the installable workflow bundle.
 | [`mastermind-audit-attestation`](workflow/mastermind-audit-attestation/SKILL.md) | Separates content integrity, signer provenance, and policy acceptance for audit evidence. |
 | [`mastermind-style-deep`](workflow/mastermind-style-deep/SKILL.md) | Adds a grounded qualitative coding portrait consumed as advisory planner/executor input. |
 
-### coding/
+## Coding
 | Skill | Description |
 |---|---|
 | [`no-ai-slop-comments`](coding/no-ai-slop-comments/SKILL.md) | Keeps useful comments and removes narration introduced by the current change without widening scope. |
 
-### code-review/
+## Code review
 | Skill | Description |
 |---|---|
 | [`mastermind-comment-audit`](code-review/mastermind-comment-audit/SKILL.md) | Reviews the comment delta of a finished change with quoted evidence, names what it kept, and reports deleted rationale. |
 | [`mastermind-test-audit`](code-review/mastermind-test-audit/SKILL.md) | Checks whether a change's tests prove its behaviour: uncovered symbols, a test on the wrong path, an assertion moved with the code, and non-asserting tests. |
 | [`mastermind-frontend-audit`](code-review/mastermind-frontend-audit/SKILL.md) | Checks a finished UI change against the codegraph: unrendered components, props contracts changed without their callers, duplicates, and raw values shadowing tokens. |
 
-### design/
+## Design
 | Skill | Description |
 |---|---|
 | [`mastermind-design-intake`](design/mastermind-design-intake/SKILL.md) | Converts a design handoff into named components, token names, and criteria that can fail, parking visual fidelity explicitly. |
 
-### testing/
+## Testing
 | Skill | Description |
 |---|---|
 | [`mastermind-browser-verification`](testing/mastermind-browser-verification/SKILL.md) | Records browser checks as evidence — accessibility tree over screenshot, console and network errors, viewports as a checklist, unchecked marked unchecked. |
 
-### debugging/
+## Debugging
 | Skill | Description |
 |---|---|
 | [`mastermind-investigation-ledger`](debugging/mastermind-investigation-ledger/SKILL.md) | Diagnoses unknown bugs with competing hypotheses, evidence for/against, and bounded decision-changing probes. |
 
-### security/
+## Security
 | Skill | Description |
 |---|---|
 | [`mastermind-security-research`](security/mastermind-security-research/SKILL.md) | Enumerates reachable privileged operations, the sites that statically apply a guard, and secret readers — reporting the difference as unestablished rather than as a verdict. |
 | [`mastermind-agent-security-review`](security/mastermind-agent-security-review/SKILL.md) | Portable security review protocol for agent/tool trust boundaries, with optional evidence-based OWASP mapping. |
 
-### prompt-engineering/
+## Prompt engineering
 | Skill | Description |
 |---|---|
 | [`mastermind-prompt-refiner`](prompt-engineering/mastermind-prompt-refiner/SKILL.md) | Rewrites explicit prompts or cold-agent handoffs while preserving the original request verbatim. |


### PR DESCRIPTION
## Summary

- rewrites the main README around the product contract, quick start, evidence model, Lens, policy, SCIP, temporal analysis, and review export
- adds a concise documentation index and reproducible local benchmark methodology with recorded 1k-file and 10k-file results
- aligns setup, integrations, MCP reference, security, contributing, workflow, agent, skill, eval, and package documentation with the current 2.0 CLI
- compares Mastermind with Graphify, Joern, CodeQL, and Glean by architecture and operating model without unsupported performance claims
- extends documentation validation so published MCP tool counts and agent catalogs cannot silently drift

## Proof

- just check
- Markdown anchor scan: 74 files, 0 broken fragments
- documented CLI parse smoke
- npm pack --dry-run --json: package 2.0.0, 79 entries
- cargo package file-list verification
- git diff --check

## Benchmark snapshot

Apple M3 Pro, 12 cores, 36 GB RAM, macOS 26.5.2, Rust 1.97.1, release build at base commit 2ee0807:

| Corpus | Cold index | Warm no-op | 10% changed | Peak RSS |
| --- | ---: | ---: | ---: | ---: |
| 1k files / 20k functions | 310 ms | 41 ms | 81 ms | ~19 MiB |
| 10k files / 200k functions | 3.20 s | 353 ms | 867 ms | ~80 MiB |

No release or package publication is performed by this PR.