### PR TITLE
chore(release): prepare 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-08-13
+
+### Fixed
+- `mastermind impact --since <ref>` no longer returns `git_output_limit` when
+  large diffs include non-indexable assets. Baseline source blobs are selected
+  through the shared language registry, size-preflighted, and fetched in
+  bounded batches with an explicit aggregate ceiling.
+
 ## [2.0.0] - 2026-08-13
 
 ### Upgrade notes
@@ -647,7 +655,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Seven prebuilt platform packages (`@xcraftmind/mmcg-*`) covering macOS (arm64, x64), Linux glibc and musl (x64, arm64), and Windows (x64). npm installs only the package matching the host's `os` / `cpu` / `libc`.
 - Install-mode-aware `setup claude` that writes the correct MCP `command` form for npx, global, project-local, and cargo installs.
 
-[Unreleased]: https://github.com/xcrft/mastermind/compare/npm-v2.0.0...HEAD
+[Unreleased]: https://github.com/xcrft/mastermind/compare/npm-v2.0.1...HEAD
+[2.0.1]: https://github.com/xcrft/mastermind/compare/npm-v2.0.0...npm-v2.0.1
 [2.0.0]: https://github.com/xcrft/mastermind/compare/npm-v1.2.1...npm-v2.0.0
 [1.2.1]: https://github.com/xcrft/mastermind/compare/npm-v1.2.0...npm-v1.2.1
 [1.2.0]: https://github.com/xcrft/mastermind/compare/npm-v1.1.1...npm-v1.2.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@xcraftmind/mastermind"><img src="https://img.shields.io/badge/npm-v2.0.0-CB3837?logo=npm" alt="npm version 2.0.0"></a>
+  <a href="https://www.npmjs.com/package/@xcraftmind/mastermind"><img src="https://img.shields.io/badge/npm-v2.0.1-CB3837?logo=npm" alt="npm version 2.0.1"></a>
   <a href="https://crates.io/crates/mmcg"><img src="https://img.shields.io/crates/v/mmcg.svg" alt="crates.io version"></a>
   <a href="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml"><img src="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml/badge.svg" alt="CI status"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT license"></a>

--- a/agents/claude-md/mastermind-workflow.md
+++ b/agents/claude-md/mastermind-workflow.md
@@ -2,7 +2,7 @@
 name: mastermind-workflow
 description: Compact project router for the Mastermind Direct, Verified, and Strict workflows.
 metadata:
-  version: 2.0.0
+  version: 2.0.1
   authors: [mastermind]
   tags: [claude-md, workflow, delegation, audit]
 ---

--- a/docs/examples/mastermind-review-pr.yml
+++ b/docs/examples/mastermind-review-pr.yml
@@ -40,7 +40,7 @@ jobs:
             install -m 0755 mcp/servers/mmcg/target/release/mmcg "$RUNNER_TEMP/mastermind-bin/mastermind"
             echo "MASTERMIND_BIN=$RUNNER_TEMP/mastermind-bin/mastermind" >> "$GITHUB_ENV"
           else
-            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@2.0.0
+            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@2.0.1
             echo "MASTERMIND_BIN=mastermind" >> "$GITHUB_ENV"
           fi
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ npx mastermind --version
 Cargo installation exposes the same binary as `mmcg`:
 
 ```bash
-cargo install mmcg --version 2.0.0 --locked
+cargo install mmcg --version 2.0.1 --locked
 mmcg --version
 ```
 

--- a/mcp/servers/mmcg/Cargo.lock
+++ b/mcp/servers/mmcg/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "mmcg"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/mcp/servers/mmcg/Cargo.toml
+++ b/mcp/servers/mmcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmcg"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.96"
 build = "build.rs"

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -2,7 +2,7 @@
 name: mmcg
 description: Mastermind Codegraph — local multi-language code indexer for Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Stores symbols, calls, imports, evidence, and project history in SQLite and exposes 28 bounded MCP tools.
 metadata:
-  version: 2.0.0
+  version: 2.0.1
   authors:
     - mastermind
   tags:

--- a/mcp/servers/mmcg/assets/mastermind-review-pr.yml
+++ b/mcp/servers/mmcg/assets/mastermind-review-pr.yml
@@ -40,7 +40,7 @@ jobs:
             install -m 0755 mcp/servers/mmcg/target/release/mmcg "$RUNNER_TEMP/mastermind-bin/mastermind"
             echo "MASTERMIND_BIN=$RUNNER_TEMP/mastermind-bin/mastermind" >> "$GITHUB_ENV"
           else
-            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@2.0.0
+            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@2.0.1
             echo "MASTERMIND_BIN=mastermind" >> "$GITHUB_ENV"
           fi
 

--- a/mcp/servers/mmcg/templates/workflow.md
+++ b/mcp/servers/mmcg/templates/workflow.md
@@ -2,7 +2,7 @@
 name: mastermind-workflow
 description: Compact project router for the Mastermind Direct, Verified, and Strict workflows.
 metadata:
-  version: 2.0.0
+  version: 2.0.1
   authors: [mastermind]
   tags: [claude-md, workflow, delegation, audit]
 ---

--- a/npm/mastermind/README.md
+++ b/npm/mastermind/README.md
@@ -1,6 +1,6 @@
 # @xcraftmind/mastermind
 
-[![npm](https://img.shields.io/badge/npm-v2.0.0-CB3837?logo=npm)](https://www.npmjs.com/package/@xcraftmind/mastermind)
+[![npm](https://img.shields.io/badge/npm-v2.0.1-CB3837?logo=npm)](https://www.npmjs.com/package/@xcraftmind/mastermind)
 [![CI](https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml/badge.svg)](https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/xcrft/mastermind/blob/main/LICENSE)
 

--- a/npm/mastermind/package.json
+++ b/npm/mastermind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mastermind",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Local codegraph and verifiable workflow for AI coding agents — project maps, change and test impact, MCP queries, Vue SFC indexing, and diff-backed implementation audits. Prebuilt binaries for macOS, Linux, and Windows.",
   "license": "MIT",
   "author": "xcraftmind",
@@ -42,12 +42,12 @@
     "mastermind"
   ],
   "optionalDependencies": {
-    "@xcraftmind/mmcg-darwin-arm64": "2.0.0",
-    "@xcraftmind/mmcg-darwin-x64": "2.0.0",
-    "@xcraftmind/mmcg-linux-x64-gnu": "2.0.0",
-    "@xcraftmind/mmcg-linux-arm64-gnu": "2.0.0",
-    "@xcraftmind/mmcg-linux-x64-musl": "2.0.0",
-    "@xcraftmind/mmcg-linux-arm64-musl": "2.0.0",
-    "@xcraftmind/mmcg-win32-x64-msvc": "2.0.0"
+    "@xcraftmind/mmcg-darwin-arm64": "2.0.1",
+    "@xcraftmind/mmcg-darwin-x64": "2.0.1",
+    "@xcraftmind/mmcg-linux-x64-gnu": "2.0.1",
+    "@xcraftmind/mmcg-linux-arm64-gnu": "2.0.1",
+    "@xcraftmind/mmcg-linux-x64-musl": "2.0.1",
+    "@xcraftmind/mmcg-linux-arm64-musl": "2.0.1",
+    "@xcraftmind/mmcg-win32-x64-msvc": "2.0.1"
   }
 }

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-darwin-arm64",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Prebuilt mmcg binary for macOS arm64 (Apple Silicon). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/darwin-x64/package.json
+++ b/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-darwin-x64",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Prebuilt mmcg binary for macOS x86_64 (Intel). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-arm64-gnu/package.json
+++ b/npm/platforms/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-arm64-gnu",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Prebuilt mmcg binary for Linux arm64 glibc. Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-arm64-musl/package.json
+++ b/npm/platforms/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-arm64-musl",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Prebuilt mmcg binary for Linux arm64 musl (Alpine, distroless). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-x64-gnu/package.json
+++ b/npm/platforms/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-x64-gnu",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Prebuilt mmcg binary for Linux x86_64 glibc. Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-x64-musl/package.json
+++ b/npm/platforms/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-x64-musl",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Prebuilt mmcg binary for Linux x86_64 musl (Alpine, distroless). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/win32-x64-msvc/package.json
+++ b/npm/platforms/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-win32-x64-msvc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Prebuilt mmcg binary for Windows x86_64 (MSVC). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",


### PR DESCRIPTION
## Summary

- bump the Rust crate, root npm package, and all seven platform packages to 2.0.1
- update public install examples, badges, and workflow metadata
- document the large-diff `git_output_limit` fix shipped from #67

## Proof

- `just check`
- `cargo package --manifest-path mcp/servers/mmcg/Cargo.toml --locked --allow-dirty`
- `just npm-smoke-native`
- release consistency: Cargo, root npm, optional dependencies, and seven platform manifests all resolve to 2.0.1

## Release plan

After this PR is reviewed, green, and merged, tag the merge commit with `mmcg-v2.0.1` and `npm-v2.0.1`. The tag workflows verify exact artifacts, publish, then install the public registry versions in isolated smoke jobs. No release has been published by this PR.