### PR TITLE
docs: sharpen product story and navigation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,10 +1,12 @@
 # Code of Conduct
 
-This project follows the
+Strong technical disagreement is welcome. Personal attacks are not.
+
+Mastermind follows the
 [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
 The full linked text is the governing policy.
 
-## Expected conduct
+## The standard
 
 - Critique code and ideas, not people.
 - Keep technical disagreements specific and evidence-based.
@@ -12,9 +14,9 @@ The full linked text is the governing policy.
   information.
 - Respect a maintainer's decision to close or moderate a discussion.
 
-## Report a violation
+## Report something safely
 
-Do not put sensitive details in a public issue. Contact the repository owner
+Keep sensitive details out of public issues. Contact the repository owner
 through the [xcrft GitHub profile](https://github.com/xcrft) and request a
 private reporting channel. Include links or screenshots, dates, participants,
 and the behavior that violated the policy. Reports are shared only with the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Contributing
 
-Mastermind combines a Rust codegraph engine with installable workflow artifacts.
-Keep changes focused, preserve local-first behavior, and attach the exact checks
-you ran.
+Ship one focused change, make its evidence easy to replay, and leave unrelated
+local state alone. Mastermind combines a Rust codegraph engine, a browser review
+surface, and installable workflow contracts, so a small edit can cross more
+than one distribution boundary.
 
 ## Repository layout
 
@@ -13,7 +14,7 @@ you ran.
 | `skills/`, `agents/` | Installed workflow and agent contracts |
 | `schemas/` | Public, versioned JSON contracts |
 | `npm/` | npm wrapper and platform packages |
-| `action.yml`, `Dockerfile` | GitHub Action runtime |
+| `action.yml`, `Dockerfile.audit-action` | GitHub Action runtime |
 | `docs/` | User and maintainer documentation |
 | `scripts/` | Validation, packaging, release, and smoke-test tooling |
 | `evals/` | Deterministic harness tests and optional model-backed evaluations |
@@ -33,7 +34,7 @@ python3 -m venv .venv
 .venv/bin/pip install --require-hashes -r scripts/requirements.txt
 ```
 
-## Canonical check
+## The ship gate
 
 Run this before opening a pull request:
 
@@ -41,10 +42,10 @@ Run this before opening a pull request:
 just check
 ```
 
-It runs the locked Rust tests, formatting and Clippy checks, npm tests, Lens
-tests, workflow-security tests, deterministic eval-harness tests, repository
-validation, and `cargo deny` policy checks. A passing subset is useful while
-developing but does not replace this gate.
+`just check` runs the locked Rust tests, formatting and Clippy checks, npm
+tests, Lens tests, workflow-security tests, deterministic eval-harness tests,
+repository validation, and `cargo deny` policy checks. A passing subset is
+useful while developing but does not replace this gate.
 
 ## Focused checks
 
@@ -72,14 +73,17 @@ See [evals/README.md](evals/README.md) for suites and limitations.
 
 ## Documentation changes
 
-- Put task-oriented guides in `docs/`; keep the root README as a short product
-  and onboarding page.
+- Lead with the outcome, then give the shortest copyable path to it.
+- Put task-oriented guides in `docs/`; keep the root README as the product and
+  onboarding page.
 - Put exhaustive CLI and MCP details in
   [docs/reference/mmcg.md](docs/reference/mmcg.md).
 - Use commands that run from the repository root unless a section says
   otherwise.
 - Label syntactic, compiler-resolved, declared, and observed evidence
   separately.
+- Delete filler and narration. Keep rationale, trust boundaries, failure modes,
+  and the facts a reader cannot recover from the command itself.
 - Do not publish speed or accuracy comparisons without a reproducible corpus,
   command, environment, and correctness boundary.
 - Run `.venv/bin/python scripts/validate.py`; it checks internal links, mirrors,

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 <h1 align="center">Mastermind</h1>
 
 <p align="center">
-  <strong>Know what your code change can break before production tells you.</strong>
+  <strong>Review the blast radius, not just the patch.</strong>
 </p>
 
 <p align="center">
   A local, diff-first codegraph for architecture review.<br>
-  Trace a change through callers, components, tests, policies, and evidence without uploading your repository.
+  See what changed, what it reaches, and which evidence supports the review—without uploading your repository.
 </p>
 
 <p align="center">
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <a href="#quick-start">Quick start</a> ·
+  <a href="#quick-start">5-minute start</a> ·
   <a href="#the-review-surface-your-diff-is-missing">Product tour</a> ·
   <a href="docs/getting-started.md">Documentation</a> ·
   <a href="docs/reference/mmcg.md#mcp-server-usage">MCP tools</a>
@@ -48,7 +48,7 @@ changed symbols  →  downstream reach  →  boundary crossings  →  candidate 
 
 Every claim keeps its source. If the index is stale, a query hits its limit, or
 evidence is incomplete, Mastermind says so instead of manufacturing a green
-check.
+check. You get a review another engineer can inspect, challenge, and replay.
 
 ## Quick start
 
@@ -66,7 +66,8 @@ mastermind ui --since main
 
 That is the whole first run. `index` creates a local SQLite graph at
 `.mastermind/mmcg.db`. `ui` opens Lens on loopback with embedded assets, no
-repository upload, and no CDN.
+repository upload, and no CDN. Start with `impact` in the terminal; open Lens
+when you want the complete review surface.
 
 <p align="center">
   <img src="docs/images/lens/mastermind-lens-live-desktop.png" alt="Mastermind Lens reviewing the current change with changed symbols, downstream impact, boundary crossings, test candidates, and explicit partial-evidence state" width="1000">
@@ -271,14 +272,18 @@ review export remain local.
 
 ## Documentation
 
-- [Start here](docs/getting-started.md)
-- [CLI and MCP reference](docs/reference/mmcg.md)
-- [Review workflow](docs/workflow.md)
-- [Client integrations](docs/integrations)
-- [Fact-ingestion SDK](docs/fact-ingestion-sdk.md)
-- [Verifiable GitHub Action](docs/github-action.md)
-- [Benchmarks](docs/benchmarks.md)
-- [Changelog](CHANGELOG.md)
+Pick the shortest path to the answer you need:
+
+| I want to… | Go here |
+|---|---|
+| See my first impact report | [Getting started](docs/getting-started.md) |
+| Look up a command, limit, schema, or MCP tool | [CLI and MCP reference](docs/reference/mmcg.md) |
+| Connect Claude Code, Codex, Cursor, Continue, or another client | [Client integrations](docs/integrations) |
+| Run Direct, Verified, or Strict delivery | [Review workflow](docs/workflow.md) |
+| Import external evidence safely | [Fact-ingestion SDK](docs/fact-ingestion-sdk.md) |
+| Publish verifiable audit evidence | [GitHub Action](docs/github-action.md) |
+| Reproduce performance numbers | [Benchmarks](docs/benchmarks.md) |
+| See what changed between releases | [Changelog](CHANGELOG.md) |
 
 ## Build and contribute
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,8 @@
 # Security policy
 
+Found a way to cross a documented trust boundary? Tell us privately so we can
+verify it without exposing users or working exploit details.
+
 ## Supported versions
 
 | Version | Security fixes |
@@ -7,9 +10,9 @@
 | 2.x | Supported |
 | 1.x and earlier | Upgrade required |
 
-## Report a vulnerability
+## Report privately
 
-Do not open a public issue. Use
+Do not open a public issue or discussion. Use
 [GitHub private vulnerability reporting](https://github.com/xcrft/mastermind/security/advisories/new).
 
 Include:

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,17 +1,17 @@
 # Agents
 
-Agent definitions are Claude Code-specific orchestration roles. Portable
-capabilities live under [`skills/`](../skills/); do not copy an agent file into
-another client and assume equivalent delegation behavior.
+These are the Claude Code roles that turn a broad task into bounded research,
+execution, and review. Portable behavior lives under [`skills/`](../skills/);
+copying an agent file into another client does not reproduce Claude Code's
+delegation runtime.
 
 | Directory | Contents |
 |---|---|
 | [`subagents/`](subagents/) | Spawnable Claude Code subagents with bounded responsibilities |
 | [`claude-md/`](claude-md/) | Project-level `CLAUDE.md` and `CONTEXT.md` templates |
 
-## Index
+## Choose a role
 
-## Subagents
 | Subagent | Description |
 |---|---|
 | [`mastermind-prompt-refiner`](subagents/mastermind-prompt-refiner.md) | Normalizes explicit prompt rewrites or cold-agent handoffs while preserving the original request. |
@@ -25,7 +25,8 @@ another client and assume equivalent delegation behavior.
 | [`mastermind-test-auditor`](subagents/mastermind-test-auditor.md) | Post-implementation test reviewer. Uses `mmcg_test_impact` classifications to separate real coverage from a filename match. |
 | [`mastermind-security-auditor`](subagents/mastermind-security-auditor.md) | Independent security reviewer. Spawned only on security-sensitive scope (auth, tools, secrets, delegation, supply chain, prompt injection); optional OWASP ASI mode. |
 
-## Project templates
+## Give a project durable context
+
 | Template | Description |
 |---|---|
 | [`mastermind-workflow`](claude-md/mastermind-workflow.md) | `CLAUDE.md` contract for Direct, Verified, and Strict task delivery. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,10 @@
 # Documentation
 
-Use this page as the documentation index. The root [README](../README.md) is the
-product overview; this directory contains guides and contracts.
+Start with the job you need to finish. The root [README](../README.md) is the
+product tour; these pages take you from a first local review to exact protocol,
+security, and extension contracts.
 
-## Start here
+## Get a useful result
 
 | Goal | Document |
 |---|---|
@@ -12,7 +13,7 @@ product overview; this directory contains guides and contracts.
 | Use Direct, Verified, or Strict delivery | [Workflow](workflow.md) |
 | Look up a command, schema, limit, or MCP tool | [CLI and MCP reference](reference/mmcg.md) |
 
-## Review and CI
+## Review a change or enforce a boundary
 
 | Goal | Document |
 |---|---|
@@ -22,7 +23,7 @@ product overview; this directory contains guides and contracts.
 | Enforce architecture rules | [Policy CLI](reference/mmcg.md#architecture-policy-as-code-mmcg-policy-check) |
 | Review architecture drift over time | [Temporal graph](reference/mmcg.md#temporal-graph-mmcg-temporal) |
 
-## Extensions
+## Bring in more evidence
 
 | Goal | Document |
 |---|---|
@@ -42,7 +43,8 @@ product overview; this directory contains guides and contracts.
 
 ## Documentation rules
 
-- Guides explain a task. Reference pages define exact behavior and limits.
+- Guides get a reader to an outcome. Reference pages define exact behavior and
+  limits. Landing pages point to both instead of duplicating them.
 - Commands must be copyable from the repository root unless a different
   working directory is stated.
 - Performance claims must link to [methodology and raw parameters](benchmarks.md).

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,11 +1,18 @@
 # Indexing benchmarks
 
-This page reports the repository's synthetic indexing benchmark. It measures
-cold indexing, an unchanged incremental scan, and a 10% incremental update.
-It does **not** compare Mastermind with another tool: no shared corpus and
-equivalent query contract currently exist for a defensible comparison.
+How quickly does the graph become useful, and what does an incremental refresh
+cost? This reproducible synthetic benchmark measures cold indexing, an
+unchanged scan, and a 10% update. It is a regression baseline, not a universal
+speed claim.
+
+There is no competitor table here. Without a shared corpus and equivalent
+query contract, the comparison would look precise and mean very little.
 
 ## Results
+
+On the recorded machine, the 1,000-file corpus became queryable in a 310 ms
+median cold run; the 10,000-file corpus took 3.20 s. Keep the machine, corpus,
+range, and contract attached to those numbers.
 
 Measurements were taken on 2026-08-13 at commit
 `2ee0807e4aab480d95d8b9199e703f9408ab21d5` with the release profile.

--- a/docs/fact-ingestion-sdk.md
+++ b/docs/fact-ingestion-sdk.md
@@ -1,16 +1,20 @@
 # Declarative fact-ingestion SDK
 
+Bring SARIF, coverage, tests, traces, or your own analysis into the same review
+without loading producer code into Mastermind.
+
 The extension boundary is data ingestion, not plugin execution. A producer
-emits a revision-bound JSON manifest. Mastermind validates the complete input,
-then atomically replaces that producer's normalized dataset in private SQLite
-tables. Lens, CLI, and the fixed read-only `mmcg_facts` tool read the result.
+emits a revision-bound JSON manifest; Mastermind validates the complete input
+before atomically replacing that producer's normalized dataset in private
+SQLite tables. Lens, CLI, and the fixed read-only `mmcg_facts` tool read the
+result.
 
 The public v1 schema is
 [`schemas/mastermind-facts-v1.schema.json`](../schemas/mastermind-facts-v1.schema.json).
 Its API identifier is `mastermind-facts/v1`, with two capabilities:
 `annotations` and `relationships`.
 
-## Contract at a glance
+## The contract in one screen
 
 | Property | v1 behavior |
 |---|---|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,12 @@
 # Getting started
 
-This guide takes a clean machine to a local index, a change-impact report, and
-an optional MCP connection. For exact flags and schemas, use the
-[technical reference](reference/mmcg.md).
+In a few minutes you will have a local codegraph, a blast-radius report for the
+current change, and—if you want it—an MCP connection for your coding agent.
+Your repository stays on the machine.
+
+For exact flags, schemas, and limits, use the
+[technical reference](reference/mmcg.md). This page is the shortest path to a
+useful result.
 
 ## Requirements
 
@@ -17,6 +21,9 @@ The npm package includes native binaries for supported macOS, Linux, and
 Windows targets. It does not compile Rust during installation.
 
 ## 1. Install the CLI
+
+Choose one installation path. npm is the fastest route because it ships a
+prebuilt native binary.
 
 Global installation:
 
@@ -51,6 +58,9 @@ The index is `.mastermind/mmcg.db`. Source discovery follows Git and `.ignore`
 rules and skips build/vendor directories. The first run parses supported files;
 later runs skip unchanged files.
 
+You are ready when `mastermind status` reports the repository and indexed file
+counts without stale-file warnings.
+
 ```bash
 mastermind index .          # incremental refresh
 mastermind index . --force  # full reparse
@@ -79,6 +89,10 @@ mastermind ui --since main
   component crossings, and candidate tests.
 - `temporal` compares architecture at the baseline and indexed worktree.
 - `ui` serves the same bounded snapshot in local read-only Mastermind Lens.
+
+For a first review, run `impact`, then open `ui`. Use `map` when you need the
+architecture around the change and `temporal` when you need base-versus-head
+drift.
 
 Refresh the index before trusting a result after source changes. Stale,
 truncated, or work-limited analysis fails closed or is labelled partial; it is

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,8 +1,11 @@
 # Mastermind verifiable audit Action
 
+Turn a Mastermind audit into evidence GitHub can verify and publish without giving
+pull-request code an OIDC token or write permission.
+
 The Docker Action creates schema-v3 audit envelopes for an exact repository
-snapshot. The recommended deployment separates untrusted pull-request analysis
-from privileged publication.
+snapshot. The secure deployment splits untrusted analysis from privileged
+verification, attestation, and publication.
 
 | Stage | Trigger | Authority | Executes PR code |
 |---|---|---|---|
@@ -11,11 +14,13 @@ from privileged publication.
 | Attest | verified result | OIDC and attestations write only | No |
 | Publish | verified result | Pull-request comment write only | No |
 
-Start from
+Do not assemble that privilege split from memory. Start from the pinned,
+repository-validated examples:
+
 [`mastermind-audit-pr.yml`](examples/mastermind-audit-pr.yml) and
 [`mastermind-audit-publish.yml`](examples/mastermind-audit-publish.yml).
 
-## What each proof means
+## Read the proof correctly
 
 - **Content integrity:** the Mastermind Canonical JSON v1 bytes match their
   SHA-256 digest. Replacing both the manifest and digest can still create a

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,9 +1,10 @@
 # Claude Code integration
 
-Claude Code supports project-local `.mcp.json` configuration and user-scope
-registration through `claude mcp`.
+Give Claude Code the local graph without hand-editing its MCP configuration.
+Use user scope for one installation across repositories or project scope when
+the repository should carry its own `.mcp.json` entry.
 
-## User scope
+## Fastest path: user scope
 
 Install Mastermind, index the repository, and preview registration:
 
@@ -26,7 +27,7 @@ output, and rechecks executable identity before later inspection or mutation.
 The process runs without a shell, has a ten-second limit, and does not print raw
 output.
 
-## Project scope
+## Repository-owned path: project scope
 
 ```bash
 npm install -D @xcraftmind/mastermind
@@ -38,7 +39,7 @@ Project scope merges the canonical `mmcg` entry into `.mcp.json` while
 preserving unrelated root fields and servers. The legacy spelling
 `--project . --write-mcp` remains compatible.
 
-## Update or remove
+## Change or undo safely
 
 A matching entry is an idempotent no-op. A customized entry requires `--force`;
 `--force` never implies `--write`. Before forced file-backed replacement or
@@ -50,7 +51,7 @@ mastermind setup claude --scope project --root . --remove          # dry-run
 mastermind setup claude --scope project --root . --remove --write
 ```
 
-## Verify
+## Verify the result
 
 ```bash
 mastermind doctor

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -1,9 +1,10 @@
 # Codex CLI integration
 
-Mastermind registers with Codex at user scope through `codex mcp`. Project
-scope is not supported.
+Give Codex the bounded local graph plus Mastermind's portable delivery skills.
+Mastermind registers through `codex mcp` at user scope; Codex does not currently
+have a project-scope setup path.
 
-## Install and register
+## Install the complete Codex bundle
 
 ```bash
 npm install -g @xcraftmind/mastermind
@@ -23,7 +24,7 @@ spawnable subagent files because Codex has a different agent runtime. This is
 workflow-contract compatibility, not a claim that both clients expose identical
 role orchestration.
 
-The normal task handoff is client-neutral:
+Once installed, the normal task handoff stays client-neutral:
 
 ```bash
 mastermind verify-spec .mastermind/tasks/001-example/spec.md
@@ -49,7 +50,7 @@ must contain the exact stdio command and ordered arguments. Truncated output is
 rejected, and executable identity is rechecked before every inspection or
 mutation within the ten-second bound.
 
-## Update or remove
+## Change or undo safely
 
 A matching native entry is an idempotent no-op. A customized entry requires
 `--force`; `--force` never implies `--write`.
@@ -59,7 +60,7 @@ mastermind setup codex --scope user --remove          # dry-run
 mastermind setup codex --scope user --remove --write
 ```
 
-## Verify
+## Verify the result
 
 ```bash
 mastermind doctor

--- a/docs/integrations/continue.md
+++ b/docs/integrations/continue.md
@@ -1,13 +1,15 @@
 # Continue integration
 
-Mastermind owns one standalone Continue YAML document:
+Connect Continue without merging into its general configuration. Mastermind
+owns one small, standalone MCP document, so setup and removal have an exact
+boundary:
 
 | Scope | Path |
 |---|---|
 | Project | `.continue/mcpServers/mastermind.yaml` |
 | User | `~/.continue/mcpServers/mastermind.yaml` |
 
-## Preview and apply
+## Preview first, then apply
 
 ```bash
 npm install -g @xcraftmind/mastermind
@@ -41,7 +43,7 @@ npx, and project-local npm launchers use `cmd.exe /d /s /c` so Continue can
 execute npm's `.cmd` shims. Mastermind does not merge this entry into Continue's
 general JSON configuration.
 
-## Update or remove
+## Change or undo safely
 
 A canonical owned document is an idempotent no-op and can be removed safely.
 Customized content requires `--force`; `--force` never implies `--write`.
@@ -53,7 +55,7 @@ mastermind setup continue --scope project --root . --remove          # dry-run
 mastermind setup continue --scope project --root . --remove --write
 ```
 
-## Verify
+## Verify the result
 
 ```bash
 mastermind doctor

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,9 +1,10 @@
 # Cursor integration
 
-Cursor reads `.cursor/mcp.json` at project scope and `~/.cursor/mcp.json` at
-user scope.
+Connect Cursor to the local graph while preserving every unrelated MCP server
+and root setting. Use project scope for `.cursor/mcp.json` or user scope for
+`~/.cursor/mcp.json`.
 
-## Preview and apply
+## Preview first, then apply
 
 ```bash
 npm install -g @xcraftmind/mastermind
@@ -22,7 +23,7 @@ mastermind setup cursor --scope user --write
 The setup engine preserves unrelated root fields and MCP servers, rejects
 duplicate JSON keys and unsafe paths, and does not write without `--write`.
 
-## Update or remove
+## Change or undo safely
 
 A canonical entry is an idempotent no-op. Customized replacement or removal
 requires `--force`, which does not imply `--write`. Forced file-backed changes
@@ -33,7 +34,7 @@ mastermind setup cursor --scope project --root . --remove          # dry-run
 mastermind setup cursor --scope project --root . --remove --write
 ```
 
-## Verify
+## Verify the result
 
 ```bash
 mastermind doctor

--- a/docs/integrations/generic-mcp.md
+++ b/docs/integrations/generic-mcp.md
@@ -1,8 +1,10 @@
 # Generic MCP client integration
 
-`mastermind serve` is an [MCP](https://modelcontextprotocol.io) stdio server.
-Use this guide when a client is not covered by the dedicated Claude Code,
-Codex, Cursor, or Continue setup commands.
+If your client can launch a stdio MCP server, it can use Mastermind. This guide
+gives you the smallest safe config and the exact protocol boundary when no
+dedicated Claude Code, Codex, Cursor, or Continue setup command applies.
+
+`mastermind serve` is the server process.
 
 ## Server spec
 
@@ -19,7 +21,7 @@ Current clients receive behavior annotations and structured results after the
 initialized notification; legacy clients retain content-only results. Input
 frames are limited to 1 MiB and serialized result payloads to 8 MiB.
 
-## Preview and apply
+## Preview first, then apply
 
 Generic setup requires an explicit JSON path:
 
@@ -34,7 +36,7 @@ Before a forced mutation, Mastermind stores previous bytes under
 `~/.mastermind/setup-backups/`. `mastermind doctor` treats configuration as
 bounded data and does not execute a configured command.
 
-## Config snippet
+## Minimal config
 
 The standard MCP client config format:
 
@@ -64,7 +66,7 @@ To target a specific index file (useful when running multiple projects):
 
 The `--index` flag is global and must come before `serve`.
 
-## Available tools
+## What the client receives
 
 - Symbol discovery: `mmcg_search`, `mmcg_outline`, `mmcg_files`,
   `mmcg_symbols_in_file`.

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -1,6 +1,7 @@
 # mmcg — Mastermind Codegraph
 
-This is the exhaustive contract for the `mmcg` engine. Start with
+Need the exact command, limit, schema, precision caveat, or MCP shape? This is
+the source of truth for the `mmcg` engine. Start with
 [Getting started](../getting-started.md) for installation or the
 [project README](../../README.md) for the product overview.
 
@@ -14,9 +15,9 @@ export, and style mining.
 > npm installs the command as both `mastermind` and `mmcg`. Cargo installs
 > `mmcg`. Examples below use `mmcg`; the command surface is identical.
 
-## Reference map
+## Find the exact contract
 
-| Need | Section |
+| You need to verify… | Section |
 |---|---|
 | Supported syntax and known extraction gaps | [What it indexes](#what-it-indexes) |
 | Installation and commands | [Build from source](#build-from-source), [CLI usage](#cli-usage) |

--- a/docs/team-graph.md
+++ b/docs/team-graph.md
@@ -1,9 +1,12 @@
 # Local team graph
 
-A team graph combines several existing local indexes into one bounded,
-read-only architecture view. Each repository stays independently indexed.
-Mastermind neither copies repositories into a central database nor infers
-cross-repository calls; the manifest declares those relationships.
+See several services as one architecture without centralizing their source or
+pretending a naming heuristic proves a network call.
+
+A team graph combines existing local indexes into one bounded, read-only view.
+Each repository stays independently indexed. Mastermind neither copies
+repositories into a central database nor infers cross-repository calls; the
+manifest declares those relationships.
 
 The public v1 schema is
 [`schemas/mastermind-team-v1.schema.json`](../schemas/mastermind-team-v1.schema.json),
@@ -17,7 +20,7 @@ Each member repository must have:
 - a fresh `.mastermind/mmcg.db` created by `mastermind index .`;
 - a stable local root and index path available to the querying process.
 
-## Define, lock, and query
+## From manifest to pinned graph
 
 Create a draft manifest. Paths may be absolute or relative to the manifest.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,8 +1,11 @@
 # Behavioral evaluations
 
-Adversarial regression cases for Mastermind agents and workflow skills. One case
-proves one expected behavior; suite pass rate is not a coverage or correctness
-metric.
+Can the shipped instruction still produce the behavior it promises under one
+focused adversarial scenario? These suites make that question replayable for
+Mastermind agents and workflow skills.
+
+One case probes one expected behavior. A pass rate is not coverage, product
+correctness, or evidence that the behavior survives a long real-world task.
 
 ## Suite map
 
@@ -18,7 +21,7 @@ metric.
 `runner.py` invokes `claude -p`. `test_runner.py` tests the deterministic
 parser, isolation, allowlist, and fixture machinery without calling a model.
 
-## Run
+## Run the right layer
 
 Model-backed runs require authenticated `claude` and `git` executables:
 
@@ -130,7 +133,7 @@ Workflow artifacts are allowlisted and loaded from the repository. Cases run
 from the system temporary directory in Claude safe mode with no tools, so the
 prompt under evaluation cannot operate on the maintainer checkout.
 
-## Case rules
+## Keep cases honest
 
 - One adversarial or golden behavior per case.
 - Explain the regression in `why`; do not leak the expected answer into source

--- a/evals/scorecard.md
+++ b/evals/scorecard.md
@@ -1,8 +1,9 @@
 # Eval scorecard
 
-This file records behavioral regression runs. It is not a model benchmark or a
-coverage percentage: case sets differ by suite, and elapsed time depends on the
-model, machine, and fixture setup.
+This is the evidence ledger for complete behavioral regression runs. Read the
+environment and trust note with every score: it is not a model leaderboard or
+a coverage percentage, case sets differ by suite, and elapsed time depends on
+the model, machine, and fixture setup.
 
 Latest complete runs: 2026-07-31, all four suites. The 2026-08-11 rerun did
 not reach inference because the local Claude Code OAuth session had expired;
@@ -165,7 +166,7 @@ honor superseded decisions and failed approaches, separate approval from proof,
 require explicit lesson-candidate review, and prevent style evidence from
 crossing author, language, repository, or authority boundaries.
 
-## Reading the result
+## What a row does—and does not—prove
 
 - Report only complete suite runs in the table. A targeted rerun can diagnose a
   case, but it does not change the suite pass rate.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,7 +1,9 @@
 # MCP servers
 
-Mastermind ships one [Model Context Protocol](https://modelcontextprotocol.io)
-server.
+One local graph, one bounded [Model Context Protocol](https://modelcontextprotocol.io)
+server, no arbitrary SQL surface.
+
+Mastermind currently ships one server:
 
 | Server | Transport | Surface |
 |---|---|---|
@@ -12,5 +14,7 @@ Go, Java, PHP, and C/C++. It exposes structural, semantic, evidence, history,
 and workflow-state queries; it does not expose arbitrary SQL or executable
 plugin hooks.
 
-Start with the [generic MCP guide](../docs/integrations/generic-mcp.md) or the
+Want to connect a client? Start with the
+[generic MCP guide](../docs/integrations/generic-mcp.md). Need exact schemas,
+limits, and precision notes? Use the
 [complete technical reference](../docs/reference/mmcg.md#mcp-tools).

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -24,6 +24,9 @@ metadata:
 
 # mmcg — Mastermind Codegraph
 
+Ask architecture questions against the repository on your machine, not against
+a pasted fragment or a remote black box.
+
 mmcg is the local structural engine inside
 [Mastermind](https://github.com/xcrft/mastermind). It indexes symbols, calls,
 imports, and evidence into SQLite, then exposes the same state through CLI,
@@ -58,7 +61,7 @@ mmcg --version
 
 SQLite and tree-sitter are bundled. No system SQLite or parser libraries are required.
 
-## Quick start
+## See your first result
 
 ```bash
 cd your-project
@@ -94,7 +97,7 @@ mastermind setup claude --scope user --write  # apply
 
 See the [client integration guides](https://github.com/xcrft/mastermind/tree/main/docs/integrations) for Claude Code, Codex, Cursor, Continue, and generic MCP clients.
 
-## Capabilities
+## What one graph can answer
 
 | Area | Examples |
 |---|---|
@@ -125,7 +128,7 @@ engine cannot prove completeness.
 - PHP
 - C and C++
 
-## Precision model
+## Know the evidence boundary
 
 The default mmcg graph is syntactic, not a compiler or language server:
 

--- a/npm/mastermind/README.md
+++ b/npm/mastermind/README.md
@@ -5,11 +5,11 @@
 <h1 align="center">@xcraftmind/mastermind</h1>
 
 <p align="center">
-  <strong>Know what your code change can break before production tells you.</strong>
+  <strong>Review the blast radius, not just the patch.</strong>
 </p>
 
 <p align="center">
-  Local codegraph and evidence-backed architecture review for developers and coding agents.
+  Local codegraph and evidence-backed architecture review for developers and coding agents—without uploading the repository.
 </p>
 
 <p align="center">
@@ -22,7 +22,7 @@
   <img src="https://raw.githubusercontent.com/xcrft/mastermind/main/docs/assets/brand/mastermind-hero.webp" alt="A bounded code graph flowing through the Mastermind lens from change to impact and test evidence" width="900">
 </p>
 
-## Stop reviewing isolated lines
+## See the consequences behind the diff
 
 A diff tells you what changed. Mastermind shows what the change reaches:
 downstream callers, architecture boundaries, candidate tests, ownership,
@@ -31,7 +31,7 @@ security findings, runtime evidence, and repository policy.
 One local snapshot powers the CLI, 28 bounded MCP tools, the read-only Lens UI,
 SARIF output, and a standalone review package.
 
-## Your first review
+## Your first review in three commands
 
 Requires Node.js 24+. The package selects a prebuilt native binary for macOS,
 Linux, or Windows. Rust is not required.
@@ -52,7 +52,7 @@ reads the index without mutating it, and loads no remote frontend resources.
   <img src="https://raw.githubusercontent.com/xcrft/mastermind/main/docs/images/lens/mastermind-lens-live-desktop.png" alt="Mastermind Lens showing changed symbols, downstream impact, boundary crossings, test candidates, and explicit partial evidence" width="900">
 </p>
 
-## What you get
+## One graph, five useful surfaces
 
 | Job | Surface |
 |---|---|
@@ -131,12 +131,14 @@ These are measurements on one machine, not portable guarantees. See the
 
 ## Documentation
 
-- [Product README](https://github.com/xcrft/mastermind)
-- [Getting started](https://github.com/xcrft/mastermind/blob/main/docs/getting-started.md)
-- [CLI and MCP reference](https://github.com/xcrft/mastermind/blob/main/docs/reference/mmcg.md)
-- [Client integrations](https://github.com/xcrft/mastermind/tree/main/docs/integrations)
-- [Review workflow](https://github.com/xcrft/mastermind/blob/main/docs/workflow.md)
-- [Fact-ingestion SDK](https://github.com/xcrft/mastermind/blob/main/docs/fact-ingestion-sdk.md)
+| I want to… | Go here |
+|---|---|
+| Understand the product | [Product README](https://github.com/xcrft/mastermind) |
+| Run my first review | [Getting started](https://github.com/xcrft/mastermind/blob/main/docs/getting-started.md) |
+| Look up a command, limit, or MCP tool | [CLI and MCP reference](https://github.com/xcrft/mastermind/blob/main/docs/reference/mmcg.md) |
+| Connect an AI client | [Client integrations](https://github.com/xcrft/mastermind/tree/main/docs/integrations) |
+| Use the delivery workflow | [Review workflow](https://github.com/xcrft/mastermind/blob/main/docs/workflow.md) |
+| Import external evidence safely | [Fact-ingestion SDK](https://github.com/xcrft/mastermind/blob/main/docs/fact-ingestion-sdk.md) |
 
 The same binary is available from crates.io as
 [`mmcg`](https://crates.io/crates/mmcg). npm installs it as both `mastermind`

--- a/npm/platforms/darwin-arm64/README.md
+++ b/npm/platforms/darwin-arm64/README.md
@@ -1,5 +1,7 @@
 # @xcraftmind/mmcg-darwin-arm64
 
-Prebuilt mmcg binary for macOS arm64 (Apple Silicon). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.
+The native Mastermind engine for **macOS on Apple Silicon**.
 
-See [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind) for usage.
+You normally never install this package directly. npm selects it automatically
+for [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind),
+which provides the `mastermind` and `mmcg` commands.

--- a/npm/platforms/darwin-x64/README.md
+++ b/npm/platforms/darwin-x64/README.md
@@ -1,5 +1,7 @@
 # @xcraftmind/mmcg-darwin-x64
 
-Prebuilt mmcg binary for macOS x86_64 (Intel). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.
+The native Mastermind engine for **macOS on Intel**.
 
-See [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind) for usage.
+You normally never install this package directly. npm selects it automatically
+for [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind),
+which provides the `mastermind` and `mmcg` commands.

--- a/npm/platforms/linux-arm64-gnu/README.md
+++ b/npm/platforms/linux-arm64-gnu/README.md
@@ -1,5 +1,7 @@
 # @xcraftmind/mmcg-linux-arm64-gnu
 
-Prebuilt mmcg binary for Linux arm64 glibc. Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.
+The native Mastermind engine for **Linux arm64 with glibc**.
 
-See [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind) for usage.
+You normally never install this package directly. npm selects it automatically
+for [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind),
+which provides the `mastermind` and `mmcg` commands.

--- a/npm/platforms/linux-arm64-musl/README.md
+++ b/npm/platforms/linux-arm64-musl/README.md
@@ -1,5 +1,8 @@
 # @xcraftmind/mmcg-linux-arm64-musl
 
-Prebuilt mmcg binary for Linux arm64 musl (Alpine, distroless). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.
+The native Mastermind engine for **Linux arm64 with musl**, including Alpine
+and compatible distroless images.
 
-See [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind) for usage.
+You normally never install this package directly. npm selects it automatically
+for [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind),
+which provides the `mastermind` and `mmcg` commands.

--- a/npm/platforms/linux-x64-gnu/README.md
+++ b/npm/platforms/linux-x64-gnu/README.md
@@ -1,5 +1,7 @@
 # @xcraftmind/mmcg-linux-x64-gnu
 
-Prebuilt mmcg binary for Linux x86_64 glibc. Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.
+The native Mastermind engine for **Linux x64 with glibc**.
 
-See [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind) for usage.
+You normally never install this package directly. npm selects it automatically
+for [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind),
+which provides the `mastermind` and `mmcg` commands.

--- a/npm/platforms/linux-x64-musl/README.md
+++ b/npm/platforms/linux-x64-musl/README.md
@@ -1,5 +1,8 @@
 # @xcraftmind/mmcg-linux-x64-musl
 
-Prebuilt mmcg binary for Linux x86_64 musl (Alpine, distroless). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.
+The native Mastermind engine for **Linux x64 with musl**, including Alpine and
+compatible distroless images.
 
-See [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind) for usage.
+You normally never install this package directly. npm selects it automatically
+for [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind),
+which provides the `mastermind` and `mmcg` commands.

--- a/npm/platforms/win32-x64-msvc/README.md
+++ b/npm/platforms/win32-x64-msvc/README.md
@@ -1,5 +1,7 @@
 # @xcraftmind/mmcg-win32-x64-msvc
 
-Prebuilt mmcg binary for Windows x86_64 (MSVC). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.
+The native Mastermind engine for **Windows x64 with the MSVC runtime**.
 
-See [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind) for usage.
+You normally never install this package directly. npm selects it automatically
+for [`@xcraftmind/mastermind`](https://www.npmjs.com/package/@xcraftmind/mastermind),
+which provides the `mastermind` and `mmcg` commands.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,9 +1,10 @@
 # Scripts
 
-Repository validation, packaging, release, and smoke-test scripts. Run scripts
-from the repository root unless a section says otherwise.
+Find the gate that matches your change, run it from the repository root, and
+keep the result replayable. This directory owns repository validation,
+packaging, release controls, and registry smoke tests.
 
-## Common entry points
+## Start with the narrowest useful gate
 
 | Goal | Command |
 |---|---|
@@ -12,15 +13,15 @@ from the repository root unless a section says otherwise.
 | Native npm tarball smoke | `just npm-smoke-native` |
 | Index benchmark | `just benchmark-index` |
 
-The `just` recipes are the canonical developer interface. Call an individual
-script directly when diagnosing that script.
+The `just` recipes are the canonical developer interface. Reach for an
+individual script only when you are diagnosing that script or its contract.
 
-## `validate.py` — repository contract validator
+## `validate.py`: catch cross-surface drift
 
 Runs the deterministic repository-level checks that do not belong in the Rust,
 npm, or model-backed test suites. CI executes it on every change.
 
-### What it checks
+### Contracts it protects
 
 - artifact frontmatter, names, versions, domains, links, and template mirrors;
 - exact MCP tool count plus read/write annotations, and parity of the public
@@ -32,7 +33,7 @@ npm, or model-backed test suites. CI executes it on every change.
 - npm package/version/platform shape, README badge alignment, and workflow-bundle staging parity;
 - answer-leak clues in adversarial eval fixture source trees.
 
-### Run directly
+### Run it directly
 
 ```bash
 # One-time setup
@@ -46,7 +47,7 @@ python3 -m venv .venv
 Exit code is `0` on clean and `1` when errors exist. Warnings do not fail the
 run.
 
-### Boundaries
+### What it cannot prove
 
 - It does not compile Rust, execute npm, or call a model.
 - It cannot prove that a prompt behaves correctly; `evals/runner.py` covers

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,13 +1,18 @@
 # Skills
 
-Portable workflow capabilities installed by Mastermind. Every `SKILL.md` in
-this tree is staged into the npm workflow bundle; `scripts/validate.py` fails if
-this index or the staged copy drifts.
+Portable, client-neutral capabilities for taking a task from intent to
+evidence. Pick the smallest skill that owns the job; combine them only when the
+task genuinely crosses research, implementation, review, or security
+boundaries.
+
+Every `SKILL.md` in this tree is staged into the npm workflow bundle;
+`scripts/validate.py` fails if this index or the staged copy drifts.
 
 Skills define task behavior. Claude Code-specific spawnable roles live under
 [`agents/`](../agents/).
 
-## Workflow
+## Move a task from request to evidence
+
 | Skill | Description |
 |---|---|
 | [`mastermind-task-planning`](workflow/mastermind-task-planning/SKILL.md) | Chooses Direct, Verified, or Strict and creates the lightest evidence-grounded delegation contract that fits the risk. |
@@ -27,40 +32,47 @@ Skills define task behavior. Claude Code-specific spawnable roles live under
 | [`mastermind-audit-attestation`](workflow/mastermind-audit-attestation/SKILL.md) | Separates content integrity, signer provenance, and policy acceptance for audit evidence. |
 | [`mastermind-style-deep`](workflow/mastermind-style-deep/SKILL.md) | Adds a grounded qualitative coding portrait consumed as advisory planner/executor input. |
 
-## Coding
+## Keep implementation clean
+
 | Skill | Description |
 |---|---|
 | [`no-ai-slop-comments`](coding/no-ai-slop-comments/SKILL.md) | Keeps useful comments and removes narration introduced by the current change without widening scope. |
 
-## Code review
+## Review what actually changed
+
 | Skill | Description |
 |---|---|
 | [`mastermind-comment-audit`](code-review/mastermind-comment-audit/SKILL.md) | Reviews the comment delta of a finished change with quoted evidence, names what it kept, and reports deleted rationale. |
 | [`mastermind-test-audit`](code-review/mastermind-test-audit/SKILL.md) | Checks whether a change's tests prove its behaviour: uncovered symbols, a test on the wrong path, an assertion moved with the code, and non-asserting tests. |
 | [`mastermind-frontend-audit`](code-review/mastermind-frontend-audit/SKILL.md) | Checks a finished UI change against the codegraph: unrendered components, props contracts changed without their callers, duplicates, and raw values shadowing tokens. |
 
-## Design
+## Turn design intent into a contract
+
 | Skill | Description |
 |---|---|
 | [`mastermind-design-intake`](design/mastermind-design-intake/SKILL.md) | Converts a design handoff into named components, token names, and criteria that can fail, parking visual fidelity explicitly. |
 
-## Testing
+## Record browser evidence honestly
+
 | Skill | Description |
 |---|---|
 | [`mastermind-browser-verification`](testing/mastermind-browser-verification/SKILL.md) | Records browser checks as evidence — accessibility tree over screenshot, console and network errors, viewports as a checklist, unchecked marked unchecked. |
 
-## Debugging
+## Investigate before declaring a cause
+
 | Skill | Description |
 |---|---|
 | [`mastermind-investigation-ledger`](debugging/mastermind-investigation-ledger/SKILL.md) | Diagnoses unknown bugs with competing hypotheses, evidence for/against, and bounded decision-changing probes. |
 
-## Security
+## Map trust boundaries and reachable risk
+
 | Skill | Description |
 |---|---|
 | [`mastermind-security-research`](security/mastermind-security-research/SKILL.md) | Enumerates reachable privileged operations, the sites that statically apply a guard, and secret readers — reporting the difference as unestablished rather than as a verdict. |
 | [`mastermind-agent-security-review`](security/mastermind-agent-security-review/SKILL.md) | Portable security review protocol for agent/tool trust boundaries, with optional evidence-based OWASP mapping. |
 
-## Prompt engineering
+## Refine the request without replacing it
+
 | Skill | Description |
 |---|---|
 | [`mastermind-prompt-refiner`](prompt-engineering/mastermind-prompt-refiner/SKILL.md) | Rewrites explicit prompts or cold-agent handoffs while preserving the original request verbatim. |


### PR DESCRIPTION
## What changed

- Reworks the first screen and navigation across all 31 product documentation pages.
- Gives the repository and npm READMEs a tighter product story, clearer first review, and decision-based docs map.
- Standardizes client guides around outcome, preview, apply, verify, and safe removal.
- Makes MCP, package, platform, contributor, security, eval, and maintainer pages easier to scan without duplicating the canonical CLI reference.
- Keeps precision, trust, performance, and evidence limits explicit.

## Scope

This is a docs-only follow-up to #77, which was merged while the refresh was in progress.

Workflow and runtime prompt contracts, test fixtures, and the historical changelog are deliberately unchanged. Cosmetic rewriting there could change executable behavior or rewrite evidence instead of improving documentation.

## Verification

- `just check`
- `scripts/validate.py`: 0 errors, 0 warnings
- GitHub GFM render for all 31 changed Markdown files
- `git diff --check`
