### PR TITLE
Harden subagent runtime contract checks

### DIFF
--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -61,5 +61,8 @@ Doctor parses supported configuration locations as bounded data, rejects
 symlinked config files or existing path ancestors, and reports only client
 labels and structural status. It does not execute commands from configuration;
 the separate MCP handshake starts only the trusted current Mastermind binary.
+For installed `mastermind-*` agents it also verifies the full runtime chain:
+explicit model, tools, `maxTurns`, and effort; registered MCP servers; exact
+known mmcg grants; and every mmcg tool named by the prompt.
 
 Restart Claude Code after changing registration.

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -191,7 +191,10 @@ mmcg ui --since main --sarif semgrep.sarif --sarif codeql.sarif \
   --junit junit.xml --otel traces.json
 
 # Health-check the project setup (index, gitignore, CLAUDE.md, MCP config,
-# `mmcg serve` handshake). Exit code 1 if any check fails — wire into CI.
+# `mmcg serve` handshake, and installed Mastermind agent runtime contracts).
+# Agent checks cover model, explicit tools, bounded turns/effort, MCP
+# registration, exact known mmcg grants, and prompt-required tools.
+# Exit code 1 if any check fails — wire into CI.
 mmcg doctor                                          # human-readable report
 mmcg doctor --json                                   # machine-parseable
 

--- a/mcp/servers/mmcg/src/commands/init.rs
+++ b/mcp/servers/mmcg/src/commands/init.rs
@@ -260,7 +260,7 @@ pub fn do_init(root: &Path, opts: InitOpts) -> Result<(), Box<dyn std::error::Er
     }
 
     println!("\nNext steps:");
-    println!("  1. Register with Claude Code:  mastermind setup claude --write-mcp");
+    println!("  1. Register with Claude Code:  mastermind setup claude --write");
     println!("     (run once — the global server serves whichever project you open)");
     println!("  2. Add `.mastermind/` to your project's root `.gitignore` (local working state)");
     println!("  3. (Optional) Keep the index fresh in another terminal:  mastermind watch");

--- a/mcp/servers/mmcg/src/commands/tour.rs
+++ b/mcp/servers/mmcg/src/commands/tour.rs
@@ -13,7 +13,7 @@ pub fn run() {
     println!("       mastermind demo signature-drift\n");
 
     println!("  3/6  Connect your editor");
-    println!("       mastermind setup claude --write-mcp   # Claude Code");
+    println!("       mastermind setup claude --write       # Claude Code");
     println!("       Cursor / Continue / Codex: see docs/integrations/");
     println!("       Restart your editor after setup.\n");
 

--- a/mcp/servers/mmcg/src/doctor.rs
+++ b/mcp/servers/mmcg/src/doctor.rs
@@ -18,7 +18,7 @@
 //! | 8 | `MCP config`           | mmcg registered in `~/.claude.json` (user) or `./.mcp.json` (project) |
 //! | 9 | `MCP serve handshake`  | spawning `mastermind serve` responds to `initialize` + `tools/list` |
 //! | 10 | `subagent MCP scoping` | every subagent `mcpServers:` entry names a registered server |
-//! | 11 | `subagent MCP tools`   | scoped agents' explicit tool allowlists grant mmcg access |
+//! | 11 | `subagent runtime contract` | Mastermind agents pin model, tools, turns, effort, and exact mmcg access |
 //! | 12 | `style profile`        | author's `~/.mastermind/style.md` has fallen behind their commits |
 //!
 //! Human-readable by default; `--json` switches to a machine-parseable format.
@@ -167,7 +167,7 @@ impl Report {
         if self.summary.fail > 0 || self.summary.warn > 0 {
             out.push_str("\nCommon fixes:\n");
             out.push_str("  No index       run `mastermind init` or `mastermind index .`\n");
-            out.push_str("  No MCP config  run `mastermind setup claude --write-mcp`\n");
+            out.push_str("  No MCP config  run `mastermind setup claude --write`\n");
             out.push_str("  Stale index    run `mastermind index .` or start `mastermind watch`\n");
             out.push_str("  No .gitignore  add `.mastermind/` to your .gitignore\n");
         }
@@ -197,7 +197,7 @@ pub fn run_with_index(root: &Path, mmcg_binary: &Path, index_path: &Path) -> Rep
         check_mcp_config(root),
         check_mcp_handshake(index_path, mmcg_binary),
         check_subagent_mcp_servers(root),
-        check_subagent_mcp_tools(root),
+        check_subagent_runtime_contract(root),
         check_style_profile(root),
     ];
     Report::from_checks(root, checks)
@@ -993,13 +993,32 @@ fn subagent_tool_allowlist(md: &str) -> Option<Vec<String>> {
         Some(serde_norway::Value::Sequence(values)) => Some(
             values
                 .iter()
-                .filter_map(|value| value.as_str().map(str::trim))
+                .map(|value| value.as_str().map(str::trim).map(String::from))
+                .collect::<Option<Vec<_>>>()
+                .unwrap_or_default()
+                .into_iter()
                 .filter(|value| !value.is_empty())
-                .map(String::from)
                 .collect(),
         ),
         Some(_) => Some(vec![]),
     }
+}
+
+fn subagent_prompt_mmcg_refs(md: &str) -> std::collections::BTreeSet<String> {
+    let body = md
+        .strip_prefix("---\n")
+        .or_else(|| md.strip_prefix("---\r\n"))
+        .and_then(|rest| rest.find("\n---").map(|end| &rest[end + 4..]))
+        .unwrap_or(md);
+    body.split(|character: char| !(character.is_ascii_lowercase() || character == '_'))
+        .filter_map(|token| {
+            token
+                .strip_prefix("mcp__mmcg__")
+                .filter(|name| name.starts_with("mmcg_"))
+                .or_else(|| token.starts_with("mmcg_").then_some(token))
+        })
+        .map(String::from)
+        .collect()
 }
 
 /// Pure core of `check_subagent_mcp_servers`: scan `agent_dirs` for subagent
@@ -1071,18 +1090,20 @@ fn check_subagent_mcp_servers(root: &Path) -> Check {
             missing.join(", ")
         ),
         hint: Some(
-            "register it (project `.mcp.json` / `mastermind setup claude --write-mcp`) or drop the `mcpServers:` entry"
+            "register it (project `.mcp.json` / `mastermind setup claude --write`) or drop the `mcpServers:` entry"
                 .into(),
         ),
     }
 }
 
-/// Return scoped mmcg agents whose explicit `tools:` allowlist makes every
-/// mmcg tool unavailable. This is separate from server registration: a server
-/// can be configured correctly while Claude silently filters all its tools.
-fn subagent_mmcg_tool_issues(agent_dirs: &[PathBuf]) -> (bool, Vec<String>) {
-    let mut scoped = false;
-    let mut inaccessible = Vec::new();
+const SUBAGENT_MODELS: &[&str] = &["haiku", "sonnet", "opus"];
+const SUBAGENT_EFFORT_LEVELS: &[&str] = &["low", "medium", "high", "xhigh", "max"];
+const SUBAGENT_MAX_TURNS: u64 = 100;
+
+/// Keep third-party agent policies outside Mastermind's strict runtime contract.
+fn subagent_runtime_contract_issues(agent_dirs: &[PathBuf]) -> (bool, Vec<String>) {
+    let mut found = false;
+    let mut issues = Vec::new();
     for dir in agent_dirs {
         let Ok(entries) = std::fs::read_dir(dir) else {
             continue;
@@ -1093,65 +1114,164 @@ fn subagent_mmcg_tool_issues(agent_dirs: &[PathBuf]) -> (bool, Vec<String>) {
                 continue;
             }
             let body = std::fs::read_to_string(&path).unwrap_or_default();
-            if !subagent_mcp_refs(&body)
-                .iter()
-                .any(|server| server == "mmcg")
-            {
+            let filename = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("?");
+            let stem = path
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .unwrap_or("");
+            let parsed = frontmatter_block(&body).and_then(|frontmatter| {
+                serde_norway::from_str::<serde_norway::Value>(frontmatter).ok()
+            });
+            let managed = stem.starts_with("mastermind-")
+                || parsed
+                    .as_ref()
+                    .and_then(|value| value.get("name"))
+                    .and_then(serde_norway::Value::as_str)
+                    .is_some_and(|name| name.starts_with("mastermind-"));
+            if !managed {
                 continue;
             }
-            scoped = true;
-            let Some(tools) = subagent_tool_allowlist(&body) else {
+            found = true;
+            let Some(frontmatter) = parsed else {
+                issues.push(format!("{filename}: missing or malformed frontmatter"));
                 continue;
             };
-            if !tools.iter().any(|tool| {
-                tool.strip_prefix("mcp__mmcg__")
-                    .is_some_and(crate::mcp::is_known_tool)
-            }) {
-                let filename = path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or("?");
-                inaccessible.push(filename.to_string());
+
+            match frontmatter
+                .get("name")
+                .and_then(serde_norway::Value::as_str)
+            {
+                Some(name) if name == stem => {}
+                Some(_) => issues.push(format!("{filename}: name does not match filename")),
+                None => issues.push(format!("{filename}: missing name")),
+            }
+            if !frontmatter
+                .get("model")
+                .and_then(serde_norway::Value::as_str)
+                .is_some_and(|model| SUBAGENT_MODELS.contains(&model))
+            {
+                issues.push(format!("{filename}: missing or unsupported model"));
+            }
+            if !frontmatter
+                .get("maxTurns")
+                .and_then(serde_norway::Value::as_u64)
+                .is_some_and(|turns| (1..=SUBAGENT_MAX_TURNS).contains(&turns))
+            {
+                issues.push(format!(
+                    "{filename}: maxTurns must be from 1 to {SUBAGENT_MAX_TURNS}"
+                ));
+            }
+            if !frontmatter
+                .get("effort")
+                .and_then(serde_norway::Value::as_str)
+                .is_some_and(|effort| SUBAGENT_EFFORT_LEVELS.contains(&effort))
+            {
+                issues.push(format!("{filename}: missing or unsupported effort"));
+            }
+
+            let tools = subagent_tool_allowlist(&body).unwrap_or_default();
+            if tools.is_empty() {
+                issues.push(format!(
+                    "{filename}: missing explicit non-empty tools allowlist"
+                ));
+            }
+            let unique_tools: std::collections::BTreeSet<&str> =
+                tools.iter().map(String::as_str).collect();
+            if unique_tools.len() != tools.len() {
+                issues.push(format!("{filename}: tools allowlist contains duplicates"));
+            }
+
+            let valid_server_shape = match frontmatter.get("mcpServers") {
+                None => true,
+                Some(serde_norway::Value::Sequence(values)) => {
+                    values.iter().all(|value| value.as_str().is_some())
+                }
+                Some(serde_norway::Value::Mapping(values)) => {
+                    values.keys().all(|value| value.as_str().is_some())
+                }
+                Some(_) => false,
+            };
+            if !valid_server_shape {
+                issues.push(format!("{filename}: mcpServers must be a list or mapping"));
+            }
+            let servers = subagent_mcp_refs(&body);
+            let scopes_mmcg = servers.iter().any(|server| server == "mmcg");
+            let grants: std::collections::BTreeSet<String> = tools
+                .iter()
+                .filter_map(|tool| tool.strip_prefix("mcp__mmcg__"))
+                .filter(|tool| !tool.contains('*'))
+                .map(String::from)
+                .collect();
+            let wildcard = tools
+                .iter()
+                .any(|tool| tool.starts_with("mcp__mmcg__") && tool.contains('*'));
+            if wildcard {
+                issues.push(format!("{filename}: mmcg wildcard grant is not allowed"));
+            }
+            for unknown in grants
+                .iter()
+                .filter(|tool| !crate::mcp::is_known_tool(tool))
+            {
+                issues.push(format!("{filename}: grants unknown mmcg tool {unknown}"));
+            }
+
+            let references = subagent_prompt_mmcg_refs(&body);
+            if (!grants.is_empty() || !references.is_empty() || wildcard) && !scopes_mmcg {
+                issues.push(format!("{filename}: uses mmcg without mcpServers: [mmcg]"));
+            }
+            if scopes_mmcg && grants.is_empty() {
+                issues.push(format!(
+                    "{filename}: scopes mmcg without an exact known grant"
+                ));
+            }
+            for required in references {
+                if !crate::mcp::is_known_tool(&required) {
+                    issues.push(format!(
+                        "{filename}: prompt names unknown mmcg tool {required}"
+                    ));
+                } else if !grants.contains(&required) {
+                    issues.push(format!("{filename}: prompt tool {required} is not allowed"));
+                }
             }
         }
     }
-    inaccessible.sort();
-    inaccessible.dedup();
-    (scoped, inaccessible)
+    issues.sort();
+    issues.dedup();
+    (found, issues)
 }
 
-fn check_subagent_mcp_tools(root: &Path) -> Check {
+fn check_subagent_runtime_contract(root: &Path) -> Check {
     let mut agent_dirs = vec![root.join(".claude").join("agents")];
     if let Some(home) = std::env::home_dir() {
         agent_dirs.push(home.join(".claude").join("agents"));
     }
-    let (scoped, inaccessible) = subagent_mmcg_tool_issues(&agent_dirs);
-    if !scoped {
+    let (found, issues) = subagent_runtime_contract_issues(&agent_dirs);
+    if !found {
         return Check {
-            name: "subagent MCP tools",
+            name: "subagent runtime contract",
             status: Status::Ok,
-            message: "no subagent scopes mmcg — nothing to verify".into(),
+            message: "no Mastermind subagents found — nothing to verify".into(),
             hint: None,
         };
     }
-    if inaccessible.is_empty() {
+    if issues.is_empty() {
         return Check {
-            name: "subagent MCP tools",
+            name: "subagent runtime contract",
             status: Status::Ok,
-            message: "scoped subagent allowlists grant mmcg tools".into(),
+            message: "Mastermind subagents have explicit bounded runtime contracts".into(),
             hint: None,
         };
     }
     Check {
-        name: "subagent MCP tools",
+        name: "subagent runtime contract",
         status: Status::Warn,
-        message: format!(
-            "explicit `tools:` blocks mmcg in {}",
-            inaccessible.join(", ")
-        ),
+        message: format!("invalid Mastermind subagent contract: {}", issues.join("; ")),
         hint: Some(
-            "add exact `mcp__mmcg__mmcg_*` permissions to each agent's top-level `tools:` allowlist"
-                .into(),
+            "run `mastermind update` or restore explicit model, tools, maxTurns, effort, and exact mmcg grants"
+                .into()
         ),
     }
 }
@@ -1608,6 +1728,23 @@ mod tests {
     }
 
     #[test]
+    fn report_explain_uses_the_canonical_setup_write_flag() {
+        let root = PathBuf::from("/tmp/test");
+        let report = Report::from_checks(
+            &root,
+            vec![Check {
+                name: "MCP config",
+                status: Status::Warn,
+                message: "missing".into(),
+                hint: None,
+            }],
+        );
+        let text = report.render_explain(Path::new("/tmp/mmcg"), Path::new("/tmp/mmcg.db"));
+        assert!(text.contains("mastermind setup claude --write"));
+        assert!(!text.contains("--write-mcp"));
+    }
+
+    #[test]
     fn subagent_mcp_refs_parses_list_and_handles_absence() {
         let list = "---\nname: r\ndescription: d\nmcpServers: [mmcg, foo]\n---\nbody";
         assert_eq!(
@@ -1640,35 +1777,82 @@ mod tests {
         );
         let inherited = "---\nname: r\nmcpServers: [mmcg]\n---\nbody";
         assert_eq!(subagent_tool_allowlist(inherited), None);
+        let malformed = "---\nname: r\ntools: [Read, 42]\n---\nbody";
+        assert_eq!(subagent_tool_allowlist(malformed), Some(vec![]));
     }
 
     #[test]
-    fn subagent_mmcg_tool_issues_catches_explicit_allowlist_block() {
+    fn subagent_prompt_mmcg_refs_reads_bare_and_qualified_names_from_the_body() {
+        let body = "---\nname: r\ntools: mcp__mmcg__mmcg_status\n---\nUse mmcg_search, then mcp__mmcg__mmcg_callers.";
+        assert_eq!(
+            subagent_prompt_mmcg_refs(body),
+            ["mmcg_callers".to_string(), "mmcg_search".to_string()]
+                .into_iter()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn subagent_runtime_contract_issues_cover_the_full_agent_chain() {
         let root = tmp();
         let agents = root.join("agents");
         fs::create_dir_all(&agents).unwrap();
         fs::write(
-            agents.join("blocked.md"),
-            "---\nname: blocked\ntools: Read, Grep\nmcpServers: [mmcg]\n---\nbody",
+            agents.join("mastermind-working.md"),
+            "---\nname: mastermind-working\nmodel: haiku\ntools: Read, mcp__mmcg__mmcg_search\nmcpServers: [mmcg]\nmaxTurns: 12\neffort: low\n---\nUse mmcg_search.",
         )
         .unwrap();
         fs::write(
-            agents.join("working.md"),
-            "---\nname: working\ntools: Read, mcp__mmcg__mmcg_search\nmcpServers: [mmcg]\n---\nbody",
+            agents.join("mastermind-missing.md"),
+            "---\nname: mastermind-missing\n---\nbody",
         )
         .unwrap();
         fs::write(
-            agents.join("unknown.md"),
-            "---\nname: unknown\ntools: Read, mcp__mmcg__mmcg_not_a_tool\nmcpServers: [mmcg]\n---\nbody",
+            agents.join("mastermind-wildcard.md"),
+            "---\nname: mastermind-wildcard\nmodel: sonnet\ntools: Read, mcp__mmcg__*\nmcpServers: [mmcg]\nmaxTurns: 20\neffort: medium\n---\nUse mmcg_search.",
+        )
+        .unwrap();
+        fs::write(
+            agents.join("mastermind-unscoped.md"),
+            "---\nname: mastermind-unscoped\nmodel: sonnet\ntools: Read, mcp__mmcg__mmcg_search\nmaxTurns: 20\neffort: medium\n---\nUse mmcg_search.",
+        )
+        .unwrap();
+        fs::write(
+            agents.join("mastermind-missing-grant.md"),
+            "---\nname: mastermind-missing-grant\nmodel: sonnet\ntools: Read, mcp__mmcg__mmcg_status\nmcpServers: [mmcg]\nmaxTurns: 20\neffort: medium\n---\nUse mmcg_search.",
+        )
+        .unwrap();
+        fs::write(
+            agents.join("mastermind-unknown.md"),
+            "---\nname: mastermind-unknown\nmodel: opus\ntools: Read, mcp__mmcg__mmcg_not_a_tool\nmcpServers: [mmcg]\nmaxTurns: 20\neffort: high\n---\nbody",
+        )
+        .unwrap();
+        fs::write(
+            agents.join("mastermind-malformed-server.md"),
+            "---\nname: mastermind-malformed-server\nmodel: haiku\ntools: Read\nmcpServers: mmcg\nmaxTurns: 4\neffort: low\n---\nbody",
         )
         .unwrap();
 
-        let (scoped, inaccessible) = subagent_mmcg_tool_issues(std::slice::from_ref(&agents));
-        assert!(scoped);
-        assert_eq!(
-            inaccessible,
-            vec!["blocked.md".to_string(), "unknown.md".to_string()]
-        );
+        let (found, issues) = subagent_runtime_contract_issues(std::slice::from_ref(&agents));
+        assert!(found);
+        let rendered = issues.join("\n");
+        for expected in [
+            "mastermind-missing.md: missing or unsupported model",
+            "mastermind-missing.md: missing explicit non-empty tools allowlist",
+            "mastermind-missing.md: maxTurns must be from 1 to 100",
+            "mastermind-missing.md: missing or unsupported effort",
+            "mastermind-wildcard.md: mmcg wildcard grant is not allowed",
+            "mastermind-unscoped.md: uses mmcg without mcpServers: [mmcg]",
+            "mastermind-missing-grant.md: prompt tool mmcg_search is not allowed",
+            "mastermind-unknown.md: grants unknown mmcg tool mmcg_not_a_tool",
+            "mastermind-malformed-server.md: mcpServers must be a list or mapping",
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "missing {expected}:\n{rendered}"
+            );
+        }
+        assert!(!rendered.contains("mastermind-working.md"));
 
         fs::remove_dir_all(&root).ok();
     }

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -96,7 +96,7 @@ pub enum UninstallScope {
 over MCP, plus runs spec-driven workflow gates (verify-spec / audit-spec).\n\n\
 Onboard a project (run inside your repo):\n  \
 mastermind init                       scaffold .mastermind/, build the index, draft CONTEXT.md\n  \
-  mastermind setup claude --write-mcp   register the codegraph with Claude Code (run once)\n  \
+mastermind setup claude --write       register the codegraph with Claude Code (run once)\n  \
 mastermind temporal --since main        review architecture drift over time\n  \
   mastermind ui --since main            inspect this change in the local read-only Lens UI\n  \
 mastermind doctor                     verify the setup\n\n\
@@ -2047,6 +2047,12 @@ mod tests {
             normalize_setup_args(mmcg::setup::Client::Claude, args).unwrap_err(),
             "legacy --dry-run conflicts with --write"
         );
+    }
+
+    #[test]
+    fn claude_setup_keeps_write_mcp_as_an_alias_for_canonical_write() {
+        assert!(claude_setup_args(&["mastermind", "setup", "claude", "--write"]).write);
+        assert!(claude_setup_args(&["mastermind", "setup", "claude", "--write-mcp"]).write);
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/setup.rs
+++ b/mcp/servers/mmcg/src/setup.rs
@@ -6,7 +6,7 @@
 //!   - project (`--project .`): writes `<root>/.mcp.json`, merging into an
 //!     existing `mcpServers` object without clobbering others (see `run_claude`).
 //!
-//! Safe by default: prints what it will do and exits unless `--write-mcp`.
+//! Safe by default: prints what it will do and exits unless `--write`.
 //!
 //! Why hand-rolled diff (vs `similar` crate): the change is always additive +
 //! contiguous (one entry into one object), and `serde_json::to_string_pretty`
@@ -100,7 +100,7 @@ pub struct Opts {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Outcome {
-    /// Showed diff only (no `--write-mcp`).
+    /// Showed diff only (no `--write`).
     DryRun,
     /// Wrote the MCP config.
     Wrote,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,8 @@ npm, or model-backed test suites. CI executes it on every change.
 ### Contracts it protects
 
 - artifact frontmatter, names, versions, domains, links, and template mirrors;
+- bounded subagent runtime contracts: explicit model, tools, turn/effort limits,
+  MCP scoping, exact known grants, and every mmcg tool referenced by the prompt;
 - exact MCP tool count plus read/write annotations, and parity of the public
   declarative-fact schema with its CLI/MCP/Lens ingestion boundary;
 - portable skill adapters and one behavioral eval case per shipped skill;

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -51,7 +51,9 @@ WIKILINK_RE = re.compile(r"\[\[([a-z][a-z0-9-]*)\]\]")
 RELATIVE_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
 MMCG_REFERENCE_RE = re.compile(r"\bmmcg_[a-z_]+\b")
+SUBAGENT_MODELS = {"haiku", "sonnet", "opus"}
 SUBAGENT_EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
+SUBAGENT_MAX_TURNS = 100
 
 
 @dataclass
@@ -225,25 +227,8 @@ def validate_artifact(a: Artifact) -> list[Issue]:
                 )
 
     if a.path.parent.name == "subagents":
-        max_turns = a.frontmatter.get("maxTurns")
-        if max_turns is not None and (
-            isinstance(max_turns, bool) or not isinstance(max_turns, int) or max_turns < 1
-        ):
-            issues.append(
-                Issue(a.path, "error", "subagent 'maxTurns' must be a positive integer")
-            )
-
-        effort = a.frontmatter.get("effort")
-        if effort is not None and (
-            not isinstance(effort, str) or effort not in SUBAGENT_EFFORT_LEVELS
-        ):
-            issues.append(
-                Issue(
-                    a.path,
-                    "error",
-                    f"subagent 'effort' must be one of {sorted(SUBAGENT_EFFORT_LEVELS)}, got {effort!r}",
-                )
-            )
+        for message in _subagent_runtime_contract_messages(a.frontmatter):
+            issues.append(Issue(a.path, "error", message))
 
     return issues
 
@@ -525,6 +510,56 @@ def _runtime_tool_names(value: object) -> list[str]:
     return []
 
 
+def _subagent_runtime_contract_messages(frontmatter: dict) -> list[str]:
+    messages: list[str] = []
+
+    model = frontmatter.get("model")
+    if not isinstance(model, str) or model not in SUBAGENT_MODELS:
+        messages.append(
+            f"subagent 'model' must be one of {sorted(SUBAGENT_MODELS)}, got {model!r}"
+        )
+
+    tools_value = frontmatter.get("tools")
+    valid_tools_shape = isinstance(tools_value, str) or (
+        isinstance(tools_value, list)
+        and all(isinstance(entry, str) for entry in tools_value)
+    )
+    runtime_tools = _runtime_tool_names(tools_value)
+    if not valid_tools_shape or not runtime_tools:
+        messages.append("subagent 'tools' must be an explicit non-empty allowlist")
+    elif len(runtime_tools) != len(set(runtime_tools)):
+        messages.append("subagent 'tools' allowlist contains duplicate entries")
+
+    max_turns = frontmatter.get("maxTurns")
+    if (
+        isinstance(max_turns, bool)
+        or not isinstance(max_turns, int)
+        or not 1 <= max_turns <= SUBAGENT_MAX_TURNS
+    ):
+        messages.append(
+            f"subagent 'maxTurns' must be an integer from 1 to {SUBAGENT_MAX_TURNS}"
+        )
+
+    effort = frontmatter.get("effort")
+    if not isinstance(effort, str) or effort not in SUBAGENT_EFFORT_LEVELS:
+        messages.append(
+            f"subagent 'effort' must be one of {sorted(SUBAGENT_EFFORT_LEVELS)}, got {effort!r}"
+        )
+
+    servers = frontmatter.get("mcpServers")
+    valid_servers_shape = (
+        isinstance(servers, list)
+        and all(isinstance(server, str) for server in servers)
+    ) or (
+        isinstance(servers, dict)
+        and all(isinstance(server, str) for server in servers)
+    )
+    if servers is not None and not valid_servers_shape:
+        messages.append("subagent 'mcpServers' must be a list or mapping when present")
+
+    return messages
+
+
 def _mcp_server_names(value: object) -> list[str]:
     if isinstance(value, list):
         return [entry for entry in value if isinstance(entry, str)]
@@ -543,36 +578,34 @@ def _subagent_mmcg_contract_messages(
         tool for tool in runtime_tools if tool.startswith("mcp__mmcg__")
     )
     messages: list[str] = []
+    all_referenced = set(MMCG_REFERENCE_RE.findall(body))
 
     if "mmcg" not in servers:
-        if grants:
+        if grants or all_referenced:
             messages.append(
-                "grants mmcg MCP tools but does not declare `mcpServers: [mmcg]`"
+                "uses mmcg tools but does not declare `mcpServers: [mmcg]`"
             )
-        return messages
 
-    if not grants:
+    if "mmcg" in servers and not grants:
         messages.append(
             "declares `mcpServers: [mmcg]` but its `tools` allowlist grants no "
             "`mcp__mmcg__mmcg_*` tools"
         )
-        return messages
 
-    wildcard = "mcp__mmcg__*"
-    if wildcard in grants:
+    wildcards = {grant for grant in grants if "*" in grant}
+    for wildcard in sorted(wildcards):
         messages.append(
-            "uses broad `mcp__mmcg__*`; grant only the mmcg tools this role needs"
+            f"uses broad `{wildcard}`; grant only the exact mmcg tools this role needs"
         )
 
     granted_mmcg = {
         grant.removeprefix("mcp__mmcg__")
         for grant in grants
-        if grant != wildcard
+        if grant not in wildcards
     }
     for granted in sorted(granted_mmcg - known_tools):
         messages.append(f"grants unknown mmcg tool `{granted}`")
 
-    all_referenced = set(MMCG_REFERENCE_RE.findall(body))
     for unknown in sorted(all_referenced - known_tools):
         messages.append(f"prompt references unknown mmcg tool `{unknown}`")
     referenced = all_referenced & known_tools
@@ -585,19 +618,44 @@ def _subagent_mmcg_contract_messages(
 
 
 def validate_subagent_mmcg_fixture(known_tools: set[str]) -> list[Issue]:
+    bounded = {
+        "model": "haiku",
+        "tools": "Read, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_search",
+        "mcpServers": ["mmcg"],
+        "maxTurns": 12,
+        "effort": "low",
+    }
     broken = {
+        **bounded,
         "mcpServers": ["mmcg"],
         "tools": "Read, Grep",
     }
     missing_reference = {
+        **bounded,
         "mcpServers": ["mmcg"],
         "tools": "Read, mcp__mmcg__mmcg_status",
     }
-    valid = {
-        "mcpServers": ["mmcg"],
-        "tools": "Read, mcp__mmcg__mmcg_status, mcp__mmcg__mmcg_search",
-    }
+    malformed_enums = {**bounded, "model": [], "effort": {}}
+    missing_server = {**bounded, "mcpServers": []}
+    wildcard = {**bounded, "tools": "Read, mcp__mmcg__*"}
     checks = (
+        not _subagent_runtime_contract_messages(bounded),
+        all(
+            field in " ".join(_subagent_runtime_contract_messages({}))
+            for field in ("model", "tools", "maxTurns", "effort")
+        ),
+        all(
+            field in " ".join(
+                _subagent_runtime_contract_messages(malformed_enums)
+            )
+            for field in ("model", "effort")
+        ),
+        any(
+            "mcpServers" in message
+            for message in _subagent_runtime_contract_messages(
+                {**bounded, "mcpServers": "mmcg"}
+            )
+        ),
         bool(_subagent_mmcg_contract_messages(broken, "mmcg_search", known_tools)),
         any(
             "prompt references `mmcg_search`" in message
@@ -605,7 +663,21 @@ def validate_subagent_mmcg_fixture(known_tools: set[str]) -> list[Issue]:
                 missing_reference, "Use mmcg_search.", known_tools
             )
         ),
-        not _subagent_mmcg_contract_messages(valid, "Use mmcg_search.", known_tools),
+        any(
+            "does not declare `mcpServers: [mmcg]`" in message
+            for message in _subagent_mmcg_contract_messages(
+                missing_server, "Use mmcg_search.", known_tools
+            )
+        ),
+        any(
+            "uses broad `mcp__mmcg__*`" in message
+            for message in _subagent_mmcg_contract_messages(
+                wildcard, "Use mmcg_search.", known_tools
+            )
+        ),
+        not _subagent_mmcg_contract_messages(
+            bounded, "Use mmcg_search.", known_tools
+        ),
     )
     if all(checks):
         return []


### PR DESCRIPTION
## Summary

- require explicit bounded model, tools, maxTurns, and effort for shipped subagents
- validate the full agent to model to tool allowlist to MCP registration chain, including exact known mmcg grants and prompt-required tools
- extend doctor with installed Mastermind agent diagnostics while leaving third-party agent policy alone
- use canonical --write guidance while keeping --write-mcp as a compatibility alias

## Verification

- [x] just check
- [x] live mastermind doctor --json: MCP scoping and subagent runtime contract are ok, with no failed checks
- [x] comment delta audit clean
- [x] no release, tag, publish, deploy, or merge