### PR TITLE
feat: harden agent workflow efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The artifact validator and `mastermind doctor` now detect Claude subagents
+  that scope an MCP server but block all of its tools with an explicit
+  frontmatter allowlist.
+- Behavioral eval output now reports turns, input/output tokens, prompt-cache
+  writes and reads, API time, and reported cost, including every retry attempt.
+
+### Fixed
+- Shipped Claude subagents grant only the exact `mmcg` tools each role needs
+  and carry bounded `maxTurns` and `effort` settings. Auditor evals exercise the
+  shipped custom-agent runtime contract instead of a separate handwritten MCP
+  allowlist.
+- Structural MCP tools now fail closed with a structured `index_stale` result
+  when source files or the extractor contract drift from the index. Diagnostic,
+  revision-bound, history, scratchpad, and change-classification tools remain
+  available for recovery.
+- Comment-audit routing now spawns the specialist only when the finished diff
+  contains an added, modified, or deleted comment.
+- `mastermind doctor` treats Claude's native `type: stdio` and empty `env`
+  fields as canonical MCP defaults while still flagging meaningful overrides.
+
 ## [2.0.1] - 2026-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and carry bounded `maxTurns` and `effort` settings. Auditor evals exercise the
   shipped custom-agent runtime contract instead of a separate handwritten MCP
   allowlist.
-- Structural MCP tools now fail closed with a structured `index_stale` result
-  when source files or the extractor contract drift from the index. Diagnostic,
-  revision-bound, history, scratchpad, and change-classification tools remain
-  available for recovery.
+- Structural MCP tools backed by the managed `.mastermind/mmcg.db` now refresh
+  the derived index automatically when source files or the extractor contract
+  drift before a query. Custom external indexes remain manual-refresh-only. If
+  a refresh is unavailable or cannot produce a fresh graph, the tool returns a
+  structured `index_stale` result. Diagnostic, revision-bound, history,
+  scratchpad, and change-classification tools remain available for recovery.
 - Comment-audit routing now spawns the specialist only when the finished diff
   contains an added, modified, or deleted comment.
 - `mastermind doctor` treats Claude's native `type: stdio` and empty `env`

--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ mastermind doctor --workflow --client all
 
 Mastermind supports Claude Code, Codex, Cursor, Continue, and generic MCP stdio
 clients. Setup is dry-run-first unless `--write` is present. The MCP surface has
-27 read-only tools and one additive write to the local gitignored scratchpad.
+19 non-destructive queries that may refresh the managed derived index, 8
+read-only tools, and one additive write to the local gitignored scratchpad.
 
 ## How it works
 

--- a/agents/claude-md/mastermind-workflow.md
+++ b/agents/claude-md/mastermind-workflow.md
@@ -34,15 +34,16 @@ Use the lightest mode that fits the risk:
 
 | Mode | Use | Flow |
 |---|---|---|
-| **Direct** | Small, reversible, clear work | inspect → impact if useful → implement → tests → comment audit |
+| **Direct** | Small, reversible, clear work | inspect → impact if useful → implement → tests → comment-delta gate |
 | **Verified** | Normal multi-file or delegated work | compact task contract → deterministic pre/post gates → semantic review |
 | **Strict** | Auth, billing, migration, public API, data loss, supply chain | verified flow + critic/security/rollback evidence + independent auditor |
 
 Do not create a spec for Direct work.
 
 Direct work has no controller and no post-flight, so the only review it gets is
-the one you run. Use `mastermind-comment-auditor` on the branch point once the
-change is finished.
+the one you run. Once the change is finished, inspect `git diff -U0 <baseline>`
+and untracked files for added, modified, or deleted comments. Spawn
+`mastermind-comment-auditor` only when that comment delta is non-empty.
 
 ### Grounding
 
@@ -77,8 +78,10 @@ and truncation caveats; source reads and tests remain authoritative for runtime 
    mastermind run-task .mastermind/tasks/<task>/spec.md --post-only
    ```
 
-7. Spawn `mastermind-comment-auditor` on the post-flight baseline. Its findings
-   are input to your semantic review, not a verdict.
+7. Inspect the post-flight baseline diff and untracked files for a comment
+   delta. Spawn `mastermind-comment-auditor` only when at least one comment was
+   added, modified, or deleted. Its findings are input to your semantic review,
+   not a verdict.
 8. Perform semantic review. Strict work additionally requires the read-only
    `mastermind-auditor`.
 
@@ -124,7 +127,8 @@ Pre-flight, before a diff exists, route on the paths named in the spec's Scope.
   supply chain, or audit policy.
 - Executor: implementation within approved scope.
 - Auditor: independent read-only review for Strict work.
-- Comment auditor: comment delta of a finished change, in every mode.
+- Comment auditor: non-empty comment delta of a finished change, in every mode;
+  skip the spawn when the gate finds no changed comments.
 - Runtime research: who already consumes a service, who writes the state, which
   boundaries the change crosses — and which invocations the graph cannot see at
   all. Zero static callers on a handler is a gap, not an absence.

--- a/agents/subagents/mastermind-auditor.md
+++ b/agents/subagents/mastermind-auditor.md
@@ -1,11 +1,13 @@
 ---
 name: mastermind-auditor
 description: Independent read-only post-flight auditor for strict tasks or unresolved high-risk uncertainty. Verifies an executor report against git diff, files, commands, and mmcg evidence; does not replace the deterministic controller audit.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_search, mcp__mmcg__mmcg_callers, mcp__mmcg__mmcg_impact
 model: opus
 mcpServers: [mmcg]
+maxTurns: 20
+effort: high
 metadata:
-  version: 0.7.0
+  version: 0.7.1
   authors: [mastermind]
   tags: [workflow, audit, mmcg, canons]
 ---

--- a/agents/subagents/mastermind-comment-auditor.md
+++ b/agents/subagents/mastermind-comment-auditor.md
@@ -1,10 +1,12 @@
 ---
 name: mastermind-comment-auditor
-description: Independent read-only reviewer of the comment delta of a finished change. Flags narration with quoted evidence, names what it kept, and reports rationale the change deleted. Spawn after implementation is complete — in post-flight for verified/strict tasks, or directly on a Direct-mode diff. Distinct from `mastermind-auditor`, which audits the spec contract.
+description: Independent read-only reviewer of a non-empty comment delta. Flags narration with quoted evidence, names what it kept, and reports rationale the change deleted. Spawn after implementation only when the pre-gate found added, modified, or deleted comments. Distinct from `mastermind-auditor`, which audits the spec contract.
 tools: Read, Grep, Glob, Bash
 model: sonnet
+maxTurns: 12
+effort: medium
 metadata:
-  version: 0.1.0
+  version: 0.1.1
   authors: [mastermind]
   tags: [code-review, comments, audit, workflow]
 ---

--- a/agents/subagents/mastermind-critic.md
+++ b/agents/subagents/mastermind-critic.md
@@ -1,11 +1,13 @@
 ---
 name: mastermind-critic
 description: Independent design-time challenger that stress-tests a proposed approach against 7 explicit engineering dimensions (correctness, performance, observability, non-breaking, YAGNI, AI slop, test/doc coverage) before it becomes a spec. Spawn from the planner during brainstorming — mandatory for sensitive areas. Distinct from `mastermind-auditor` which verifies post-execution.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_search, mcp__mmcg__mmcg_callers, mcp__mmcg__mmcg_impact
 model: opus
 mcpServers: [mmcg]
+maxTurns: 10
+effort: high
 metadata:
-  version: 0.4.1
+  version: 0.4.2
   authors:
     - mastermind
   tags:

--- a/agents/subagents/mastermind-frontend-auditor.md
+++ b/agents/subagents/mastermind-frontend-auditor.md
@@ -1,11 +1,13 @@
 ---
 name: mastermind-frontend-auditor
 description: Independent read-only reviewer of a finished React or Vue change, grounded in the codegraph. Reports components nothing renders, props contracts changed without their callers, reinvented components, and raw values shadowing design tokens. Spawn after UI implementation is complete. Distinct from `mastermind-auditor`, which audits the spec contract.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_symbols_changed_since, mcp__mmcg__mmcg_callers, mcp__mmcg__mmcg_search, mcp__mmcg__mmcg_centrality
 model: sonnet
 mcpServers: [mmcg]
+maxTurns: 15
+effort: medium
 metadata:
-  version: 0.1.0
+  version: 0.1.1
   authors: [mastermind]
   tags: [code-review, frontend, components, mmcg]
 ---

--- a/agents/subagents/mastermind-investigator.md
+++ b/agents/subagents/mastermind-investigator.md
@@ -1,11 +1,13 @@
 ---
 name: mastermind-investigator
 description: Sonnet-tier debugging subagent that structures root-cause investigations using a Hypothesis Ledger — tracks symptoms, known facts, competing hypotheses, evidence for/against each, and one focused next probe. Spawn from a planner when you have a bug or unexpected behavior with an unknown cause. Prevents premature closure by forcing evidence_against before any hypothesis can be confirmed.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_search, mcp__mmcg__mmcg_callers, mcp__mmcg__mmcg_callees, mcp__mmcg__mmcg_impact
 model: sonnet
 mcpServers: [mmcg]
+maxTurns: 20
+effort: high
 metadata:
-  version: 0.1.1
+  version: 0.1.2
   authors:
     - mastermind
   tags:

--- a/agents/subagents/mastermind-prompt-refiner.md
+++ b/agents/subagents/mastermind-prompt-refiner.md
@@ -3,8 +3,10 @@ name: mastermind-prompt-refiner
 description: Read-only handoff normalizer for explicit prompt rewrites or rough requests being sent to a cold agent. Preserves the original request verbatim and does not execute it.
 tools: Read
 model: sonnet
+maxTurns: 4
+effort: low
 metadata:
-  version: 0.4.0
+  version: 0.4.1
   authors: [mastermind]
   tags: [prompt-engineering, workflow]
 ---

--- a/agents/subagents/mastermind-researcher.md
+++ b/agents/subagents/mastermind-researcher.md
@@ -1,11 +1,13 @@
 ---
 name: mastermind-researcher
 description: Read-only Haiku-tier subagent that explores the codebase, reads documentation, and returns structured fact summaries without making decisions. Spawn from a planner when you need to gather facts before designing — bulk grep/read/glob work that doesn't deserve Opus time. Use when you'd otherwise burn the main agent's context on "find all callsites of X" or "list all configs under Y".
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_search, mcp__mmcg__mmcg_callers, mcp__mmcg__mmcg_callees, mcp__mmcg__mmcg_impact, mcp__mmcg__mmcg_imports, mcp__mmcg__mmcg_imported_by
 model: haiku
 mcpServers: [mmcg]
+maxTurns: 12
+effort: low
 metadata:
-  version: 0.2.1
+  version: 0.2.2
   authors:
     - mastermind
   tags:

--- a/agents/subagents/mastermind-security-auditor.md
+++ b/agents/subagents/mastermind-security-auditor.md
@@ -1,11 +1,13 @@
 ---
 name: mastermind-security-auditor
 description: Independent security reviewer for Mastermind specs, agent workflows, MCP tools, auth boundaries, policy enforcement, and high-risk implementation plans. Spawn only when the task touches security, permissions, tools, agent delegation, prompt injection, secrets, auth/authz, supply chain, or when the user explicitly asks for a security audit.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_search, mcp__mmcg__mmcg_callers, mcp__mmcg__mmcg_callees, mcp__mmcg__mmcg_impact, mcp__mmcg__mmcg_imports, mcp__mmcg__mmcg_imported_by, mcp__mmcg__mmcg_change_impact
 model: opus
 mcpServers: [mmcg]
+maxTurns: 18
+effort: high
 metadata:
-  version: 0.1.0
+  version: 0.1.1
   authors:
     - mastermind
   tags:

--- a/agents/subagents/mastermind-task-executor.md
+++ b/agents/subagents/mastermind-task-executor.md
@@ -1,11 +1,13 @@
 ---
 name: mastermind-task-executor
 description: Executes an approved `.mastermind/tasks/<NNN>-<name>/spec.md` within scope, proves its acceptance criteria, and writes the canonical file-backed executor report.
-tools: Read, Edit, Write, Grep, Glob, Bash
+tools: Read, Edit, Write, Grep, Glob, Bash, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_search, mcp__mmcg__mmcg_callers, mcp__mmcg__mmcg_impact
 model: sonnet
 mcpServers: [mmcg]
+maxTurns: 40
+effort: high
 metadata:
-  version: 0.5.1
+  version: 0.5.2
   authors: [mastermind]
   tags: [workflow, delegation]
 ---

--- a/agents/subagents/mastermind-test-auditor.md
+++ b/agents/subagents/mastermind-test-auditor.md
@@ -1,11 +1,13 @@
 ---
 name: mastermind-test-auditor
 description: Independent read-only reviewer of whether a finished change's tests prove its behaviour. Reports changed code no test reaches, a test exercising a different path than the change, an assertion edited to match new output, and non-asserting tests. Spawn after implementation. Distinct from `mastermind-auditor`, which audits the spec contract.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_test_impact, mcp__mmcg__mmcg_callers, mcp__mmcg__mmcg_callees
 model: sonnet
 mcpServers: [mmcg]
+maxTurns: 15
+effort: medium
 metadata:
-  version: 0.1.0
+  version: 0.1.1
   authors: [mastermind]
   tags: [code-review, testing, qa, mmcg]
 ---

--- a/docs/integrations/generic-mcp.md
+++ b/docs/integrations/generic-mcp.md
@@ -13,7 +13,7 @@ dedicated Claude Code, Codex, Cursor, or Continue setup command applies.
 | transport | stdio |
 | command | `mastermind serve` |
 | protocol | MCP 2025-11-25; legacy 2024-11-05 |
-| tools | 28: 27 read-only, 1 additive local write (see below) |
+| tools | 28: 19 refreshable non-destructive queries, 8 read-only queries, 1 additive local write (see below) |
 | resources | none |
 | prompts | none |
 

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -8,7 +8,8 @@ the source of truth for the `mmcg` engine. Start with
 `mmcg` is a Rust binary that builds a local structural index for Python,
 TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++.
 It exposes the same indexed state through CLI, Lens, and MCP. The MCP surface
-contains 28 tools: 27 read-only queries and one additive local scratchpad write.
+contains 28 tools: 19 non-destructive queries that may refresh the managed
+derived index, 8 read-only queries, and one additive local scratchpad write.
 The binary also provides spec gates, client setup, evidence ingestion, review
 export, and style mining.
 
@@ -99,8 +100,9 @@ bounded query surface instead of repeatedly rescanning source text.
   syntactic graph.
 - External producers submit validated facts; they cannot execute inside the
   process or write SQLite.
-- MCP exposes 28 bounded tools: 27 read-only queries and the additive,
-  gitignored `mmcg_scratchpad_append` write.
+- MCP exposes 28 bounded tools: 19 non-destructive queries that may refresh the
+  managed derived index, 8 read-only queries, and the additive, gitignored
+  `mmcg_scratchpad_append` write.
 
 ## Performance model
 
@@ -340,8 +342,9 @@ not prove that every reference is a call. The resolution contract is explicit:
 - OpenTelemetry remains observed runtime corroboration and never creates
   topology.
 
-Use `mmcg query semantic SYMBOL` or the read-only `mmcg_semantic` MCP tool to
-inspect definitions and relationships directly. Lens loads a valid imported
+Use `mmcg query semantic SYMBOL` or the non-destructive `mmcg_semantic` MCP tool
+to inspect definitions and relationships directly. The MCP call may refresh the
+managed derived index first. Lens loads a valid imported
 overlay automatically, shows its producer and precision diagnostics, and only
 decorates exact returned endpoint and display-name pairs. `mmcg map`, callers,
 impact, and all existing tools continue to work unchanged without SCIP.
@@ -455,8 +458,9 @@ and SQLite phases cooperatively observe the request budget/cancel signal.
 Temporal topology is Tree-sitter syntactic evidence in v1; SCIP, runtime,
 coverage, and test overlays keep their separate provenance in Lens.
 
-The same response is available through read-only `mmcg_temporal` and appears in
-Lens below the blast trace. Lens renders bounded identities for component,
+The same response is available through non-destructive `mmcg_temporal`, which
+may refresh the managed derived index first, and appears in Lens below the blast
+trace. Lens renders bounded identities for component,
 boundary/API, cycle, hotspot, ownership, and history events. It isolates a
 bounded temporal-unavailable result so ordinary impact evidence remains usable,
 but a repository, Git, or SQLite snapshot race still fails the refresh.
@@ -839,6 +843,13 @@ The equivalent generic MCP JSON shape is:
 
 Run `mmcg watch` in a separate terminal so the index stays current while you work.
 
+Structural MCP queries also refresh the managed `.mastermind/mmcg.db` on demand
+when source files or the extractor contract drift. The repository root is
+derived from the canonical database path and checked against the stored index
+identity before any refresh. A custom external `--index` remains query-compatible
+when fresh but requires an explicit `mmcg index` when stale. Failed or unavailable
+refreshes return the structured `index_stale` result.
+
 ## MCP tools
 
 | Tool | Args | What it returns |
@@ -870,7 +881,7 @@ Run `mmcg watch` in a separate terminal so the index stays current while you wor
 | `mmcg_history` | `query`, optional `kind`, `top` (default 10) | Searches `CONTEXT.md`, `CONTEXT-archive-*.md`, canonical task specs, executor reports, audits, `.mastermind/releases/*.md`, legacy task-local release notes, lessons, and Markdown architecture decisions under conventional ADR directories. `architecture_decision` is an exact `kind` filter. `candidate` lessons are unresolved signals, not active guidance. Returns observed matches, `skipped_artifacts`, `truncated`, and an explicit retrieval-only epistemic contract. Markdown remains authoritative; re-index after Markdown changes. Each artifact is capped at 1 MiB and the corpus at 5,000 files. |
 | `mmcg_dependency_cycles` | optional `language`, `min_size` (default 2) | Detect circular imports — strongly-connected components in the file-level import graph (Tarjan's algorithm). Each result is a cycle = a list of files. Pre-merge guard ("does this PR introduce a new cycle?") and architectural-hygiene survey. Resolves edges by leaf-name match — over-approximates (two unrelated `Logger` symbols cross-link) so verify before refactoring. Bump `min_size` to hide trivial A↔B and surface only larger structural problems. Work-capped at 50,000 file-pair edges: above that, `truncated: true` with an empty `cycles` list — incomplete and possibly inaccurate, not "more available"; narrow with `language` and retry. |
 | `mmcg_symbols_changed_since` | `git_ref`, optional `root` | Symbol-level diff between a git ref and the current index. Returns `{added, removed, signature_changed}` symbol sets for files in `git diff --name-only <ref>..HEAD`. Re-parses old blobs from `git show <ref>:<path>` using the same extractor. Different from `mmcg_recent_changes` (watcher mtime) — this is git-ref-based, answering "what symbols did THIS PR/branch touch?". PR-review pre-flight, auditor verification, "what new public API appeared in v2.3?". Git subprocesses are killed after `MMCG_GIT_TIMEOUT_MS`; the per-file loop is capped at 10,000 files with `truncated: true` marking a partial diff. |
-| `mmcg_status` | — | Index path, file/symbol counts, and bounded `stale_files`. A non-zero value means re-index before trusting structural answers. |
+| `mmcg_status` | — | Index path, file/symbol counts, and bounded `stale_files`. A non-zero value means the next structural query will refresh a managed index, or that a custom external index needs an explicit `mmcg index`. |
 
 Tool responses are bounded JSON. Collection responses expose their own count or
 collection metadata; status and workflow responses use named fields.

--- a/evals/README.md
+++ b/evals/README.md
@@ -18,8 +18,15 @@ correctness, or evidence that the behavior survives a long real-world task.
 | `fixtures/` | Real Git histories for auditor cases | Exact planted change |
 | `scorecard.md` | Dated full-suite results | Environment and trust notes |
 
-`runner.py` invokes `claude -p`. `test_runner.py` tests the deterministic
-parser, isolation, allowlist, and fixture machinery without calling a model.
+`runner.py` invokes `claude -p`. Auditor cases load the shipped agent through
+Claude's `--agents` / `--agent` runtime contract, so frontmatter tool scoping is
+part of the eval instead of a separate handwritten allowlist. `test_runner.py`
+tests the deterministic parser, isolation, runtime contract, allowlist, and
+fixture machinery without calling a model.
+
+Every case and suite summary reports turns, input/output tokens, prompt-cache
+creation/read tokens, API time, and Claude CLI reported cost. Retries aggregate
+both attempts, so a recovered flaky case does not hide its token spend.
 
 ## Run the right layer
 

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import shutil
@@ -130,7 +131,7 @@ GIT_ENV = {
 # when available so color hints still work in interactive mode.
 _PROC_ENV: dict[str, str] = {**os.environ, "TERM": os.environ.get("TERM") or "dumb"}
 
-AUDITOR_ALLOWED_TOOLS = (
+AUDITOR_SAFE_ALLOWED_TOOLS = (
     "Read",
     "Glob",
     "Grep",
@@ -146,29 +147,6 @@ AUDITOR_ALLOWED_TOOLS = (
     "Bash(git ls-files *)",
     "Bash(git grep *)",
     "Bash(cargo test --locked *)",
-    "mcp__mmcg__mmcg_search",
-    "mcp__mmcg__mmcg_callers",
-    "mcp__mmcg__mmcg_callees",
-    "mcp__mmcg__mmcg_impact",
-    "mcp__mmcg__mmcg_symbols_in_file",
-    "mcp__mmcg__mmcg_outline",
-    "mcp__mmcg__mmcg_files",
-    "mcp__mmcg__mmcg_imports",
-    "mcp__mmcg__mmcg_imported_by",
-    "mcp__mmcg__mmcg_unreferenced",
-    "mcp__mmcg__mmcg_api_surface",
-    "mcp__mmcg__mmcg_symbols_changed_since",
-    "mcp__mmcg__mmcg_dependency_cycles",
-    "mcp__mmcg__mmcg_tasks",
-    "mcp__mmcg__mmcg_history",
-    "mcp__mmcg__mmcg_centrality",
-    "mcp__mmcg__mmcg_map",
-    "mcp__mmcg__mmcg_change_impact",
-    "mcp__mmcg__mmcg_test_impact",
-    "mcp__mmcg__mmcg_recent_changes",
-    "mcp__mmcg__mmcg_status",
-    "mcp__mmcg__mmcg_scratchpad_read",
-    "mcp__mmcg__mmcg_change_class",
 )
 
 
@@ -183,6 +161,24 @@ class Result:
     retry_used: bool = False
     retry_attempted: bool = False
     output_excerpt: str = ""
+    duration_api_ms: int = 0
+    num_turns: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cost_usd: float = 0.0
+
+    def add_attempt(self, prior: "Result") -> None:
+        """Aggregate usage from an earlier attempt into this final result."""
+        self.duration_ms += prior.duration_ms
+        self.duration_api_ms += prior.duration_api_ms
+        self.num_turns += prior.num_turns
+        self.input_tokens += prior.input_tokens
+        self.output_tokens += prior.output_tokens
+        self.cache_creation_input_tokens += prior.cache_creation_input_tokens
+        self.cache_read_input_tokens += prior.cache_read_input_tokens
+        self.cost_usd += prior.cost_usd
 
 
 def strip_frontmatter(text: str) -> str:
@@ -191,6 +187,118 @@ def strip_frontmatter(text: str) -> str:
         if end != -1:
             return text[end + 5 :].lstrip()
     return text
+
+
+def subagent_runtime_definition(
+    path: Path, *, model_override: str | None = None
+) -> tuple[str, dict]:
+    """Translate shipped YAML frontmatter into Claude's `--agents` contract."""
+    if not _YAML_AVAILABLE:
+        raise RuntimeError("PyYAML is required to load subagent frontmatter")
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        raise ValueError(f"subagent has no YAML frontmatter: {path}")
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        raise ValueError(f"subagent frontmatter is not terminated: {path}")
+    loaded = _yaml.safe_load(text[4:end])
+    if not isinstance(loaded, dict):
+        raise ValueError(f"subagent frontmatter is not a mapping: {path}")
+    name = loaded.get("name")
+    description = loaded.get("description")
+    if not isinstance(name, str) or not isinstance(description, str):
+        raise ValueError(f"subagent name/description is invalid: {path}")
+
+    definition: dict = {
+        "description": description,
+        "prompt": text[end + 5 :].lstrip(),
+    }
+    for key in (
+        "tools",
+        "disallowedTools",
+        "model",
+        "mcpServers",
+        "permissionMode",
+        "maxTurns",
+        "skills",
+        "hooks",
+        "memory",
+        "effort",
+    ):
+        if key in loaded:
+            definition[key] = loaded[key]
+    if isinstance(definition.get("tools"), str):
+        definition["tools"] = [
+            tool.strip()
+            for tool in definition["tools"].split(",")
+            if tool.strip()
+        ]
+    if model_override is not None:
+        definition["model"] = model_override
+    return name, definition
+
+
+def subagent_cli_args(path: Path, *, model_override: str) -> list[str]:
+    """Run the eval through the same custom-agent boundary as production."""
+    name, definition = subagent_runtime_definition(
+        path, model_override=model_override
+    )
+    return [
+        "--agents",
+        json.dumps({name: definition}, sort_keys=True),
+        "--agent",
+        name,
+    ]
+
+
+def subagent_mcp_tools(path: Path) -> tuple[str, ...]:
+    _, definition = subagent_runtime_definition(path)
+    tools = definition.get("tools", [])
+    if not isinstance(tools, list):
+        return ()
+    return tuple(
+        tool
+        for tool in tools
+        if isinstance(tool, str) and tool.startswith("mcp__mmcg__")
+    )
+
+
+def auditor_allowed_tools() -> tuple[str, ...]:
+    return AUDITOR_SAFE_ALLOWED_TOOLS + subagent_mcp_tools(
+        SUITES["auditor"]["subagent"]
+    )
+
+
+def _nonnegative_int(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0
+    return max(0, value)
+
+
+def _nonnegative_float(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    result = float(value)
+    return result if math.isfinite(result) and result >= 0 else 0.0
+
+
+def telemetry_from_payload(payload: dict) -> dict[str, int | float]:
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        usage = {}
+    return {
+        "duration_api_ms": _nonnegative_int(payload.get("duration_api_ms")),
+        "num_turns": _nonnegative_int(payload.get("num_turns")),
+        "input_tokens": _nonnegative_int(usage.get("input_tokens")),
+        "output_tokens": _nonnegative_int(usage.get("output_tokens")),
+        "cache_creation_input_tokens": _nonnegative_int(
+            usage.get("cache_creation_input_tokens")
+        ),
+        "cache_read_input_tokens": _nonnegative_int(
+            usage.get("cache_read_input_tokens")
+        ),
+        "cost_usd": _nonnegative_float(payload.get("total_cost_usd")),
+    }
 
 
 # ----- fixture lifecycle ----------------------------------------------------
@@ -342,7 +450,7 @@ def isolated_cli_args(suite_name: str) -> list[str]:
             "--tools",
             "Read,Glob,Grep,Bash",
             "--allowedTools",
-            ",".join(AUDITOR_ALLOWED_TOOLS),
+            ",".join(auditor_allowed_tools()),
             "--setting-sources",
             "",
             "--strict-mcp-config",
@@ -595,9 +703,14 @@ def evaluate_case(
             has_mmcg = db_path.is_file()
             if suite_name == "auditor" and not has_mmcg and not case.get("allow_no_mmcg"):
                 return Result(
-                    case_id, suite_name, False,
-                    ["mmcg index unavailable — build the mmcg binary first (`cargo build --release`)"],
-                    0, fixture_path,
+                    case_id=case_id,
+                    suite=suite_name,
+                    passed=False,
+                    reasons=[
+                        "mmcg index unavailable — build the mmcg binary first "
+                        "(`cargo build --release`)"
+                    ],
+                    fixture_path=fixture_path,
                 )
             user_message = render_auditor_input(
                 case["input"],
@@ -630,7 +743,17 @@ def evaluate_case(
         # Pass the user message via stdin — passing it as a positional arg
         # collides with `--add-dir <directories...>` (variadic), which would
         # swallow the message as another directory.
-        prompt_flag = "--system-prompt" if suite_name == "workflow" else "--append-system-prompt"
+        if suite_name == "auditor":
+            prompt_args: list[str] = []
+            agent_args = subagent_cli_args(prompt_path, model_override=model)
+        else:
+            prompt_flag = (
+                "--system-prompt"
+                if suite_name == "workflow"
+                else "--append-system-prompt"
+            )
+            prompt_args = [prompt_flag, system_prompt]
+            agent_args = []
         workflow_safety = isolated_cli_args(suite_name)
         if requires_prompt_sandbox(suite_name):
             prompt_sandbox = tempfile.TemporaryDirectory(prefix="mastermind-eval-")
@@ -643,7 +766,8 @@ def evaluate_case(
             "claude",
             "-p",
             "--model", model,
-            prompt_flag, system_prompt,
+            *prompt_args,
+            *agent_args,
             "--output-format", "json",
             "--no-session-persistence",
             "--permission-mode", "dontAsk",
@@ -663,27 +787,40 @@ def evaluate_case(
             )
         except subprocess.TimeoutExpired:
             return Result(
-                case_id, suite_name, False, ["timeout after 480s"], 0, fixture_path
+                case_id=case_id,
+                suite=suite_name,
+                passed=False,
+                reasons=["timeout after 480s"],
+                fixture_path=fixture_path,
             )
 
         if proc.returncode != 0:
             err = (proc.stderr or proc.stdout or "").strip()[:300]
             return Result(
-                case_id, suite_name, False,
-                [f"claude exit {proc.returncode}: {err}"], 0, fixture_path,
+                case_id=case_id,
+                suite=suite_name,
+                passed=False,
+                reasons=[f"claude exit {proc.returncode}: {err}"],
+                fixture_path=fixture_path,
             )
 
         permission_denials: list[dict] = []
+        telemetry: dict[str, int | float] = telemetry_from_payload({})
         try:
             payload = json.loads(proc.stdout)
+            if not isinstance(payload, dict):
+                raise ValueError("Claude JSON result is not an object")
             output = payload.get("result", "")
-            duration_ms = int(payload.get("duration_ms", 0))
+            if not isinstance(output, str):
+                output = json.dumps(output, sort_keys=True, ensure_ascii=False)
+            duration_ms = _nonnegative_int(payload.get("duration_ms"))
+            telemetry = telemetry_from_payload(payload)
             raw_denials = payload.get("permission_denials", [])
             if isinstance(raw_denials, list):
                 permission_denials = [
                     denial for denial in raw_denials if isinstance(denial, dict)
                 ]
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, TypeError, ValueError):
             output = proc.stdout
             duration_ms = 0
 
@@ -777,13 +914,22 @@ def evaluate_case(
             )
 
         return Result(
-            case_id,
-            suite_name,
-            passed,
-            reasons,
-            duration_ms,
-            fixture_path,
+            case_id=case_id,
+            suite=suite_name,
+            passed=passed,
+            reasons=reasons,
+            duration_ms=duration_ms,
+            fixture_path=fixture_path,
             output_excerpt=output[:4000],
+            duration_api_ms=int(telemetry["duration_api_ms"]),
+            num_turns=int(telemetry["num_turns"]),
+            input_tokens=int(telemetry["input_tokens"]),
+            output_tokens=int(telemetry["output_tokens"]),
+            cache_creation_input_tokens=int(
+                telemetry["cache_creation_input_tokens"]
+            ),
+            cache_read_input_tokens=int(telemetry["cache_read_input_tokens"]),
+            cost_usd=float(telemetry["cost_usd"]),
         )
     finally:
         if prompt_sandbox is not None:
@@ -852,20 +998,24 @@ def main() -> int:
                     and _SENTINEL_MISSING in r.reasons[0]
                 ):
                     print(f"retry (sentinel missing) ...", end=" ", flush=True)
-                    first_duration_ms = r.duration_ms
                     r2 = evaluate_case(
                         args.model, suite_name, suite_cfg, case,
                         keep_fixtures=args.keep_fixtures,
                     )
                     r2.retry_attempted = True
-                    r2.duration_ms += first_duration_ms
+                    r2.add_attempt(r)
                     if r2.passed:
                         r2.retry_used = True
                     r = r2
                 results.append(r)
                 status = "✓ pass" if r.passed else "✗ FAIL"
                 retry_tag = " [retry]" if r.retry_used else ""
-                print(f"{status}{retry_tag}  ({r.duration_ms}ms)")
+                print(
+                    f"{status}{retry_tag}  ({r.duration_ms}ms, {r.num_turns} turns, "
+                    f"tokens {r.input_tokens} in/{r.output_tokens} out, "
+                    f"cache {r.cache_creation_input_tokens} write/"
+                    f"{r.cache_read_input_tokens} read, ${r.cost_usd:.4f})"
+                )
                 if args.keep_fixtures and r.fixture_path is not None:
                     print(f"      fixture: {r.fixture_path}")
                 for reason in r.reasons:
@@ -885,6 +1035,13 @@ def main() -> int:
     n_retry_attempted = sum(r.retry_attempted for r in results)
     n_retry_pass = sum(r.passed and r.retry_used for r in results)
     total_ms = sum(r.duration_ms for r in results)
+    total_api_ms = sum(r.duration_api_ms for r in results)
+    total_turns = sum(r.num_turns for r in results)
+    total_input = sum(r.input_tokens for r in results)
+    total_output = sum(r.output_tokens for r in results)
+    total_cache_creation = sum(r.cache_creation_input_tokens for r in results)
+    total_cache_read = sum(r.cache_read_input_tokens for r in results)
+    total_cost = sum(r.cost_usd for r in results)
     print(f"\n=== summary ===")
     print(f"  passed: {n_pass}/{len(results)}")
     print(f"  first_pass: {n_first_pass}/{len(results)}")
@@ -893,6 +1050,13 @@ def main() -> int:
     if n_retry_pass:
         print(f"  after_retry: {n_first_pass + n_retry_pass}/{len(results)} ({n_retry_pass} case(s) passed on retry)")
     print(f"  total time: {total_ms / 1000:.1f}s")
+    print(f"  API time: {total_api_ms / 1000:.1f}s across {total_turns} turns")
+    print(
+        "  tokens: "
+        f"{total_input} input, {total_output} output, "
+        f"{total_cache_creation} cache write, {total_cache_read} cache read"
+    )
+    print(f"  reported cost: ${total_cost:.4f}")
     return 0 if n_fail == 0 else 1
 
 

--- a/evals/test_runner.py
+++ b/evals/test_runner.py
@@ -60,6 +60,65 @@ action: passthrough
         result = runner.Result("case", "workflow", False, output_excerpt="x" * 4000)
         self.assertEqual(len(result.output_excerpt), 4000)
 
+    def test_cli_usage_telemetry_is_parsed_without_guessing(self):
+        telemetry = runner.telemetry_from_payload(
+            {
+                "duration_api_ms": 1234,
+                "num_turns": 3,
+                "total_cost_usd": 0.0125,
+                "usage": {
+                    "input_tokens": 101,
+                    "output_tokens": 202,
+                    "cache_creation_input_tokens": 303,
+                    "cache_read_input_tokens": 404,
+                },
+            }
+        )
+        self.assertEqual(telemetry["duration_api_ms"], 1234)
+        self.assertEqual(telemetry["num_turns"], 3)
+        self.assertEqual(telemetry["input_tokens"], 101)
+        self.assertEqual(telemetry["output_tokens"], 202)
+        self.assertEqual(telemetry["cache_creation_input_tokens"], 303)
+        self.assertEqual(telemetry["cache_read_input_tokens"], 404)
+        self.assertEqual(telemetry["cost_usd"], 0.0125)
+
+    def test_retry_usage_is_aggregated_across_both_attempts(self):
+        first = runner.Result(
+            "case",
+            "auditor",
+            False,
+            duration_ms=100,
+            duration_api_ms=80,
+            num_turns=2,
+            input_tokens=10,
+            output_tokens=20,
+            cache_creation_input_tokens=30,
+            cache_read_input_tokens=40,
+            cost_usd=0.01,
+        )
+        second = runner.Result(
+            "case",
+            "auditor",
+            True,
+            duration_ms=200,
+            duration_api_ms=160,
+            num_turns=3,
+            input_tokens=11,
+            output_tokens=21,
+            cache_creation_input_tokens=31,
+            cache_read_input_tokens=41,
+            cost_usd=0.02,
+        )
+        second.add_attempt(first)
+        self.assertEqual(second.duration_ms, 300)
+        self.assertEqual(second.duration_api_ms, 240)
+        self.assertEqual(second.num_turns, 5)
+        self.assertEqual(second.input_tokens, 21)
+        self.assertEqual(second.output_tokens, 41)
+        self.assertEqual(second.cache_creation_input_tokens, 61)
+        self.assertEqual(second.cache_read_input_tokens, 81)
+        self.assertAlmostEqual(second.cost_usd, 0.03)
+
     def test_alternative_phrases_accept_equivalent_wording(self):
         self.assertTrue(
             runner.contains_any_phrase("No spec file is needed.", ["no task spec", "no spec file"])
@@ -114,6 +173,7 @@ class PromptIsolationTests(unittest.TestCase):
             "Bash(git diff *)",
             "Bash(git status *)",
             "Bash(cargo test --locked *)",
+            "mcp__mmcg__mmcg_status",
             "mcp__mmcg__mmcg_search",
             "mcp__mmcg__mmcg_callers",
             "mcp__mmcg__mmcg_impact",
@@ -123,6 +183,37 @@ class PromptIsolationTests(unittest.TestCase):
         self.assertNotIn("Bash(cargo *)", allowed)
         self.assertNotIn("Bash(cargo test *)", allowed)
         self.assertFalse(runner.requires_prompt_sandbox("auditor"))
+
+    def test_auditor_eval_uses_the_shipped_agent_runtime_contract(self):
+        path = runner.SUITES["auditor"]["subagent"]
+        name, definition = runner.subagent_runtime_definition(
+            path, model_override="sonnet"
+        )
+        self.assertEqual(name, "mastermind-auditor")
+        self.assertEqual(definition["model"], "sonnet")
+        self.assertEqual(definition["mcpServers"], ["mmcg"])
+        self.assertEqual(definition["maxTurns"], 20)
+        self.assertEqual(definition["effort"], "high")
+        self.assertIn("mcp__mmcg__mmcg_search", definition["tools"])
+        self.assertNotIn("mcp__mmcg__*", definition["tools"])
+        self.assertIn("# Mastermind auditor", definition["prompt"])
+
+        args = runner.subagent_cli_args(path, model_override="sonnet")
+        self.assertEqual(args[-2:], ["--agent", "mastermind-auditor"])
+        payload = json.loads(args[args.index("--agents") + 1])
+        self.assertEqual(payload["mastermind-auditor"]["maxTurns"], 20)
+
+    def test_every_scoped_shipped_agent_grants_exact_mmcg_tools(self):
+        for path in (runner.REPO_ROOT / "agents/subagents").glob("*.md"):
+            _, definition = runner.subagent_runtime_definition(path)
+            if "mmcg" not in definition.get("mcpServers", []):
+                continue
+            tools = definition.get("tools", [])
+            self.assertTrue(
+                any(tool.startswith("mcp__mmcg__mmcg_") for tool in tools),
+                path.name,
+            )
+            self.assertNotIn("mcp__mmcg__*", tools, path.name)
 
     def test_auditor_runs_inside_its_disposable_fixture(self):
         fixture = runner.REPO_ROOT / "evals/fixtures/fake-session"

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -7,7 +7,7 @@ Mastermind currently ships one server:
 
 | Server | Transport | Surface |
 |---|---|---|
-| [`mmcg`](servers/mmcg/README.md) | stdio | 28 bounded tools over a local SQLite index: 27 read-only queries and one additive scratchpad write |
+| [`mmcg`](servers/mmcg/README.md) | stdio | 28 bounded tools over a local SQLite index: 19 refreshable non-destructive queries, 8 read-only queries, and one additive scratchpad write |
 
 The server supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#,
 Go, Java, PHP, and C/C++. It exposes structural, semantic, evidence, history,

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -82,6 +82,11 @@ reports bounded path samples for skipped inputs. It automatically rebuilds when
 stored extractor semantics are incompatible. Use `mmcg watch` to keep it
 refreshed while editing.
 
+Structural MCP queries refresh the managed `.mastermind/mmcg.db` on demand
+before querying. The canonical database path, not mutable SQLite metadata,
+selects the repository root. Custom external indexes remain manual-refresh-only;
+failed or unavailable refreshes return a structured `index_stale` result.
+
 Run the stdio MCP server directly:
 
 ```bash
@@ -111,9 +116,10 @@ See the [client integration guides](https://github.com/xcrft/mastermind/tree/mai
 | Workflow gates | `verify-spec`, `audit-spec`, and `run-task` |
 | Local coordination | Bounded additive scratchpad and indexed project history |
 
-The MCP surface contains 27 read-only tools and one additive local scratchpad
-write. Results are bounded and return precision or truncation notes when the
-engine cannot prove completeness.
+The MCP surface contains 19 non-destructive queries that may refresh the managed
+derived index, 8 read-only tools, and one additive local scratchpad write.
+Results are bounded and return precision or truncation notes when the engine
+cannot prove completeness.
 
 ## Supported languages
 

--- a/mcp/servers/mmcg/src/doctor.rs
+++ b/mcp/servers/mmcg/src/doctor.rs
@@ -13,12 +13,13 @@
 //! | 3 | `index repository`     | selected index belongs to the requested repository     |
 //! | 4 | `symbols indexed`      | non-empty index (catches "I ran init but not index")   |
 //! | 5 | `index freshness`      | no source file newer than the index                    |
-//! | 5 | `gitignore`            | `.mastermind/` is excluded from VCS                    |
-//! | 6 | `CLAUDE.md`            | exists and references the workflow                     |
-//! | 7 | `MCP config`           | mmcg registered in `~/.claude.json` (user) or `./.mcp.json` (project) |
-//! | 8 | `MCP serve handshake`  | spawning `mastermind serve` responds to `initialize` + `tools/list` |
-//! | 9 | `subagent MCP scoping` | every subagent `mcpServers:` entry names a registered server |
-//! | 10 | `style profile`       | author's `~/.mastermind/style.md` has fallen behind their commits |
+//! | 6 | `gitignore`            | `.mastermind/` is excluded from VCS                    |
+//! | 7 | `CLAUDE.md`            | exists and references the workflow                     |
+//! | 8 | `MCP config`           | mmcg registered in `~/.claude.json` (user) or `./.mcp.json` (project) |
+//! | 9 | `MCP serve handshake`  | spawning `mastermind serve` responds to `initialize` + `tools/list` |
+//! | 10 | `subagent MCP scoping` | every subagent `mcpServers:` entry names a registered server |
+//! | 11 | `subagent MCP tools`   | scoped agents' explicit tool allowlists grant mmcg access |
+//! | 12 | `style profile`        | author's `~/.mastermind/style.md` has fallen behind their commits |
 //!
 //! Human-readable by default; `--json` switches to a machine-parseable format.
 
@@ -196,6 +197,7 @@ pub fn run_with_index(root: &Path, mmcg_binary: &Path, index_path: &Path) -> Rep
         check_mcp_config(root),
         check_mcp_handshake(index_path, mmcg_binary),
         check_subagent_mcp_servers(root),
+        check_subagent_mcp_tools(root),
         check_style_profile(root),
     ];
     Report::from_checks(root, checks)
@@ -525,6 +527,33 @@ fn check_mcp_config(root: &Path) -> Check {
     )
 }
 
+/// Native client registrars may materialize protocol defaults that are
+/// semantically identical to the compact entry emitted by `setup`. Claude's
+/// CLI currently adds `type = "stdio"` and an empty `env` object. Ignore only
+/// those two exact defaults; any command, argument, environment, transport, or
+/// unknown-field change remains customized.
+fn mcp_entries_equivalent(left: &serde_json::Value, right: &serde_json::Value) -> bool {
+    fn without_native_defaults(value: &serde_json::Value) -> serde_json::Value {
+        let mut normalized = value.clone();
+        let Some(object) = normalized.as_object_mut() else {
+            return normalized;
+        };
+        if object.get("type").and_then(serde_json::Value::as_str) == Some("stdio") {
+            object.remove("type");
+        }
+        if object
+            .get("env")
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(serde_json::Map::is_empty)
+        {
+            object.remove("env");
+        }
+        normalized
+    }
+
+    without_native_defaults(left) == without_native_defaults(right)
+}
+
 fn check_mcp_config_at(root: &Path, home: Option<&Path>, canonical: &serde_json::Value) -> Check {
     let mut statuses = Vec::new();
     let mut canonical_found = false;
@@ -544,7 +573,7 @@ fn check_mcp_config_at(root: &Path, home: Option<&Path>, canonical: &serde_json:
             config_found = true;
         }
         let status = match crate::setup::read_json_mmcg(&path) {
-            Ok(Some(entry)) if entry == *canonical => {
+            Ok(Some(entry)) if mcp_entries_equivalent(&entry, canonical) => {
                 canonical_found = true;
                 "canonical"
             }
@@ -607,7 +636,7 @@ fn check_mcp_config_at(root: &Path, home: Option<&Path>, canonical: &serde_json:
                 .transpose()
                 .map(Option::flatten)
         }) {
-            Ok(Some(entry)) if entry == *canonical => {
+            Ok(Some(entry)) if mcp_entries_equivalent(&entry, canonical) => {
                 canonical_found = true;
                 "canonical"
             }
@@ -943,6 +972,36 @@ fn subagent_mcp_refs(md: &str) -> Vec<String> {
     }
 }
 
+/// Claude Code's explicit subagent `tools:` allowlist. `None` means the field
+/// is absent and the runtime inherits the parent tool surface. A malformed
+/// value becomes an empty explicit allowlist so doctor fails safe.
+fn subagent_tool_allowlist(md: &str) -> Option<Vec<String>> {
+    let fm = frontmatter_block(md)?;
+    let Ok(v) = serde_norway::from_str::<serde_norway::Value>(fm) else {
+        return Some(vec![]);
+    };
+    match v.get("tools") {
+        None => None,
+        Some(serde_norway::Value::String(value)) => Some(
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(String::from)
+                .collect(),
+        ),
+        Some(serde_norway::Value::Sequence(values)) => Some(
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::trim))
+                .filter(|value| !value.is_empty())
+                .map(String::from)
+                .collect(),
+        ),
+        Some(_) => Some(vec![]),
+    }
+}
+
 /// Pure core of `check_subagent_mcp_servers`: scan `agent_dirs` for subagent
 /// `.md` files; return `(any_declared, sorted unregistered "server (in file)"
 /// descriptions)`. Split out so tests use a controlled directory, not the real
@@ -1013,6 +1072,85 @@ fn check_subagent_mcp_servers(root: &Path) -> Check {
         ),
         hint: Some(
             "register it (project `.mcp.json` / `mastermind setup claude --write-mcp`) or drop the `mcpServers:` entry"
+                .into(),
+        ),
+    }
+}
+
+/// Return scoped mmcg agents whose explicit `tools:` allowlist makes every
+/// mmcg tool unavailable. This is separate from server registration: a server
+/// can be configured correctly while Claude silently filters all its tools.
+fn subagent_mmcg_tool_issues(agent_dirs: &[PathBuf]) -> (bool, Vec<String>) {
+    let mut scoped = false;
+    let mut inaccessible = Vec::new();
+    for dir in agent_dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("md") {
+                continue;
+            }
+            let body = std::fs::read_to_string(&path).unwrap_or_default();
+            if !subagent_mcp_refs(&body)
+                .iter()
+                .any(|server| server == "mmcg")
+            {
+                continue;
+            }
+            scoped = true;
+            let Some(tools) = subagent_tool_allowlist(&body) else {
+                continue;
+            };
+            if !tools.iter().any(|tool| {
+                tool.strip_prefix("mcp__mmcg__")
+                    .is_some_and(crate::mcp::is_known_tool)
+            }) {
+                let filename = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("?");
+                inaccessible.push(filename.to_string());
+            }
+        }
+    }
+    inaccessible.sort();
+    inaccessible.dedup();
+    (scoped, inaccessible)
+}
+
+fn check_subagent_mcp_tools(root: &Path) -> Check {
+    let mut agent_dirs = vec![root.join(".claude").join("agents")];
+    if let Some(home) = std::env::home_dir() {
+        agent_dirs.push(home.join(".claude").join("agents"));
+    }
+    let (scoped, inaccessible) = subagent_mmcg_tool_issues(&agent_dirs);
+    if !scoped {
+        return Check {
+            name: "subagent MCP tools",
+            status: Status::Ok,
+            message: "no subagent scopes mmcg — nothing to verify".into(),
+            hint: None,
+        };
+    }
+    if inaccessible.is_empty() {
+        return Check {
+            name: "subagent MCP tools",
+            status: Status::Ok,
+            message: "scoped subagent allowlists grant mmcg tools".into(),
+            hint: None,
+        };
+    }
+    Check {
+        name: "subagent MCP tools",
+        status: Status::Warn,
+        message: format!(
+            "explicit `tools:` blocks mmcg in {}",
+            inaccessible.join(", ")
+        ),
+        hint: Some(
+            "add exact `mcp__mmcg__mmcg_*` permissions to each agent's top-level `tools:` allowlist"
                 .into(),
         ),
     }
@@ -1211,10 +1349,20 @@ mod tests {
                 )
                 .unwrap();
             } else {
+                let entry = if label == "claude-user" {
+                    serde_json::json!({
+                        "type": "stdio",
+                        "command": "/trusted/mmcg",
+                        "args": ["serve"],
+                        "env": {},
+                    })
+                } else {
+                    canonical.clone()
+                };
                 fs::write(
                     &path,
                     serde_json::to_vec(&serde_json::json!({
-                        "mcpServers": {"mmcg": canonical.clone()}
+                        "mcpServers": {"mmcg": entry}
                     }))
                     .unwrap(),
                 )
@@ -1226,6 +1374,40 @@ mod tests {
             fs::remove_dir_all(root).ok();
             fs::remove_dir_all(home).ok();
         }
+    }
+
+    #[test]
+    fn mcp_entry_equivalence_ignores_only_native_stdio_defaults() {
+        let canonical = serde_json::json!({
+            "command": "/trusted/mmcg",
+            "args": ["serve"],
+        });
+        assert!(mcp_entries_equivalent(
+            &serde_json::json!({
+                "type": "stdio",
+                "command": "/trusted/mmcg",
+                "args": ["serve"],
+                "env": {},
+            }),
+            &canonical,
+        ));
+        assert!(!mcp_entries_equivalent(
+            &serde_json::json!({
+                "type": "stdio",
+                "command": "/trusted/mmcg",
+                "args": ["serve"],
+                "env": {"TOKEN": "changed"},
+            }),
+            &canonical,
+        ));
+        assert!(!mcp_entries_equivalent(
+            &serde_json::json!({
+                "type": "sse",
+                "command": "/trusted/mmcg",
+                "args": ["serve"],
+            }),
+            &canonical,
+        ));
     }
 
     #[test]
@@ -1436,6 +1618,59 @@ mod tests {
         assert!(subagent_mcp_refs(none).is_empty());
         let no_fm = "# heading only\n";
         assert!(subagent_mcp_refs(no_fm).is_empty());
+    }
+
+    #[test]
+    fn subagent_tool_allowlist_parses_scalar_list_and_inheritance() {
+        let scalar = "---\nname: r\ntools: Read, mcp__mmcg__mmcg_search\n---\nbody";
+        assert_eq!(
+            subagent_tool_allowlist(scalar),
+            Some(vec![
+                "Read".to_string(),
+                "mcp__mmcg__mmcg_search".to_string()
+            ])
+        );
+        let list = "---\nname: r\ntools: [Read, mcp__mmcg__mmcg_status]\n---\nbody";
+        assert_eq!(
+            subagent_tool_allowlist(list),
+            Some(vec![
+                "Read".to_string(),
+                "mcp__mmcg__mmcg_status".to_string()
+            ])
+        );
+        let inherited = "---\nname: r\nmcpServers: [mmcg]\n---\nbody";
+        assert_eq!(subagent_tool_allowlist(inherited), None);
+    }
+
+    #[test]
+    fn subagent_mmcg_tool_issues_catches_explicit_allowlist_block() {
+        let root = tmp();
+        let agents = root.join("agents");
+        fs::create_dir_all(&agents).unwrap();
+        fs::write(
+            agents.join("blocked.md"),
+            "---\nname: blocked\ntools: Read, Grep\nmcpServers: [mmcg]\n---\nbody",
+        )
+        .unwrap();
+        fs::write(
+            agents.join("working.md"),
+            "---\nname: working\ntools: Read, mcp__mmcg__mmcg_search\nmcpServers: [mmcg]\n---\nbody",
+        )
+        .unwrap();
+        fs::write(
+            agents.join("unknown.md"),
+            "---\nname: unknown\ntools: Read, mcp__mmcg__mmcg_not_a_tool\nmcpServers: [mmcg]\n---\nbody",
+        )
+        .unwrap();
+
+        let (scoped, inaccessible) = subagent_mmcg_tool_issues(std::slice::from_ref(&agents));
+        assert!(scoped);
+        assert_eq!(
+            inaccessible,
+            vec!["blocked.md".to_string(), "unknown.md".to_string()]
+        );
+
+        fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/indexer.rs
+++ b/mcp/servers/mmcg/src/indexer.rs
@@ -249,6 +249,7 @@ impl Indexer {
     /// Files in the index but gone from disk are purged at the end. Writes to `store`.
     pub fn index_all(&self, store: &mut Store, force_full: bool) -> Result<IndexStats, IndexError> {
         let start = SystemTime::now();
+        ensure_indexing_active(store)?;
         self.bind_or_validate_index_root(store)?;
         let stored_extractor_contract = store
             .meta_value(EXTRACTOR_CONTRACT_META_KEY)
@@ -264,6 +265,7 @@ impl Indexer {
 
         // Phase 1: walk filesystem
         let candidates = source_candidates(&self.root);
+        ensure_indexing_active(store)?;
 
         let mut stats = IndexStats {
             files_scanned: candidates.len() as u32,
@@ -277,6 +279,7 @@ impl Indexer {
             std::collections::HashSet::with_capacity(candidates.len());
 
         for path in &candidates {
+            ensure_indexing_active(store)?;
             let rel = path
                 .strip_prefix(&self.root)
                 .unwrap_or(path)
@@ -329,6 +332,7 @@ impl Indexer {
         // SQLite's single writer before parsing the next batch. The old all-at-once
         // collection retained every PendingFile until parsing the whole repository.
         for batch in to_parse.chunks(PARSE_BATCH_SIZE) {
+            ensure_indexing_active(store)?;
             let parsed: Vec<(PathBuf, Result<PendingFile, IndexError>)> = batch
                 .par_iter()
                 .filter_map(|path| {
@@ -339,8 +343,10 @@ impl Indexer {
                     ))
                 })
                 .collect();
+            ensure_indexing_active(store)?;
 
             for (path, outcome) in parsed {
+                ensure_indexing_active(store)?;
                 let rel = path
                     .strip_prefix(&self.root)
                     .unwrap_or(&path)
@@ -373,8 +379,10 @@ impl Indexer {
 
         // Phase 5: purge orphans (in index, no longer on disk). Safe only after a
         // FULL root scan — a partial scan would wrongly purge the unscanned subtree.
+        ensure_indexing_active(store)?;
         if let Ok(indexed) = store.indexed_paths() {
             for path in indexed {
+                ensure_indexing_active(store)?;
                 if !current_paths.contains(&path) && store.purge_file(&path).is_ok() {
                     stats.files_purged += 1;
                 }
@@ -387,15 +395,18 @@ impl Indexer {
         // layout, both excluded). Whole-corpus replace — spec sets are small
         // (<100 files), so atomic replace beats delta tracking and avoids stale
         // entries on rename/delete.
+        ensure_indexing_active(store)?;
         if let Ok(count) = self.index_task_specs(store) {
             stats.task_specs_indexed = count;
         }
+        ensure_indexing_active(store)?;
         let history = self.index_project_history(store)?;
         stats.history_entries_indexed = history.indexed;
         stats.history_entries_skipped = history.skipped;
         stats.history_entries_truncated = history.truncated;
 
         if stats.files_failed == 0 {
+            ensure_indexing_active(store)?;
             store
                 .set_meta(EXTRACTOR_CONTRACT_META_KEY, EXTRACTOR_CONTRACT_VERSION)
                 .map_err(|error| IndexError::Other(error.to_string()))?;
@@ -415,6 +426,7 @@ impl Indexer {
     /// `_`-prefixed files (e.g. `_lessons.md`) are shared assets, excluded from
     /// search.
     pub fn index_task_specs(&self, store: &mut Store) -> Result<u32, IndexError> {
+        ensure_indexing_active(store)?;
         let tasks_dir = self.root.join(".mastermind").join("tasks");
         if !tasks_dir.is_dir() {
             // No `.mastermind/tasks/` — clear any stale entries from a prior run too.
@@ -426,6 +438,7 @@ impl Indexer {
 
         let mut entries: Vec<crate::store::TaskSpecEntry> = Vec::new();
         for dirent in std::fs::read_dir(&tasks_dir).map_err(|e| IndexError::Io(e.to_string()))? {
+            ensure_indexing_active(store)?;
             let dirent = dirent.map_err(|e| IndexError::Io(e.to_string()))?;
             let path = dirent.path();
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
@@ -453,6 +466,7 @@ impl Indexer {
             });
         }
         let count = entries.len() as u32;
+        ensure_indexing_active(store)?;
         store
             .replace_task_specs(&entries)
             .map_err(|e| IndexError::Other(e.to_string()))?;
@@ -466,6 +480,7 @@ impl Indexer {
         &self,
         store: &mut Store,
     ) -> Result<ProjectHistoryIndexStats, IndexError> {
+        ensure_indexing_active(store)?;
         self.bind_or_validate_index_root(store)?;
         let mut candidates: Vec<(PathBuf, &'static str)> = Vec::new();
         {
@@ -477,6 +492,7 @@ impl Indexer {
             add_if_present(self.root.join("CONTEXT.md"), "context");
             if let Ok(entries) = std::fs::read_dir(&self.root) {
                 for entry in entries.flatten() {
+                    ensure_indexing_active(store)?;
                     let path = entry.path();
                     let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
                         continue;
@@ -493,6 +509,7 @@ impl Indexer {
                 for dirent in std::fs::read_dir(&tasks_dir)
                     .map_err(|error| IndexError::Io(error.to_string()))?
                 {
+                    ensure_indexing_active(store)?;
                     let dirent = dirent.map_err(|error| IndexError::Io(error.to_string()))?;
                     let path = dirent.path();
                     let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
@@ -518,6 +535,7 @@ impl Indexer {
             let releases_dir = self.root.join(".mastermind").join("releases");
             if let Ok(entries) = std::fs::read_dir(&releases_dir) {
                 for entry in entries.flatten() {
+                    ensure_indexing_active(store)?;
                     let path = entry.path();
                     let is_markdown =
                         path.extension().and_then(|value| value.to_str()) == Some("md");
@@ -540,6 +558,7 @@ impl Indexer {
         let mut decision_directories = 0usize;
         let mut decision_truncated = false;
         for decision_root in decision_roots {
+            ensure_indexing_active(store)?;
             decision_truncated |= add_markdown_tree_candidates(
                 &decision_root,
                 "architecture_decision",
@@ -555,6 +574,7 @@ impl Indexer {
         let mut entries = Vec::new();
         let mut skipped = 0_u32;
         for (path, kind) in candidates {
+            ensure_indexing_active(store)?;
             let Ok(metadata) = std::fs::symlink_metadata(&path) else {
                 skipped += 1;
                 continue;
@@ -588,6 +608,7 @@ impl Indexer {
             });
         }
         let count = entries.len() as u32;
+        ensure_indexing_active(store)?;
         store
             .replace_project_history(&entries)
             .map_err(|error| IndexError::Other(error.to_string()))?;
@@ -609,9 +630,11 @@ impl Indexer {
 
     /// Re-index a single file. Used by the watcher.
     pub fn index_one(&self, store: &mut Store, path: &Path) -> Result<(), IndexError> {
+        ensure_indexing_active(store)?;
         let extractor = extractor_for_path(path)
             .ok_or_else(|| IndexError::Parse(format!("no extractor for {path:?}")))?;
         let pending = parse_one(path, &self.root, extractor.as_ref())?;
+        ensure_indexing_active(store)?;
         store
             .commit_file(pending)
             .map_err(|e| IndexError::Other(e.to_string()))
@@ -1033,6 +1056,14 @@ pub enum IndexError {
     Skipped(IndexSkipReason),
 }
 
+fn ensure_indexing_active(store: &Store) -> Result<(), IndexError> {
+    if store.work_interrupted() {
+        Err(IndexError::Other("indexing interrupted".to_string()))
+    } else {
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IndexSkipReason {
     Binary,
@@ -1109,6 +1140,28 @@ mod incremental_tests {
             second.files_unchanged, 2,
             "both files should be marked unchanged"
         );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn cancellation_stops_indexing_before_derived_state_changes() {
+        let (dir, db) = setup("cancel_before_index");
+        fs::write(dir.join("a.py"), "def foo(): pass\n").unwrap();
+
+        let mut store = Store::open(&db).unwrap();
+        let indexer = Indexer::new(&dir);
+        indexer.index_all(&mut store, false).unwrap();
+        fs::write(dir.join("b.py"), "def bar(): pass\n").unwrap();
+
+        store.cancel_handle().cancel();
+        let error = indexer.index_all(&mut store, false).unwrap_err();
+        assert!(error.to_string().contains("indexing interrupted"));
+        assert_eq!(
+            store.take_interrupt_source(),
+            Some(crate::store::InterruptSource::Cancel)
+        );
+        assert_eq!(store.file_count().unwrap(), 1);
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/mcp/servers/mmcg/src/mcp.rs
+++ b/mcp/servers/mmcg/src/mcp.rs
@@ -104,7 +104,13 @@ enum Frame {
 #[derive(Debug)]
 enum HandlerError {
     InvalidArguments(String),
-    Internal { class: &'static str },
+    IndexStale {
+        stale_files: usize,
+        extractor_contract_current: bool,
+    },
+    Internal {
+        class: &'static str,
+    },
 }
 
 impl HandlerError {
@@ -252,6 +258,29 @@ static TOOLS: &[ToolDef] = &[
         handle_change_class,
     ),
 ];
+
+pub(crate) fn is_known_tool(name: &str) -> bool {
+    TOOLS.iter().any(|tool| tool.name == name)
+}
+
+/// Structural graph answers are trustworthy only while the index matches the
+/// repository. A small set of diagnostic, revision-bound, and additive tools
+/// remains available so clients can inspect or recover from stale state.
+#[cfg(test)]
+fn tool_requires_fresh_index(name: &str) -> bool {
+    !matches!(
+        name,
+        "mmcg_tasks"
+            | "mmcg_history"
+            | "mmcg_facts"
+            | "mmcg_team_map"
+            | "mmcg_recent_changes"
+            | "mmcg_status"
+            | "mmcg_scratchpad_append"
+            | "mmcg_scratchpad_read"
+            | "mmcg_change_class"
+    )
+}
 
 /// `Stdin` itself is `Send + 'static` (unlike its lock guard) — wrapping it
 /// this way lets the `serve_io` reader thread own an input source without
@@ -1007,11 +1036,40 @@ fn handle_tools_call_inner(
                 HandlerError::InvalidArguments(message) => {
                     tool_result(version, json!({ "error": message }), true)
                 }
+                HandlerError::IndexStale {
+                    stale_files,
+                    extractor_contract_current,
+                } => tool_result(
+                    version,
+                    index_stale_payload(stale_files, extractor_contract_current),
+                    true,
+                ),
                 HandlerError::Internal { class } => Err(ToolCallError::Internal { class }),
             },
         },
         None => tool_result(version, work_limit_payload(budget), true),
     }
+}
+
+fn index_stale_payload(stale_files: usize, extractor_contract_current: bool) -> Value {
+    json!({
+        "code": "index_stale",
+        "stale_files": stale_files,
+        "extractor_contract_current": extractor_contract_current,
+        "guidance": "run `mastermind index .` before using structural mmcg tools"
+    })
+}
+
+fn ensure_fresh_index(store: &Store) -> Result<(), HandlerError> {
+    let status = queries::status(store)
+        .map_err(|error| HandlerError::internal("index_freshness_query", error))?;
+    if status.stale_files > 0 || !status.extractor_contract_current {
+        return Err(HandlerError::IndexStale {
+            stale_files: status.stale_files,
+            extractor_contract_current: status.extractor_contract_current,
+        });
+    }
+    Ok(())
 }
 
 /// Structured `work_limit_exceeded` tool error — mirrors the `change_impact`
@@ -1599,6 +1657,7 @@ fn handle_search(store: &mut Store, args: &Value) -> Result<Value, HandlerError>
     let kind = opt_str_arg(args, "kind");
     let language = opt_str_arg(args, "language");
     let collapse = opt_bool_arg(args, "collapse_partials").unwrap_or(true);
+    ensure_fresh_index(store)?;
     let r = queries::search(store, name, kind, language, collapse)
         .map_err(|error| HandlerError::internal("search_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1608,6 +1667,7 @@ fn handle_callers(store: &mut Store, args: &Value) -> Result<Value, HandlerError
     let name = str_arg(args, "name")?;
     let language = opt_str_arg(args, "language");
     let edge_kind = opt_str_arg(args, "edge_kind");
+    ensure_fresh_index(store)?;
     let r = queries::callers(store, name, language, edge_kind)
         .map_err(|error| HandlerError::internal("callers_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1617,6 +1677,7 @@ fn handle_callees(store: &mut Store, args: &Value) -> Result<Value, HandlerError
     let name = str_arg(args, "name")?;
     let language = opt_str_arg(args, "language");
     let edge_kind = opt_str_arg(args, "edge_kind");
+    ensure_fresh_index(store)?;
     let r = queries::callees(store, name, language, edge_kind)
         .map_err(|error| HandlerError::internal("callees_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1626,6 +1687,7 @@ fn handle_impact(store: &mut Store, args: &Value) -> Result<Value, HandlerError>
     let name = str_arg(args, "name")?;
     let max_depth = args.get("max_depth").and_then(|v| v.as_u64()).unwrap_or(2) as u32;
     let language = opt_str_arg(args, "language");
+    ensure_fresh_index(store)?;
     let r = queries::impact(store, name, max_depth, language)
         .map_err(|error| HandlerError::internal("impact_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1633,6 +1695,7 @@ fn handle_impact(store: &mut Store, args: &Value) -> Result<Value, HandlerError>
 
 fn handle_symbols_in_file(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
     let file = str_arg(args, "file")?;
+    ensure_fresh_index(store)?;
     let r = queries::symbols_in_file(store, file)
         .map_err(|error| HandlerError::internal("symbols_in_file_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1640,6 +1703,7 @@ fn handle_symbols_in_file(store: &mut Store, args: &Value) -> Result<Value, Hand
 
 fn handle_outline(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
     let file = str_arg(args, "file")?;
+    ensure_fresh_index(store)?;
     let r = queries::outline(store, file)
         .map_err(|error| HandlerError::internal("outline_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1648,6 +1712,7 @@ fn handle_outline(store: &mut Store, args: &Value) -> Result<Value, HandlerError
 fn handle_files(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
     let prefix = opt_str_arg(args, "prefix");
     let language = opt_str_arg(args, "language");
+    ensure_fresh_index(store)?;
     let r = queries::files(store, prefix, language)
         .map_err(|error| HandlerError::internal("files_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1655,6 +1720,7 @@ fn handle_files(store: &mut Store, args: &Value) -> Result<Value, HandlerError> 
 
 fn handle_imports(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
     let file = str_arg(args, "file")?;
+    ensure_fresh_index(store)?;
     let r = queries::imports(store, file)
         .map_err(|error| HandlerError::internal("imports_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1664,6 +1730,7 @@ fn handle_imported_by(store: &mut Store, args: &Value) -> Result<Value, HandlerE
     let query = str_arg(args, "query").or_else(|_| str_arg(args, "name"))?;
     let match_kind = opt_str_arg(args, "match").unwrap_or("name");
     let language = opt_str_arg(args, "language");
+    ensure_fresh_index(store)?;
     let r = queries::imported_by(store, query, match_kind, language)
         .map_err(|error| HandlerError::internal("imported_by_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1672,6 +1739,7 @@ fn handle_imported_by(store: &mut Store, args: &Value) -> Result<Value, HandlerE
 fn handle_unreferenced(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
     let kind = opt_str_arg(args, "kind");
     let language = opt_str_arg(args, "language");
+    ensure_fresh_index(store)?;
     let r = queries::unreferenced(store, kind, language)
         .map_err(|error| HandlerError::internal("unreferenced_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1680,6 +1748,7 @@ fn handle_unreferenced(store: &mut Store, args: &Value) -> Result<Value, Handler
 fn handle_api_surface(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
     let prefix = str_arg(args, "prefix")?;
     let language = opt_str_arg(args, "language");
+    ensure_fresh_index(store)?;
     let r = queries::api_surface(store, prefix, language)
         .map_err(|error| HandlerError::internal("api_surface_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1708,6 +1777,7 @@ fn changed_since_root(
 fn handle_symbols_changed_since(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
     let git_ref = str_arg(args, "git_ref")?;
     let root = changed_since_root(opt_str_arg(args, "root"), store.db_path())?;
+    ensure_fresh_index(store)?;
     let diff = queries::symbols_changed_since(store, &root, git_ref)
         .map_err(|error| HandlerError::internal("git_diff", error))?;
     serde_json::to_value(diff).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1721,6 +1791,7 @@ fn handle_dependency_cycles(store: &mut Store, args: &Value) -> Result<Value, Ha
         .and_then(|n| u32::try_from(n).ok())
         .unwrap_or(2)
         .clamp(2, 100);
+    ensure_fresh_index(store)?;
     let r = queries::dependency_cycles(store, language, min_size)
         .map_err(|error| HandlerError::internal("dependency_cycles_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1764,6 +1835,7 @@ fn handle_centrality(store: &mut Store, args: &Value) -> Result<Value, HandlerEr
         .and_then(|n| u32::try_from(n).ok())
         .unwrap_or(20)
         .clamp(1, 200);
+    ensure_fresh_index(store)?;
     let r = queries::centrality(store, prefix, language, kind, top)
         .map_err(|error| HandlerError::internal("centrality_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -1798,6 +1870,7 @@ fn handle_map(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
             HandlerError::InvalidArguments("Invalid argument: production_only".into())
         })?,
     };
+    ensure_fresh_index(store)?;
     let result =
         queries::project_map_with_options(store, path, depth as u8, top as u32, production_only)
             .map_err(|error| match error.as_str() {
@@ -1873,6 +1946,7 @@ fn handle_temporal(store: &mut Store, args: &Value) -> Result<Value, HandlerErro
             ))
         }
     };
+    ensure_fresh_index(store)?;
     let response = crate::temporal::analyze(
         store,
         &root,
@@ -1905,6 +1979,7 @@ fn handle_semantic(store: &mut Store, args: &Value) -> Result<Value, HandlerErro
             .and_then(|value| u32::try_from(value).ok())
             .ok_or_else(|| HandlerError::InvalidArguments("Invalid argument: top".into()))?,
     };
+    ensure_fresh_index(store)?;
     let result = crate::scip_overlay::query(store, symbol, top)
         .map_err(|error| HandlerError::internal("semantic_query", error))?;
     serde_json::to_value(result)
@@ -2012,6 +2087,7 @@ fn run_change_impact_with_engine(
     impact_engine: &queries::ImpactEngine<'_>,
 ) -> Result<queries::ChangeImpactResponse, HandlerError> {
     let (since, root, depth, top) = impact_arguments(store, args)?;
+    ensure_fresh_index(store)?;
     impact_engine(store, &root, &since, depth, top)
         .map_err(|error| HandlerError::InvalidArguments(error.code().to_string()))
 }
@@ -2125,6 +2201,15 @@ mod tests {
     fn unwrap_content(v: &serde_json::Value) -> serde_json::Value {
         let text = v["content"][0]["text"].as_str().expect("content[0].text");
         serde_json::from_str(text).expect("content[0].text was not valid JSON")
+    }
+
+    fn fresh_test_store() -> (tempfile::TempDir, Store) {
+        let root = tempfile::tempdir().unwrap();
+        let mut store = Store::open(root.path().join("mmcg.db")).unwrap();
+        crate::indexer::Indexer::new(root.path())
+            .index_all(&mut store, true)
+            .unwrap();
+        (root, store)
     }
 
     #[derive(Default)]
@@ -2295,8 +2380,7 @@ mod tests {
     #[test]
     fn stateless_tools_list_and_call_work_without_initialize() {
         const MODERN: &str = "2026-07-28";
-        let tmp = tempfile::tempdir().unwrap();
-        let mut store = crate::store::Store::open(tmp.path().join("mmcg.db")).unwrap();
+        let (_tmp, mut store) = fresh_test_store();
         let mut state = SessionState::Cold;
 
         let list_request = json!({
@@ -2338,7 +2422,7 @@ mod tests {
                     "io.modelcontextprotocol/protocolVersion": MODERN,
                     "io.modelcontextprotocol/clientCapabilities": {}
                 },
-                "name": "mmcg_files",
+                "name": "mmcg_status",
                 "arguments": {}
             }
         });
@@ -2706,10 +2790,7 @@ mod tests {
 
     #[test]
     fn semantic_tool_keeps_no_overlay_as_a_read_only_fallback() {
-        let path =
-            std::env::temp_dir().join(format!("mmcg-mcp-semantic-fallback-{}", std::process::id()));
-        let _ = std::fs::remove_file(&path);
-        let mut store = Store::open(&path).unwrap();
+        let (_tmp, mut store) = fresh_test_store();
         let result = handle_tools_call(
             ProtocolVersion::Current,
             &mut store,
@@ -2724,7 +2805,6 @@ mod tests {
         assert_eq!(payload["available"], false);
         assert_eq!(payload["fallback_active"], true);
         assert_eq!(payload["resolution"]["default_graph"], "tree-sitter");
-        std::fs::remove_file(path).ok();
     }
 
     #[test]
@@ -2868,11 +2948,13 @@ mod tests {
 
     #[test]
     fn map_tool_matches_the_shared_engine_payload() {
-        let path = std::env::temp_dir().join("mmcg_mcp_map.db");
-        let _ = std::fs::remove_file(&path);
-        let mut store = crate::store::Store::open(&path).unwrap();
-        store.upsert_file("src/main.rs", 1, 1).unwrap();
-        store.upsert_file("src/lib.rs", 1, 1).unwrap();
+        let (root, mut store) = fresh_test_store();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(root.path().join("src/lib.rs"), "pub fn value() {}\n").unwrap();
+        crate::indexer::Indexer::new(root.path())
+            .index_all(&mut store, true)
+            .unwrap();
         let expected =
             serde_json::to_value(queries::project_map(&store, ".", 2, 20).unwrap()).unwrap();
         let actual = handle_map(&mut store, &json!({})).unwrap();
@@ -2902,7 +2984,6 @@ mod tests {
             .find(|tool| tool["name"] == "mmcg_map")
             .unwrap();
         assert_eq!(map["annotations"], json!({ "readOnlyHint": true }));
-        std::fs::remove_file(&path).ok();
     }
 
     fn impact_fixture(name: &str) -> (std::path::PathBuf, crate::store::Store) {
@@ -3102,10 +3183,8 @@ mod tests {
 
     #[test]
     fn impact_failure_codes_are_sanitized_in_cli_current_and_legacy_mcp() {
-        let path = std::env::temp_dir().join("mmcg-mcp-impact-errors.db");
-        let _ = std::fs::remove_file(&path);
-        let mut store = crate::store::Store::open(&path).unwrap();
-        let root = std::env::temp_dir().canonicalize().unwrap();
+        let (root, mut store) = fresh_test_store();
+        let canonical_root = root.path().canonicalize().unwrap();
         for (error, code) in [
             (queries::ChangeImpactError::InvalidRef, "invalid_ref"),
             (queries::ChangeImpactError::RootMismatch, "root_mismatch"),
@@ -3136,7 +3215,7 @@ mod tests {
                             "name": tool,
                             "arguments": {
                                 "since": injected_detail,
-                                "root": root.to_string_lossy(),
+                                "root": canonical_root.to_string_lossy(),
                                 "depth": 3,
                                 "top": 100
                             }
@@ -3156,7 +3235,6 @@ mod tests {
                 }
             }
         }
-        std::fs::remove_file(path).ok();
     }
 
     #[test]
@@ -3404,6 +3482,113 @@ mod tests {
     }
 
     #[test]
+    fn structural_tools_fail_closed_when_index_is_stale() {
+        let (root, mut store) = impact_fixture("stale-structural-tool");
+        let fresh = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_search", "arguments": { "name": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(fresh["isError"], false);
+
+        std::fs::write(
+            root.join("src/unindexed.py"),
+            "def unindexed():\n    return 1\n",
+        )
+        .unwrap();
+        for tool in TOOLS
+            .iter()
+            .filter(|tool| tool_requires_fresh_index(tool.name))
+        {
+            let arguments = match tool.name {
+                "mmcg_search" | "mmcg_callers" | "mmcg_callees" | "mmcg_impact" => {
+                    json!({ "name": "value" })
+                }
+                "mmcg_symbols_in_file" | "mmcg_outline" | "mmcg_imports" => {
+                    json!({ "file": "src/app.py" })
+                }
+                "mmcg_files"
+                | "mmcg_unreferenced"
+                | "mmcg_dependency_cycles"
+                | "mmcg_centrality"
+                | "mmcg_map" => json!({}),
+                "mmcg_imported_by" => json!({ "query": "app" }),
+                "mmcg_api_surface" => json!({ "prefix": "src" }),
+                "mmcg_symbols_changed_since" => {
+                    json!({ "git_ref": "HEAD", "root": root.to_string_lossy() })
+                }
+                "mmcg_semantic" => json!({ "symbol": "value" }),
+                "mmcg_temporal" | "mmcg_change_impact" | "mmcg_test_impact" => {
+                    json!({ "since": "HEAD", "root": root.to_string_lossy() })
+                }
+                name => panic!("missing valid-argument fixture for structural tool {name}"),
+            };
+            let stale = handle_tools_call(
+                ProtocolVersion::Current,
+                &mut store,
+                &json!({ "name": tool.name, "arguments": arguments }),
+            )
+            .unwrap();
+            let payload = unwrap_content(&stale);
+            assert_eq!(stale["isError"], true, "{} did not fail", tool.name);
+            assert_eq!(
+                payload["code"], "index_stale",
+                "{} did not fail closed",
+                tool.name
+            );
+            assert!(payload["stale_files"].as_u64().unwrap() >= 1);
+            assert_eq!(payload["extractor_contract_current"], true);
+            assert_eq!(stale["structuredContent"], payload);
+        }
+
+        let status = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_status", "arguments": {} }),
+        )
+        .unwrap();
+        assert_eq!(status["isError"], false);
+        assert!(unwrap_content(&status)["stale_files"].as_u64().unwrap() >= 1);
+
+        let scratchpad = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({
+                "name": "mmcg_scratchpad_append",
+                "arguments": { "agent": "test", "kind": "note", "body": "stale recovery" }
+            }),
+        )
+        .unwrap();
+        assert_eq!(scratchpad["isError"], false);
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn stale_tolerant_tool_list_is_explicit_and_bounded() {
+        let exempt = [
+            "mmcg_tasks",
+            "mmcg_history",
+            "mmcg_facts",
+            "mmcg_team_map",
+            "mmcg_recent_changes",
+            "mmcg_status",
+            "mmcg_scratchpad_append",
+            "mmcg_scratchpad_read",
+            "mmcg_change_class",
+        ];
+        for tool in TOOLS {
+            assert_eq!(
+                tool_requires_fresh_index(tool.name),
+                !exempt.contains(&tool.name),
+                "unexpected freshness policy for {}",
+                tool.name
+            );
+        }
+    }
+
+    #[test]
     fn team_map_requires_an_exact_server_authorized_manifest() {
         let root = tempfile::tempdir().unwrap();
         let manifest = root.path().join("team.lock.json");
@@ -3530,9 +3715,7 @@ mod tests {
 
     #[test]
     fn serve_io_cancel_interrupts_inflight_request() {
-        let path = std::env::temp_dir().join("mmcg_mcp_cancel_inflight.db");
-        let _ = std::fs::remove_file(&path);
-        let mut store = crate::store::Store::open(&path).unwrap();
+        let (_tmp, mut store) = fresh_test_store();
         // Unlimited outer budget: only the client cancel — not a budget —
         // may interrupt this call.
         store.set_default_work_budget(WorkBudget::UNLIMITED);
@@ -3581,7 +3764,6 @@ mod tests {
             elapsed < std::time::Duration::from_secs(2),
             "cancel should interrupt well before the walk's own internal 2s cap: {elapsed:?}"
         );
-        let _ = std::fs::remove_file(&path);
     }
 
     #[test]
@@ -3701,9 +3883,7 @@ mod tests {
 
     #[test]
     fn serve_io_late_cancel_does_not_abort_next_request() {
-        let path = std::env::temp_dir().join("mmcg_mcp_late_cancel.db");
-        let _ = std::fs::remove_file(&path);
-        let mut store = crate::store::Store::open(&path).unwrap();
+        let (_tmp, mut store) = fresh_test_store();
         store
             .insert_symbol("solo", "function", "src/solo.rs", 1, 2, None, None)
             .unwrap();
@@ -3746,8 +3926,6 @@ mod tests {
             content.get("code").and_then(Value::as_str),
             Some("cancelled")
         );
-
-        let _ = std::fs::remove_file(&path);
     }
 
     #[test]
@@ -3774,9 +3952,7 @@ mod tests {
 
         // Cancel path, on a fresh store with an unlimited budget: the same
         // interrupt machinery reports `cancelled`, never `work_limit_exceeded`.
-        let cancel_path = std::env::temp_dir().join("mmcg_mcp_cancel_vs_work_limit_cancel.db");
-        let _ = std::fs::remove_file(&cancel_path);
-        let mut cancel_store = crate::store::Store::open(&cancel_path).unwrap();
+        let (_cancel_tmp, mut cancel_store) = fresh_test_store();
         cancel_store.set_default_work_budget(WorkBudget::UNLIMITED);
         seed_dense_collision_fixture(&cancel_store);
 
@@ -3805,6 +3981,5 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&path);
-        let _ = std::fs::remove_file(&cancel_path);
     }
 }

--- a/mcp/servers/mmcg/src/mcp.rs
+++ b/mcp/servers/mmcg/src/mcp.rs
@@ -107,6 +107,7 @@ enum HandlerError {
     IndexStale {
         stale_files: usize,
         extractor_contract_current: bool,
+        refresh_attempted: bool,
     },
     Internal {
         class: &'static str,
@@ -155,6 +156,7 @@ enum RequestMetaError {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ToolBehavior {
     ReadOnly,
+    RefreshableQuery,
     AdditiveNonIdempotent,
 }
 
@@ -191,51 +193,64 @@ const fn additive_tool(
     }
 }
 
+const fn refreshable_tool(
+    name: &'static str,
+    schema: fn() -> Value,
+    handler: fn(&mut Store, &Value) -> Result<Value, HandlerError>,
+) -> ToolDef {
+    ToolDef {
+        name,
+        schema,
+        handler,
+        behavior: ToolBehavior::RefreshableQuery,
+    }
+}
+
 /// Authoritative tool list — order matches `tools/list` output.
 static TOOLS: &[ToolDef] = &[
-    read_only_tool("mmcg_search", schema_search, handle_search),
-    read_only_tool("mmcg_callers", schema_callers, handle_callers),
-    read_only_tool("mmcg_callees", schema_callees, handle_callees),
-    read_only_tool("mmcg_impact", schema_impact, handle_impact),
-    read_only_tool(
+    refreshable_tool("mmcg_search", schema_search, handle_search),
+    refreshable_tool("mmcg_callers", schema_callers, handle_callers),
+    refreshable_tool("mmcg_callees", schema_callees, handle_callees),
+    refreshable_tool("mmcg_impact", schema_impact, handle_impact),
+    refreshable_tool(
         "mmcg_symbols_in_file",
         schema_symbols_in_file,
         handle_symbols_in_file,
     ),
-    read_only_tool("mmcg_outline", schema_outline, handle_outline),
-    read_only_tool("mmcg_files", schema_files, handle_files),
-    read_only_tool("mmcg_imports", schema_imports, handle_imports),
-    read_only_tool("mmcg_imported_by", schema_imported_by, handle_imported_by),
-    read_only_tool(
+    refreshable_tool("mmcg_outline", schema_outline, handle_outline),
+    refreshable_tool("mmcg_files", schema_files, handle_files),
+    refreshable_tool("mmcg_imports", schema_imports, handle_imports),
+    refreshable_tool("mmcg_imported_by", schema_imported_by, handle_imported_by),
+    refreshable_tool(
         "mmcg_unreferenced",
         schema_unreferenced,
         handle_unreferenced,
     ),
-    read_only_tool("mmcg_api_surface", schema_api_surface, handle_api_surface),
-    read_only_tool(
+    refreshable_tool("mmcg_api_surface", schema_api_surface, handle_api_surface),
+    refreshable_tool(
         "mmcg_symbols_changed_since",
         schema_symbols_changed_since,
         handle_symbols_changed_since,
     ),
-    read_only_tool(
+    refreshable_tool(
         "mmcg_dependency_cycles",
         schema_dependency_cycles,
         handle_dependency_cycles,
     ),
     read_only_tool("mmcg_tasks", schema_tasks, handle_tasks),
     read_only_tool("mmcg_history", schema_history, handle_history),
-    read_only_tool("mmcg_centrality", schema_centrality, handle_centrality),
-    read_only_tool("mmcg_semantic", schema_semantic, handle_semantic),
+    refreshable_tool("mmcg_centrality", schema_centrality, handle_centrality),
+    refreshable_tool("mmcg_semantic", schema_semantic, handle_semantic),
     read_only_tool("mmcg_facts", schema_facts, handle_facts),
     read_only_tool("mmcg_team_map", schema_team_map, handle_team_map),
-    read_only_tool("mmcg_map", schema_map, handle_map),
-    read_only_tool("mmcg_temporal", schema_temporal, handle_temporal),
-    read_only_tool(
+    refreshable_tool("mmcg_map", schema_map, handle_map),
+    refreshable_tool("mmcg_temporal", schema_temporal, handle_temporal),
+    refreshable_tool(
         "mmcg_change_impact",
         schema_change_impact,
         handle_change_impact,
     ),
-    read_only_tool("mmcg_test_impact", schema_test_impact, handle_test_impact),
+    refreshable_tool("mmcg_test_impact", schema_test_impact, handle_test_impact),
     read_only_tool(
         "mmcg_recent_changes",
         schema_recent_changes,
@@ -266,7 +281,6 @@ pub(crate) fn is_known_tool(name: &str) -> bool {
 /// Structural graph answers are trustworthy only while the index matches the
 /// repository. A small set of diagnostic, revision-bound, and additive tools
 /// remains available so clients can inspect or recover from stale state.
-#[cfg(test)]
 fn tool_requires_fresh_index(name: &str) -> bool {
     !matches!(
         name,
@@ -948,6 +962,11 @@ fn tools_list(version: ProtocolVersion) -> Value {
             if version.is_current() {
                 let annotations = match tool.behavior {
                     ToolBehavior::ReadOnly => json!({ "readOnlyHint": true }),
+                    ToolBehavior::RefreshableQuery => json!({
+                        "readOnlyHint": false,
+                        "destructiveHint": false,
+                        "idempotentHint": true
+                    }),
                     ToolBehavior::AdditiveNonIdempotent => json!({
                         "readOnlyHint": false,
                         "destructiveHint": false,
@@ -975,6 +994,49 @@ fn handle_tools_call(
     params: &Value,
 ) -> Result<Value, ToolCallError> {
     handle_tools_call_inner(version, store, params, None)
+}
+
+fn invoke_tool(
+    tool: &ToolDef,
+    tool_name: &str,
+    store: &mut Store,
+    arguments: &Value,
+    impact_engine: Option<&queries::ImpactEngine<'_>>,
+) -> Result<Value, HandlerError> {
+    match (tool_name, impact_engine) {
+        ("mmcg_change_impact", Some(engine)) => {
+            handle_change_impact_with_engine(store, arguments, engine)
+        }
+        ("mmcg_test_impact", Some(engine)) => {
+            handle_test_impact_with_engine(store, arguments, engine)
+        }
+        _ => (tool.handler)(store, arguments),
+    }
+}
+
+fn invoke_tool_with_budget(
+    tool: &ToolDef,
+    tool_name: &str,
+    store: &mut Store,
+    arguments: &Value,
+    impact_engine: Option<&queries::ImpactEngine<'_>>,
+    budget: WorkBudget,
+) -> (Option<Result<Value, HandlerError>>, Option<InterruptSource>) {
+    let already_expired = store.push_work_budget(budget);
+    let handled = if already_expired {
+        None
+    } else {
+        Some(invoke_tool(
+            tool,
+            tool_name,
+            store,
+            arguments,
+            impact_engine,
+        ))
+    };
+    let interrupt = store.take_interrupt_source();
+    store.pop_work_budget();
+    (handled, interrupt)
 }
 
 fn handle_tools_call_inner(
@@ -1010,22 +1072,47 @@ fn handle_tools_call_inner(
     // ever runs, so coverage doesn't depend on a query being slow enough to
     // trip the in-flight progress-handler check.
     let budget = store.default_work_budget();
-    let already_expired = store.push_work_budget(budget);
-    let handled = if already_expired {
-        None
+    let (mut handled, mut interrupt) =
+        invoke_tool_with_budget(tool, tool_name, store, &arguments, impact_engine, budget);
+
+    // Argument parsing happens before each structural handler checks
+    // freshness, preserving precise invalid-argument errors without indexing.
+    // A validated stale call gets one refresh outside the narrow query budget,
+    // then one retry. The request watchdog and client cancellation still bound
+    // both indexing and the retried query.
+    let stale_index = if interrupt.is_none() && tool_requires_fresh_index(tool_name) {
+        match handled.as_ref() {
+            Some(Err(HandlerError::IndexStale {
+                stale_files,
+                extractor_contract_current,
+                ..
+            })) => Some((*stale_files, *extractor_contract_current)),
+            _ => None,
+        }
     } else {
-        Some(match (tool_name, impact_engine) {
-            ("mmcg_change_impact", Some(engine)) => {
-                handle_change_impact_with_engine(store, &arguments, engine)
-            }
-            ("mmcg_test_impact", Some(engine)) => {
-                handle_test_impact_with_engine(store, &arguments, engine)
-            }
-            _ => (tool.handler)(store, &arguments),
-        })
+        None
     };
-    let interrupt = store.take_interrupt_source();
-    store.pop_work_budget();
+    let mut refresh_completed = false;
+    if let Some((stale_files, extractor_contract_current)) = stale_index {
+        let refresh = refresh_stale_index(store, stale_files, extractor_contract_current);
+        interrupt = store.take_interrupt_source();
+        if interrupt.is_none() {
+            match refresh {
+                Ok(()) => {
+                    refresh_completed = true;
+                    (handled, interrupt) = invoke_tool_with_budget(
+                        tool,
+                        tool_name,
+                        store,
+                        &arguments,
+                        impact_engine,
+                        budget,
+                    );
+                }
+                Err(error) => handled = Some(Err(error)),
+            }
+        }
+    }
 
     match handled {
         Some(Ok(payload)) => tool_result(version, payload, false),
@@ -1039,9 +1126,14 @@ fn handle_tools_call_inner(
                 HandlerError::IndexStale {
                     stale_files,
                     extractor_contract_current,
+                    refresh_attempted,
                 } => tool_result(
                     version,
-                    index_stale_payload(stale_files, extractor_contract_current),
+                    index_stale_payload(
+                        stale_files,
+                        extractor_contract_current,
+                        refresh_attempted || refresh_completed,
+                    ),
                     true,
                 ),
                 HandlerError::Internal { class } => Err(ToolCallError::Internal { class }),
@@ -1051,23 +1143,104 @@ fn handle_tools_call_inner(
     }
 }
 
-fn index_stale_payload(stale_files: usize, extractor_contract_current: bool) -> Value {
+fn index_stale_payload(
+    stale_files: usize,
+    extractor_contract_current: bool,
+    refresh_attempted: bool,
+) -> Value {
+    let guidance = if refresh_attempted {
+        "automatic refresh did not produce a fresh index; run `mastermind index .` and inspect indexing errors"
+    } else {
+        "automatic refresh is unavailable for this index; run `mastermind index .` before using structural mmcg tools"
+    };
     json!({
         "code": "index_stale",
         "stale_files": stale_files,
         "extractor_contract_current": extractor_contract_current,
-        "guidance": "run `mastermind index .` before using structural mmcg tools"
+        "refresh_attempted": refresh_attempted,
+        "guidance": guidance
     })
 }
 
+fn index_stale_error(
+    stale_files: usize,
+    extractor_contract_current: bool,
+    refresh_attempted: bool,
+) -> HandlerError {
+    HandlerError::IndexStale {
+        stale_files,
+        extractor_contract_current,
+        refresh_attempted,
+    }
+}
+
+fn safe_index_status(store: &Store) -> Result<queries::StatusResponse, HandlerError> {
+    if let Some(root) = managed_auto_refresh_root(store) {
+        if crate::indexer::validate_index_root(store, &root).is_err() {
+            return Ok(queries::StatusResponse {
+                db_path: store.db_path().to_string_lossy().to_string(),
+                symbol_count: store
+                    .symbol_count()
+                    .map_err(|error| HandlerError::internal("symbol_count_query", error))?,
+                file_count: store
+                    .file_count()
+                    .map_err(|error| HandlerError::internal("file_count_query", error))?,
+                stale_files: 1,
+                extractor_contract_current: store
+                    .extractor_contract_current()
+                    .map_err(|error| HandlerError::internal("extractor_contract_query", error))?,
+            });
+        }
+    }
+    queries::status(store).map_err(|error| HandlerError::internal("index_freshness_query", error))
+}
+
 fn ensure_fresh_index(store: &Store) -> Result<(), HandlerError> {
-    let status = queries::status(store)
-        .map_err(|error| HandlerError::internal("index_freshness_query", error))?;
+    let status = safe_index_status(store)?;
     if status.stale_files > 0 || !status.extractor_contract_current {
-        return Err(HandlerError::IndexStale {
-            stale_files: status.stale_files,
-            extractor_contract_current: status.extractor_contract_current,
-        });
+        return Err(index_stale_error(
+            status.stale_files,
+            status.extractor_contract_current,
+            false,
+        ));
+    }
+    Ok(())
+}
+
+/// Derive refresh authority from the canonical managed database location, not
+/// from mutable index metadata that could redirect automatic filesystem reads.
+fn managed_auto_refresh_root(store: &Store) -> Option<PathBuf> {
+    let db_path = store.db_path().canonicalize().ok()?;
+    if db_path.file_name()? != OsStr::new("mmcg.db") {
+        return None;
+    }
+    let state_dir = db_path.parent()?;
+    if state_dir.file_name()? != OsStr::new(".mastermind") {
+        return None;
+    }
+    state_dir.parent()?.canonicalize().ok()
+}
+
+fn refresh_stale_index(
+    store: &mut Store,
+    stale_files: usize,
+    extractor_contract_current: bool,
+) -> Result<(), HandlerError> {
+    let Some(root) = managed_auto_refresh_root(store) else {
+        return Err(index_stale_error(
+            stale_files,
+            extractor_contract_current,
+            false,
+        ));
+    };
+
+    let refresh = crate::indexer::Indexer::new(root).index_all(store, false);
+    if !matches!(refresh, Ok(stats) if stats.files_failed == 0) {
+        return Err(index_stale_error(
+            stale_files,
+            extractor_contract_current,
+            true,
+        ));
     }
     Ok(())
 }
@@ -1601,7 +1774,7 @@ fn schema_recent_changes() -> Value {
 fn schema_status() -> Value {
     json!({
         "name": "mmcg_status",
-        "description": "Show index health — file count, symbol count, db path, extractor-contract compatibility, and `stale_files`: the number of added, deleted, or newer indexable source paths relative to their stored snapshot (capped at 100). If `extractor_contract_current` is false or `stale_files` is non-zero, re-index before trusting structural answers.",
+        "description": "Show index health — file count, symbol count, db path, extractor-contract compatibility, and `stale_files`: the number of added, deleted, or newer indexable source paths relative to their stored snapshot (capped at 100). Structural tools automatically refresh a stale managed `.mastermind/mmcg.db` before querying. Custom external indexes remain manual-refresh-only; unavailable or failed refreshes return `index_stale`.",
         "inputSchema": { "type": "object", "properties": {} }
     })
 }
@@ -2149,8 +2322,7 @@ fn handle_recent_changes(store: &mut Store, args: &Value) -> Result<Value, Handl
 }
 
 fn handle_status(store: &mut Store, _args: &Value) -> Result<Value, HandlerError> {
-    let r =
-        queries::status(store).map_err(|error| HandlerError::internal("status_query", error))?;
+    let r = safe_index_status(store)?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
 }
 
@@ -2768,6 +2940,7 @@ mod tests {
         let tools = current["tools"].as_array().unwrap();
         assert_eq!(tools.len(), 28);
         let mut readers = 0;
+        let mut refreshers = 0;
         for tool in tools {
             let annotations = &tool["annotations"];
             assert!(annotations.get("openWorldHint").is_none());
@@ -2780,12 +2953,23 @@ mod tests {
                         "idempotentHint": false
                     })
                 );
+            } else if tool_requires_fresh_index(tool["name"].as_str().unwrap()) {
+                assert_eq!(
+                    annotations,
+                    &json!({
+                        "readOnlyHint": false,
+                        "destructiveHint": false,
+                        "idempotentHint": true
+                    })
+                );
+                refreshers += 1;
             } else {
                 assert_eq!(annotations, &json!({ "readOnlyHint": true }));
                 readers += 1;
             }
         }
-        assert_eq!(readers, 27);
+        assert_eq!(readers, 8);
+        assert_eq!(refreshers, 19);
     }
 
     #[test]
@@ -2983,7 +3167,14 @@ mod tests {
             .iter()
             .find(|tool| tool["name"] == "mmcg_map")
             .unwrap();
-        assert_eq!(map["annotations"], json!({ "readOnlyHint": true }));
+        assert_eq!(
+            map["annotations"],
+            json!({
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": true
+            })
+        );
     }
 
     fn impact_fixture(name: &str) -> (std::path::PathBuf, crate::store::Store) {
@@ -3011,9 +3202,7 @@ mod tests {
         run(&["add", "-A"]);
         run(&["commit", "-q", "-m", "baseline"]);
         std::fs::write(root.join("src/app.py"), "def value():\n    return 2\n").unwrap();
-        let db =
-            std::env::temp_dir().join(format!("mmcg-mcp-impact-{}-{name}.db", std::process::id()));
-        let _ = std::fs::remove_file(&db);
+        let db = root.join(".mastermind/mmcg.db");
         let mut store = crate::store::Store::open(db).unwrap();
         crate::indexer::Indexer::new(&root)
             .index_all(&mut store, true)
@@ -3037,7 +3226,7 @@ mod tests {
     }
 
     #[test]
-    fn temporal_tool_returns_schema_v1_and_is_read_only() {
+    fn temporal_tool_returns_schema_v1_and_is_non_destructive() {
         let (root, mut store) = impact_fixture("temporal");
         let actual = handle_temporal(
             &mut store,
@@ -3062,7 +3251,14 @@ mod tests {
             .iter()
             .find(|tool| tool["name"] == "mmcg_temporal")
             .unwrap();
-        assert_eq!(temporal["annotations"], json!({ "readOnlyHint": true }));
+        assert_eq!(
+            temporal["annotations"],
+            json!({
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": true
+            })
+        );
         std::fs::remove_dir_all(root).ok();
     }
 
@@ -3482,8 +3678,159 @@ mod tests {
     }
 
     #[test]
-    fn structural_tools_fail_closed_when_index_is_stale() {
+    fn structural_tool_refreshes_stale_index_before_query() {
         let (root, mut store) = impact_fixture("stale-structural-tool");
+        std::fs::write(
+            root.join("src/unindexed.py"),
+            "def unindexed():\n    return 1\n",
+        )
+        .unwrap();
+
+        let stale_status = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_status", "arguments": {} }),
+        )
+        .unwrap();
+        assert_eq!(stale_status["isError"], false);
+        assert!(
+            unwrap_content(&stale_status)["stale_files"]
+                .as_u64()
+                .unwrap()
+                >= 1
+        );
+
+        let refreshed = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({
+                "name": "mmcg_search",
+                "arguments": { "name": "unindexed" }
+            }),
+        )
+        .unwrap();
+        assert_eq!(refreshed["isError"], false);
+        let payload = unwrap_content(&refreshed);
+        assert_eq!(payload["results"][0]["name"], "unindexed");
+        assert_eq!(payload["results"][0]["file"], "src/unindexed.py");
+
+        let fresh_status = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_status", "arguments": {} }),
+        )
+        .unwrap();
+        assert_eq!(unwrap_content(&fresh_status)["stale_files"], 0);
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn structural_tool_rebuilds_an_outdated_extractor_contract() {
+        let (root, mut store) = impact_fixture("stale-extractor-contract");
+        store
+            .set_meta(
+                crate::indexer::EXTRACTOR_CONTRACT_META_KEY,
+                "outdated-contract",
+            )
+            .unwrap();
+
+        let stale_status = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_status", "arguments": {} }),
+        )
+        .unwrap();
+        assert_eq!(
+            unwrap_content(&stale_status)["extractor_contract_current"],
+            false
+        );
+
+        let rebuilt = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_search", "arguments": { "name": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(rebuilt["isError"], false);
+        assert_eq!(unwrap_content(&rebuilt)["results"][0]["name"], "value");
+
+        let fresh_status = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_status", "arguments": {} }),
+        )
+        .unwrap();
+        assert_eq!(
+            unwrap_content(&fresh_status)["extractor_contract_current"],
+            true
+        );
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn structural_tool_does_not_refresh_from_tampered_index_root() {
+        let (root, mut store) = impact_fixture("tampered-index-root");
+        let untrusted_root =
+            std::env::temp_dir().join(format!("mmcg-mcp-untrusted-root-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&untrusted_root);
+        std::fs::create_dir_all(&untrusted_root).unwrap();
+        std::fs::write(
+            untrusted_root.join("secret.py"),
+            "def secret_symbol():\n    return 1\n",
+        )
+        .unwrap();
+        store
+            .set_meta(
+                "index_root",
+                &untrusted_root.canonicalize().unwrap().to_string_lossy(),
+            )
+            .unwrap();
+
+        let status = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_status", "arguments": {} }),
+        )
+        .unwrap();
+        assert_eq!(status["isError"], false);
+        assert_eq!(unwrap_content(&status)["stale_files"], 1);
+
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_search", "arguments": { "name": "secret_symbol" } }),
+        )
+        .unwrap();
+        let payload = unwrap_content(&result);
+        assert_eq!(result["isError"], true);
+        assert_eq!(payload["code"], "index_stale");
+        assert_eq!(payload["refresh_attempted"], true);
+        assert!(payload["guidance"]
+            .as_str()
+            .unwrap()
+            .contains("automatic refresh did not produce a fresh index"));
+        assert_eq!(result["structuredContent"], payload);
+        assert!(queries::search(&store, "secret_symbol", None, None, true)
+            .unwrap()
+            .results
+            .is_empty());
+
+        std::fs::remove_dir_all(untrusted_root).ok();
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn external_index_queries_remain_compatible_but_refresh_manually() {
+        let (root, managed_store) = impact_fixture("external-index");
+        drop(managed_store);
+        let external_dir = tempfile::tempdir().unwrap();
+        let mut store = crate::store::Store::open(external_dir.path().join("index.db")).unwrap();
+        crate::indexer::Indexer::new(&root)
+            .index_all(&mut store, true)
+            .unwrap();
+
         let fresh = handle_tools_call(
             ProtocolVersion::Current,
             &mut store,
@@ -3497,6 +3844,33 @@ mod tests {
             "def unindexed():\n    return 1\n",
         )
         .unwrap();
+        let stale = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_search", "arguments": { "name": "unindexed" } }),
+        )
+        .unwrap();
+        let payload = unwrap_content(&stale);
+        assert_eq!(stale["isError"], true);
+        assert_eq!(payload["code"], "index_stale");
+        assert_eq!(payload["refresh_attempted"], false);
+        assert!(queries::search(&store, "unindexed", None, None, true)
+            .unwrap()
+            .results
+            .is_empty());
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn every_structural_handler_enforces_freshness_before_query() {
+        let (root, mut store) = impact_fixture("handler-freshness-invariant");
+        std::fs::write(
+            root.join("src/unindexed.py"),
+            "def unindexed():\n    return 1\n",
+        )
+        .unwrap();
+
         for tool in TOOLS
             .iter()
             .filter(|tool| tool_requires_fresh_index(tool.name))
@@ -3524,43 +3898,13 @@ mod tests {
                 }
                 name => panic!("missing valid-argument fixture for structural tool {name}"),
             };
-            let stale = handle_tools_call(
-                ProtocolVersion::Current,
-                &mut store,
-                &json!({ "name": tool.name, "arguments": arguments }),
-            )
-            .unwrap();
-            let payload = unwrap_content(&stale);
-            assert_eq!(stale["isError"], true, "{} did not fail", tool.name);
-            assert_eq!(
-                payload["code"], "index_stale",
-                "{} did not fail closed",
+            let error = (tool.handler)(&mut store, &arguments).unwrap_err();
+            assert!(
+                matches!(error, HandlerError::IndexStale { .. }),
+                "{} queried without enforcing freshness: {error:?}",
                 tool.name
             );
-            assert!(payload["stale_files"].as_u64().unwrap() >= 1);
-            assert_eq!(payload["extractor_contract_current"], true);
-            assert_eq!(stale["structuredContent"], payload);
         }
-
-        let status = handle_tools_call(
-            ProtocolVersion::Current,
-            &mut store,
-            &json!({ "name": "mmcg_status", "arguments": {} }),
-        )
-        .unwrap();
-        assert_eq!(status["isError"], false);
-        assert!(unwrap_content(&status)["stale_files"].as_u64().unwrap() >= 1);
-
-        let scratchpad = handle_tools_call(
-            ProtocolVersion::Current,
-            &mut store,
-            &json!({
-                "name": "mmcg_scratchpad_append",
-                "arguments": { "agent": "test", "kind": "note", "body": "stale recovery" }
-            }),
-        )
-        .unwrap();
-        assert_eq!(scratchpad["isError"], false);
 
         std::fs::remove_dir_all(root).ok();
     }
@@ -3583,6 +3927,12 @@ mod tests {
                 tool_requires_fresh_index(tool.name),
                 !exempt.contains(&tool.name),
                 "unexpected freshness policy for {}",
+                tool.name
+            );
+            assert_eq!(
+                tool.behavior == ToolBehavior::RefreshableQuery,
+                tool_requires_fresh_index(tool.name),
+                "freshness and MCP behavior drifted for {}",
                 tool.name
             );
         }

--- a/mcp/servers/mmcg/src/run_task.rs
+++ b/mcp/servers/mmcg/src/run_task.rs
@@ -1268,7 +1268,9 @@ fn run_post(
 
 fn comment_audit_hint(outcome: Outcome, baseline_ref: &str) -> Option<String> {
     matches!(outcome, Outcome::PostHeld | Outcome::PostDrift).then(|| {
-        format!("  next: review the comment delta vs `{baseline_ref}` — `mastermind-comment-audit`")
+        format!(
+            "  next: inspect the comment delta vs `{baseline_ref}`; run `mastermind-comment-audit` only when it is non-empty"
+        )
     })
 }
 
@@ -1317,6 +1319,7 @@ mod tests {
             let hint = comment_audit_hint(outcome, "main")
                 .unwrap_or_else(|| panic!("expected a hint for {outcome:?}"));
             assert!(hint.contains("mastermind-comment-audit"), "{hint}");
+            assert!(hint.contains("only when it is non-empty"), "{hint}");
             assert!(hint.contains("main"), "{hint}");
         }
     }

--- a/mcp/servers/mmcg/templates/workflow.md
+++ b/mcp/servers/mmcg/templates/workflow.md
@@ -34,15 +34,16 @@ Use the lightest mode that fits the risk:
 
 | Mode | Use | Flow |
 |---|---|---|
-| **Direct** | Small, reversible, clear work | inspect → impact if useful → implement → tests → comment audit |
+| **Direct** | Small, reversible, clear work | inspect → impact if useful → implement → tests → comment-delta gate |
 | **Verified** | Normal multi-file or delegated work | compact task contract → deterministic pre/post gates → semantic review |
 | **Strict** | Auth, billing, migration, public API, data loss, supply chain | verified flow + critic/security/rollback evidence + independent auditor |
 
 Do not create a spec for Direct work.
 
 Direct work has no controller and no post-flight, so the only review it gets is
-the one you run. Use `mastermind-comment-auditor` on the branch point once the
-change is finished.
+the one you run. Once the change is finished, inspect `git diff -U0 <baseline>`
+and untracked files for added, modified, or deleted comments. Spawn
+`mastermind-comment-auditor` only when that comment delta is non-empty.
 
 ### Grounding
 
@@ -77,8 +78,10 @@ and truncation caveats; source reads and tests remain authoritative for runtime 
    mastermind run-task .mastermind/tasks/<task>/spec.md --post-only
    ```
 
-7. Spawn `mastermind-comment-auditor` on the post-flight baseline. Its findings
-   are input to your semantic review, not a verdict.
+7. Inspect the post-flight baseline diff and untracked files for a comment
+   delta. Spawn `mastermind-comment-auditor` only when at least one comment was
+   added, modified, or deleted. Its findings are input to your semantic review,
+   not a verdict.
 8. Perform semantic review. Strict work additionally requires the read-only
    `mastermind-auditor`.
 
@@ -124,7 +127,8 @@ Pre-flight, before a diff exists, route on the paths named in the spec's Scope.
   supply chain, or audit policy.
 - Executor: implementation within approved scope.
 - Auditor: independent read-only review for Strict work.
-- Comment auditor: comment delta of a finished change, in every mode.
+- Comment auditor: non-empty comment delta of a finished change, in every mode;
+  skip the spawn when the gate finds no changed comments.
 - Runtime research: who already consumes a service, who writes the state, which
   boundaries the change crosses — and which invocations the graph cannot see at
   all. Zero static callers on a handler is a gap, not an absence.

--- a/npm/mastermind/README.md
+++ b/npm/mastermind/README.md
@@ -103,8 +103,8 @@ mastermind doctor --workflow --client all
 
 Mastermind supports Claude Code, Codex, Cursor, Continue, and generic MCP stdio
 clients. Setup previews changes unless `--write` is present. The MCP server
-exposes 27 read-only tools and one additive write to the local gitignored
-scratchpad.
+exposes 19 non-destructive queries that may refresh the managed derived index,
+8 read-only tools, and one additive write to the local gitignored scratchpad.
 
 ## Supported stack
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -498,7 +498,7 @@ def _extract_mmcg_tools_from_source(src: str) -> list[str]:
     body = src[start:end] if start != -1 and end != -1 else src
     pattern = re.compile(
         r'name:\s*"(mmcg_[a-z_]+)"'
-        r'|(?:read_only_tool|additive_tool)\s*\(\s*"(mmcg_[a-z_]+)"'
+        r'|(?:read_only_tool|refreshable_tool|additive_tool)\s*\(\s*"(mmcg_[a-z_]+)"'
     )
     tools: list[str] = []
     seen: set[str] = set()
@@ -647,11 +647,12 @@ def validate_mmcg_tool_extractor_fixture() -> list[Issue]:
 static TOOLS: &[ToolDef] = &[
     ToolDef { name: "mmcg_legacy", schema: schema_legacy, handler: handle_legacy },
     read_only_tool("mmcg_reader", schema_reader, handle_reader),
+    refreshable_tool("mmcg_refresher", schema_refresher, handle_refresher),
     additive_tool("mmcg_writer", schema_writer, handle_writer),
     read_only_tool("mmcg_reader", schema_reader, handle_reader),
 ];
 '''
-    expected = ["mmcg_legacy", "mmcg_reader", "mmcg_writer"]
+    expected = ["mmcg_legacy", "mmcg_reader", "mmcg_refresher", "mmcg_writer"]
     actual = _extract_mmcg_tools_from_source(fixture)
     if actual == expected:
         return []

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -50,6 +50,8 @@ WIKILINK_RE = re.compile(r"\[\[([a-z][a-z0-9-]*)\]\]")
 # is external/anchor-only.
 RELATIVE_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+MMCG_REFERENCE_RE = re.compile(r"\bmmcg_[a-z_]+\b")
+SUBAGENT_EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
 
 
 @dataclass
@@ -204,7 +206,14 @@ def validate_artifact(a: Artifact) -> list[Issue]:
     # inherits every tool and the parent's model. Catch the
     # regression at lint time so it can't ship again.
     if a.path.parent.name == "subagents" and isinstance(metadata, dict):
-        for field in ("tools", "model", "mcpServers", "disallowedTools"):
+        for field in (
+            "tools",
+            "model",
+            "mcpServers",
+            "disallowedTools",
+            "maxTurns",
+            "effort",
+        ):
             if field in metadata:
                 issues.append(
                     Issue(
@@ -214,6 +223,27 @@ def validate_artifact(a: Artifact) -> list[Issue]:
                         "Claude Code reads it only at the top level; move it up",
                     )
                 )
+
+    if a.path.parent.name == "subagents":
+        max_turns = a.frontmatter.get("maxTurns")
+        if max_turns is not None and (
+            isinstance(max_turns, bool) or not isinstance(max_turns, int) or max_turns < 1
+        ):
+            issues.append(
+                Issue(a.path, "error", "subagent 'maxTurns' must be a positive integer")
+            )
+
+        effort = a.frontmatter.get("effort")
+        if effort is not None and (
+            not isinstance(effort, str) or effort not in SUBAGENT_EFFORT_LEVELS
+        ):
+            issues.append(
+                Issue(
+                    a.path,
+                    "error",
+                    f"subagent 'effort' must be one of {sorted(SUBAGENT_EFFORT_LEVELS)}, got {effort!r}",
+                )
+            )
 
     return issues
 
@@ -484,6 +514,132 @@ def extract_mmcg_tools() -> list[str]:
     """Pull every mmcg_xxx tool name from mcp.rs in declaration order."""
     src = (REPO_ROOT / MMCG_MCP_SRC).read_text()
     return _extract_mmcg_tools_from_source(src)
+
+
+def _runtime_tool_names(value: object) -> list[str]:
+    """Normalize Claude Code's scalar or YAML-list `tools` frontmatter."""
+    if isinstance(value, str):
+        return [entry.strip() for entry in value.split(",") if entry.strip()]
+    if isinstance(value, list) and all(isinstance(entry, str) for entry in value):
+        return [entry.strip() for entry in value if entry.strip()]
+    return []
+
+
+def _mcp_server_names(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [entry for entry in value if isinstance(entry, str)]
+    if isinstance(value, dict):
+        return [entry for entry in value if isinstance(entry, str)]
+    return []
+
+
+def _subagent_mmcg_contract_messages(
+    frontmatter: dict, body: str, known_tools: set[str]
+) -> list[str]:
+    """Return deterministic Claude Code MCP allowlist violations."""
+    servers = _mcp_server_names(frontmatter.get("mcpServers"))
+    runtime_tools = _runtime_tool_names(frontmatter.get("tools"))
+    grants = sorted(
+        tool for tool in runtime_tools if tool.startswith("mcp__mmcg__")
+    )
+    messages: list[str] = []
+
+    if "mmcg" not in servers:
+        if grants:
+            messages.append(
+                "grants mmcg MCP tools but does not declare `mcpServers: [mmcg]`"
+            )
+        return messages
+
+    if not grants:
+        messages.append(
+            "declares `mcpServers: [mmcg]` but its `tools` allowlist grants no "
+            "`mcp__mmcg__mmcg_*` tools"
+        )
+        return messages
+
+    wildcard = "mcp__mmcg__*"
+    if wildcard in grants:
+        messages.append(
+            "uses broad `mcp__mmcg__*`; grant only the mmcg tools this role needs"
+        )
+
+    granted_mmcg = {
+        grant.removeprefix("mcp__mmcg__")
+        for grant in grants
+        if grant != wildcard
+    }
+    for granted in sorted(granted_mmcg - known_tools):
+        messages.append(f"grants unknown mmcg tool `{granted}`")
+
+    all_referenced = set(MMCG_REFERENCE_RE.findall(body))
+    for unknown in sorted(all_referenced - known_tools):
+        messages.append(f"prompt references unknown mmcg tool `{unknown}`")
+    referenced = all_referenced & known_tools
+    for required in sorted(referenced - granted_mmcg):
+        messages.append(
+            f"prompt references `{required}` but `tools` omits "
+            f"`mcp__mmcg__{required}`"
+        )
+    return messages
+
+
+def validate_subagent_mmcg_fixture(known_tools: set[str]) -> list[Issue]:
+    broken = {
+        "mcpServers": ["mmcg"],
+        "tools": "Read, Grep",
+    }
+    missing_reference = {
+        "mcpServers": ["mmcg"],
+        "tools": "Read, mcp__mmcg__mmcg_status",
+    }
+    valid = {
+        "mcpServers": ["mmcg"],
+        "tools": "Read, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_search",
+    }
+    checks = (
+        bool(_subagent_mmcg_contract_messages(broken, "mmcg_search", known_tools)),
+        any(
+            "prompt references `mmcg_search`" in message
+            for message in _subagent_mmcg_contract_messages(
+                missing_reference, "Use mmcg_search.", known_tools
+            )
+        ),
+        not _subagent_mmcg_contract_messages(valid, "Use mmcg_search.", known_tools),
+    )
+    if all(checks):
+        return []
+    return [
+        Issue(
+            REPO_ROOT / "scripts/validate.py",
+            "error",
+            "subagent mmcg allowlist validator fixture failed",
+        )
+    ]
+
+
+def validate_subagent_mmcg_access(artifacts: list[Artifact]) -> list[Issue]:
+    source = REPO_ROOT / MMCG_MCP_SRC
+    if not source.is_file():
+        return [Issue(source, "error", "mcp.rs missing — cannot validate agent tools")]
+    known_tools = set(extract_mmcg_tools())
+    issues = validate_subagent_mmcg_fixture(known_tools)
+    if issues:
+        return issues
+    for artifact in artifacts:
+        if artifact.path.parent.name != "subagents":
+            continue
+        try:
+            text = artifact.path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        match = FRONTMATTER_RE.match(text)
+        body = text[match.end() :] if match else text
+        for message in _subagent_mmcg_contract_messages(
+            artifact.frontmatter, body, known_tools
+        ):
+            issues.append(Issue(artifact.path, "error", message))
+    return issues
 
 
 def validate_mmcg_tool_extractor_fixture() -> list[Issue]:
@@ -1757,6 +1913,7 @@ def main(argv: list[str]) -> int:
     issues: list[Issue] = []
     for a in artifacts:
         issues.extend(validate_artifact(a))
+    issues.extend(validate_subagent_mmcg_access(artifacts))
     issues.extend(validate_openai_skill_adapters(artifacts))
     issues.extend(validate_workflow_role_contracts())
     issues.extend(validate_portable_skill_semantics())

--- a/skills/code-review/mastermind-comment-audit/SKILL.md
+++ b/skills/code-review/mastermind-comment-audit/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: mastermind-comment-audit
-description: Read-only post-implementation review of the comments a change added, modified, or deleted. Flags narration with evidence, names what it deliberately kept, and reports removed rationale. Use after implementation is complete — triggers "check the comments", "audit the slop", "review comment discipline", or a finished diff awaiting review.
+description: Read-only review of a non-empty comment delta. Flags narration with evidence, names what it deliberately kept, and reports removed rationale. Use when the user asks to check comments or a finished diff's pre-gate found added, modified, or deleted comments; skip automatic routing when no comment changed.
 metadata:
-  version: 0.1.0
+  version: 0.1.1
   authors:
     - mastermind
   tags:


### PR DESCRIPTION
## Summary

Harden the agent workflow so scoped Claude agents get only the mmcg tools they need, waste fewer turns, and expose token and cost telemetry. Managed structural indexes now refresh automatically on the first stale query instead of forcing a manual retry loop.

## Scope

- add exact mmcg grants plus bounded `maxTurns` and `effort` to shipped subagents
- validate and diagnose missing, broad, or unknown MCP grants
- refresh a stale managed `.mastermind/mmcg.db` once, then retry the structural query once
- derive refresh authority from the canonical database path, reject tampered index roots, and keep custom external indexes manual-refresh-only
- preserve request cancellation and watchdog bounds during indexing
- report typed `index_stale` fallback data when refresh is unavailable or fails
- advertise refreshable queries as non-destructive and idempotent instead of read-only
- run auditor evals through the shipped custom-agent contract and report token, cache, turn, and cost usage
- skip the comment auditor when the finished diff has no comment delta

Deliberately excluded: merge, version bumps, tags, package publication, deployment, and release.

## Verification

- [x] `just check`
- [x] Focused stale-source, extractor-contract, cancellation, external-index, and tampered-root regressions
- [x] Documentation and validator updated for the public MCP behavior and annotations
- [x] Screenshots — not applicable
- [x] No merge, release, or external publication was performed

## Compatibility and risk

No database schema or version migration. `index_stale` gains an additive `refresh_attempted` field. The 19 structural queries may update the rebuildable managed index and now advertise `readOnlyHint: false`, `destructiveHint: false`, and `idempotentHint: true`. Fresh custom external indexes remain query-compatible; stale external indexes still return `index_stale` and require an explicit index command.

Rollback is a normal revert of these commits. No source files, migrations, packages, deployments, or irreversible state are involved; the local index is derived and rebuildable.
