### PR TITLE
Harden bounded index and query snapshots

### DIFF
--- a/.github/workflows/ci-npm.yml
+++ b/.github/workflows/ci-npm.yml
@@ -155,7 +155,7 @@ jobs:
             for CLIENT_ROOT in .claude .codex; do
               ./node_modules/.bin/mastermind workflow audit \
                 --root "$MASTERMIND_WORKFLOW_HOME/$CLIENT_ROOT" --json > "workflow-audit-${PROFILE}-${CLIENT_ROOT#.}.json"
-              PROFILE="$PROFILE" CLIENT_ROOT="$CLIENT_ROOT" python3 -c 'import json, os; path = f"workflow-audit-{os.environ[\"PROFILE\"]}-{os.environ[\"CLIENT_ROOT\"].lstrip(\".\")}.json"; report = json.load(open(path)); assert report["schema_version"] == 1, report; assert report["complete"], report; assert report["profile"] == os.environ["PROFILE"], report; assert not [item for item in report["diagnostics"] if item["severity"] == "error"], report'
+              PROFILE="$PROFILE" CLIENT_ROOT="$CLIENT_ROOT" python3 -c 'import json, os; path = "workflow-audit-{}-{}.json".format(os.environ["PROFILE"], os.environ["CLIENT_ROOT"].lstrip(".")); report = json.load(open(path)); assert report["schema_version"] == 1, report; assert report["complete"], report; assert report["profile"] == os.environ["PROFILE"], report; assert not [item for item in report["diagnostics"] if item["severity"] == "error"], report'
             done
           done
           echo "✓ all workflow install profiles audit cleanly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are covered by deterministic and model-backed evals.
 
 ### Fixed
+- Repository source, change-impact, and project-history reads now use one
+  descriptor-relative no-follow reader with regular-file, identity, size,
+  deadline, and cancellation checks. History persists an atomic bounded
+  inventory digest and reports live `fresh`, `stale`, `incomplete`, or
+  `snapshot_changed` state independently from structural freshness.
+- A single absolute MCP request budget now spans the initial query, at most one
+  managed refresh and retry, Git, filesystem work, private snapshots, and
+  serialization. Automatic refresh is capped at 20,000 candidates and 512 MiB
+  declared bytes and returns `refresh_limit_exceeded` when bounded out.
+- Custom MCP indexes open read-only and are never migrated or given sidecars;
+  incompatible schemas return `schema_incompatible`. Git refs are length- and
+  option-safe and resolve to a validated commit OID before later commands;
+  commit-range symbol diffs now share one deadline, bounded NUL-delimited file
+  inventory, and capped batched baseline-blob reads.
 - Shipped Claude subagents grant only the exact `mmcg` tools each role needs
   and carry bounded `maxTurns` and `effort` settings. Auditor evals exercise the
   shipped custom-agent runtime contract instead of a separate handwritten MCP

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,27 @@ comment.
 
 We still welcome a private report when scope is uncertain.
 
+## Local index and repository boundary
+
+Repository source and durable history are untrusted local inputs. Mastermind
+opens admitted files relative to the selected repository capability without
+following symlinks or Windows reparse points, rejects special files and path
+escapes, enforces per-file and aggregate limits, and compares descriptor
+identity before and after reads. History is derived retrieval evidence;
+Markdown remains authoritative, and its structural freshness is tracked
+separately from the source graph.
+
+One absolute MCP request deadline and cancellation state spans SQLite, Git,
+filesystem inventory and reads, automatic refresh, the single retry, private
+snapshots, and serialization. A cancel reports `cancelled`; deadline expiry
+reports `work_limit_exceeded`. Automatic refresh is limited to 20,000 source
+candidates and 512 MiB of declared source bytes.
+
+Only the canonical `ROOT/.mastermind/mmcg.db` opened by `serve` is eligible for
+automatic writable refresh. A custom `--index` is served through a read-only
+snapshot and is never created, migrated, truncated, or given source-side
+SQLite sidecars; an incompatible schema fails as `schema_incompatible`.
+
 ## Response and disclosure
 
 This is a small-maintainer open-source project. Targets are best effort:

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -109,7 +109,7 @@ bounded query surface instead of repeatedly rescanning source text.
 - **Parsers**: tree-sitter (C, vendored — no system tree-sitter required)
 - **Parallelism**: `rayon` parses files in parallel; writes serialize through a single SQLite connection (WAL mode)
 - **Bounded batching**: at most 64 parsed files are retained before the single SQLite writer commits them; each file uses one transaction via `Store::commit_file`
-- **Source admission**: source-looking files above 5 MiB or containing a NUL byte in the first 8 KiB are skipped before parsing; UTF-16 BOMs are admitted and decoded
+- **Source admission**: repository-relative descriptors are opened without following symlinks or Windows reparse points, every parent component stays beneath the repository capability, and identity is rechecked after the read. Source-looking files above 5 MiB or containing a NUL byte in the first 8 KiB are skipped before parsing; UTF-16 BOMs are admitted and decoded
 - **Storage**: SQLite with indexes on `symbols.name`, `edges.from_id`, and `edges.to_name`
 
 Index time depends on repository size, filesystem, hardware, and whether the run
@@ -571,7 +571,10 @@ repository-wide clean result.
 
 mmcg never invokes a model. It can read an optional bounded interpretation from
 `.mastermind/audit-narrative.json`, or from the path in
-`MMCG_AUDIT_NARRATIVE`. Start from `audit.narrative_binding` in the current
+`MMCG_AUDIT_NARRATIVE`. Relative overrides are repository-relative; absolute
+overrides must still resolve inside the selected repository. The sidecar is
+opened through the same no-follow capability and 256 KiB/deadline limit as
+other repository-owned inputs. Start from `audit.narrative_binding` in the current
 `/api/lens` response and copy that object unchanged into the sidecar's required
 `binding` field. The binding covers repository identity, baseline and HEAD,
 the working-tree snapshot, and the exact returned map. A stale or foreign
@@ -899,9 +902,14 @@ Run `mmcg watch` in a separate terminal so the index stays current while you wor
 Structural MCP queries also refresh the managed `.mastermind/mmcg.db` on demand
 when source files or the extractor contract drift. The repository root is
 derived from the canonical database path and checked against the stored index
-identity before any refresh. A custom external `--index` remains query-compatible
-when fresh but requires an explicit `mmcg index` when stale. Failed or unavailable
-refreshes return the structured `index_stale` result.
+identity before any refresh. Automatic refresh admits at most 20,000 source
+candidates and 512 MiB of declared source bytes; exceeding either cap returns
+`refresh_limit_exceeded` without a partial refresh. A custom external `--index`
+is opened read-only by `serve`: it remains query-compatible when fresh, requires
+an explicit `mmcg index` when stale, and is never created, migrated, truncated,
+or given WAL/SHM sidecars by the server. Incompatible custom schemas return
+`schema_incompatible`. Other failed or unavailable refreshes return
+`index_stale`.
 
 ## MCP tools
 
@@ -931,7 +939,7 @@ refreshes return the structured `index_stale` result.
 | `mmcg_change_impact` | `since`, optional `root`, `depth` (1–5), `top` (1–500) | Stable schema-v1 analysis of the resolved baseline against staged, unstaged, and untracked content. Reports added/removed/signature/body-changed symbols, batched transitive callers, component crossings, ranked test candidates, a `disciplines` block routing the change to an evidence set, exact collection metadata, caps, and precision notes. Root, SHA-256 index freshness, Git snapshot, and SQLite snapshot checks fail closed with stable codes. |
 | `mmcg_test_impact` | `since`, optional `root`, `depth` (1–5), `top` (1–500) | Exact test-focused projection of `mmcg_change_impact`. Changed tests and depth-1 graph tests are direct, deeper graph tests are transitive, and scoped filename candidates are heuristic. Focused candidates never replace the repository's full required gate. |
 | `mmcg_tasks` | `query`, optional `top` (default 10) | Full-text search past task specs (`.mastermind/tasks/<NNN>-<name>/spec.md`). FTS5 MATCH syntax (bare words AND-joined, `"phrases"`, `OR`/`NOT`). Returns paths, titles, and snippet excerpts with `«match»` highlights ranked by BM25. Use as planner pre-flight: "have we touched this area before?" surfaces past designs and prior verdicts. Top-level files prefixed with `_` (e.g. `_lessons.md`) and bare `.md` files at the top of `tasks/` (legacy 0.6.x layout) are intentionally excluded. |
-| `mmcg_history` | `query`, optional `kind`, `top` (default 10) | Searches `CONTEXT.md`, `CONTEXT-archive-*.md`, canonical task specs, executor reports, audits, `.mastermind/releases/*.md`, legacy task-local release notes, lessons, and Markdown architecture decisions under conventional ADR directories. `architecture_decision` is an exact `kind` filter. `candidate` lessons are unresolved signals, not active guidance. Returns observed matches, `skipped_artifacts`, `truncated`, and an explicit retrieval-only epistemic contract. Markdown remains authoritative; re-index after Markdown changes. Each artifact is capped at 1 MiB and the corpus at 5,000 files. |
+| `mmcg_history` | `query`, optional `kind`, `top` (default 10) | Searches `CONTEXT.md`, `CONTEXT-archive-*.md`, canonical task specs, executor reports, audits, `.mastermind/releases/*.md`, legacy task-local release notes, lessons, and Markdown architecture decisions under conventional ADR directories. `architecture_decision` is an exact `kind` filter. `candidate` lessons are unresolved signals, not active guidance. Returns observed matches, `skipped_artifacts`, `truncated`, `freshness` (`fresh`, `stale`, `incomplete`, or `snapshot_changed`), and an explicit retrieval-only epistemic contract. Markdown remains authoritative. The deterministic inventory binds path, kind, length, content digest, skipped state, and truncation state. Limits are 1 MiB per artifact, 5,000 artifacts, and 32 MiB of admitted text. |
 | `mmcg_dependency_cycles` | optional `language`, `min_size` (default 2) | Detect circular imports — strongly-connected components in the file-level import graph (Tarjan's algorithm). Each result is a cycle = a list of files. Pre-merge guard ("does this PR introduce a new cycle?") and architectural-hygiene survey. Resolves edges by leaf-name match — over-approximates (two unrelated `Logger` symbols cross-link) so verify before refactoring. Bump `min_size` to hide trivial A↔B and surface only larger structural problems. Work-capped at 50,000 file-pair edges: above that, `truncated: true` with an empty `cycles` list — incomplete and possibly inaccurate, not "more available"; narrow with `language` and retry. |
 | `mmcg_symbols_changed_since` | `git_ref`, optional `root` | Symbol-level diff between a git ref and the current index. Returns `{added, removed, signature_changed}` symbol sets for files in `git diff --name-only <ref>..HEAD`. Re-parses old blobs from `git show <ref>:<path>` using the same extractor. Different from `mmcg_recent_changes` (watcher mtime) — this is git-ref-based, answering "what symbols did THIS PR/branch touch?". PR-review pre-flight, auditor verification, "what new public API appeared in v2.3?". Git subprocesses are killed after `MMCG_GIT_TIMEOUT_MS`; the per-file loop is capped at 10,000 files with `truncated: true` marking a partial diff. |
 | `mmcg_status` | — | Index path, file/symbol counts, and bounded `stale_files`. A non-zero value means the next structural query will refresh a managed index, or that a custom external index needs an explicit `mmcg index`. |
@@ -976,13 +984,16 @@ wedge every subsequent call in the session. Two independent mechanisms bound
 that now: a **work budget** enforced inside SQLite, and a **watchdog** that
 bounds the request as a whole.
 
-The distinction matters. The work budget is a SQLite progress handler, so it
-can only interrupt work that is executing *inside* SQLite. A handler that
-spends its time in a Rust graph walk, an indexing pass, or waiting on a `git`
-subprocess never reaches it. The watchdog is what covers those paths.
+The distinction matters. SQLite work is interrupted by its progress handler;
+filesystem walks and reads, managed refresh, Git subprocesses, retries, private
+snapshot work, and response serialization cooperatively observe the same
+absolute request deadline and cancel state. The watchdog remains a final hard
+ceiling for code that cannot cooperate.
 
 - **MCP serve** installs `MMCG_QUERY_BUDGET_MS` (default 10,000 ms; `0` =
-  unlimited) around every `tools/call` dispatch, before the handler runs.
+  unlimited) once around every complete `tools/call`, before the first handler
+  attempt. A stale managed index may receive exactly one refresh and one retry,
+  but neither resets the deadline.
 - **CLI graph queries** (`mmcg query <kind>`, `mmcg map`, and `mmcg impact`) use the same env var with a 60,000 ms
   default — one-shot invocations can afford to wait longer than an
   interactive session.
@@ -1016,6 +1027,10 @@ subprocess never reaches it. The watchdog is what covers those paths.
   `MMCG_GIT_TIMEOUT_MS` (default 30,000 ms). The per-file diff loop is
   additionally capped at 10,000 files; beyond that, `truncated: true` marks
   the response as a prefix, not the full diff.
+- **Git refs** are non-empty and at most 1,024 bytes, cannot begin with `-` or
+  contain NUL, and must resolve through `rev-parse --verify --end-of-options`
+  to one 40-hex commit OID. Later Git commands use that OID and an explicit
+  `--` path separator, never the raw caller-supplied ref.
 - **Serve watchdog.** `mmcg serve` runs a polling thread that measures each
   in-flight request on the wall clock, independent of where the time is being
   spent. It escalates: at `MMCG_REQUEST_SOFT_TIMEOUT_MS` (default 30,000 ms) it

--- a/mcp/servers/mmcg/Cargo.lock
+++ b/mcp/servers/mmcg/Cargo.lock
@@ -105,6 +105,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "cap-fs-ext"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cap-primitives"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +636,7 @@ version = "2.0.1"
 dependencies = [
  "aho-corasick",
  "base64",
+ "cap-fs-ext",
  "cap-std",
  "clap",
  "ed25519-dalek",

--- a/mcp/servers/mmcg/Cargo.toml
+++ b/mcp/servers/mmcg/Cargo.toml
@@ -70,6 +70,7 @@ libc = "0.2"
 similar = "3.1"
 tempfile = "3"
 cap-std = "4.0.3"
+cap-fs-ext = "4.0.3"
 
 # YAML frontmatter in spec files. `serde_norway` is the maintained fork of
 # `serde_yaml` (archived upstream Sept 2024) — switched to it from `serde_yml`

--- a/mcp/servers/mmcg/src/bounded_fs.rs
+++ b/mcp/servers/mmcg/src/bounded_fs.rs
@@ -1,0 +1,798 @@
+//! Capability-scoped, bounded reads for repository-owned regular files.
+//!
+//! Callers pass an already selected repository root plus a repository-relative
+//! path. Every directory component and the final file are opened without
+//! following links. The descriptor identity is checked before and after the
+//! read and then re-opened through the same root capability, closing the usual
+//! check/open and rename/swap races.
+
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::time::{Instant, SystemTime};
+
+const READ_CHUNK_BYTES: usize = 64 * 1024;
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct ReadControl<'a> {
+    pub deadline: Option<Instant>,
+    pub interrupted: Option<&'a dyn Fn() -> bool>,
+}
+
+impl<'a> ReadControl<'a> {
+    pub(crate) fn check(self) -> Result<(), BoundedReadError> {
+        if self.interrupted.is_some_and(|check| check()) {
+            return Err(BoundedReadError::Interrupted);
+        }
+        if self
+            .deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            return Err(BoundedReadError::DeadlineExceeded);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum BoundedReadError {
+    InvalidPath,
+    OutsideRoot,
+    NotRegular,
+    TooLarge { size: u64, limit: u64 },
+    SnapshotChanged,
+    Interrupted,
+    DeadlineExceeded,
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for BoundedReadError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPath => formatter.write_str("path is not a safe repository-relative path"),
+            Self::OutsideRoot => formatter.write_str("path escapes the repository root"),
+            Self::NotRegular => formatter.write_str("path is not a regular no-follow file"),
+            Self::TooLarge { size, limit } => {
+                write!(formatter, "file has {size} bytes, limit is {limit}")
+            }
+            Self::SnapshotChanged => formatter.write_str("file identity changed during read"),
+            Self::Interrupted => formatter.write_str("file read was cancelled"),
+            Self::DeadlineExceeded => formatter.write_str("file read deadline exceeded"),
+            Self::Io(error) => write!(formatter, "file read failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for BoundedReadError {}
+
+#[derive(Debug)]
+pub(crate) struct BoundedFile {
+    pub bytes: Vec<u8>,
+    pub declared_len: u64,
+    pub modified_millis: i64,
+    pub identity: StableFileIdentity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StableFileIdentity {
+    volume: u64,
+    index: u64,
+    length: u64,
+    modified_seconds: i64,
+    modified_fraction: i64,
+    attributes: u64,
+}
+
+impl StableFileIdentity {
+    pub(crate) fn same_object(self, other: Self) -> bool {
+        self.volume == other.volume && self.index == other.index
+    }
+}
+
+pub(crate) struct RootCapability {
+    requested_root: PathBuf,
+    canonical_root: PathBuf,
+    directory: Dir,
+    identity: StableFileIdentity,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BoundedPathKind {
+    RegularFile,
+    Directory,
+    Other,
+}
+
+#[cfg(unix)]
+fn stable_file_identity(file: &std::fs::File) -> std::io::Result<StableFileIdentity> {
+    use std::os::unix::fs::MetadataExt;
+    let metadata = file.metadata()?;
+    Ok(StableFileIdentity {
+        volume: metadata.dev(),
+        index: metadata.ino(),
+        length: metadata.len(),
+        modified_seconds: metadata.mtime(),
+        modified_fraction: metadata.mtime_nsec(),
+        attributes: metadata.mode() as u64,
+    })
+}
+
+#[cfg(windows)]
+fn stable_file_identity(file: &std::fs::File) -> std::io::Result<StableFileIdentity> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+
+    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    let success = unsafe {
+        GetFileInformationByHandle(file.as_raw_handle(), std::ptr::addr_of_mut!(information))
+    };
+    if success == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(StableFileIdentity {
+        volume: information.dwVolumeSerialNumber as u64,
+        index: ((information.nFileIndexHigh as u64) << 32) | information.nFileIndexLow as u64,
+        length: ((information.nFileSizeHigh as u64) << 32) | information.nFileSizeLow as u64,
+        modified_seconds: information.ftLastWriteTime.dwHighDateTime as i64,
+        modified_fraction: information.ftLastWriteTime.dwLowDateTime as i64,
+        attributes: information.dwFileAttributes as u64,
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn stable_file_identity(_file: &std::fs::File) -> std::io::Result<StableFileIdentity> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "stable file identity is unavailable on this platform",
+    ))
+}
+
+fn relative_path(root: &Path, path: &Path) -> Result<PathBuf, BoundedReadError> {
+    let relative = if path.is_absolute() {
+        path.strip_prefix(root)
+            .map_err(|_| BoundedReadError::OutsideRoot)?
+    } else {
+        path
+    };
+    let mut normalized = PathBuf::new();
+    for component in relative.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(value) => normalized.push(value),
+            _ => return Err(BoundedReadError::InvalidPath),
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        return Err(BoundedReadError::InvalidPath);
+    }
+    Ok(normalized)
+}
+
+#[cfg(unix)]
+fn open_absolute_directory_nofollow(path: &Path) -> Result<Dir, BoundedReadError> {
+    if !path.is_absolute() {
+        return Err(BoundedReadError::InvalidPath);
+    }
+    let mut directory =
+        Dir::open_ambient_dir(Path::new("/"), ambient_authority()).map_err(BoundedReadError::Io)?;
+    for component in path.components() {
+        match component {
+            Component::RootDir => {}
+            Component::Normal(component) => {
+                directory = directory
+                    .open_dir_nofollow(component)
+                    .map_err(BoundedReadError::Io)?;
+            }
+            _ => return Err(BoundedReadError::InvalidPath),
+        }
+    }
+    Ok(directory)
+}
+
+#[cfg(windows)]
+fn open_absolute_directory_nofollow(path: &Path) -> Result<Dir, BoundedReadError> {
+    if !path.is_absolute() {
+        return Err(BoundedReadError::InvalidPath);
+    }
+    let mut components = path.components();
+    let Component::Prefix(prefix) = components.next().ok_or(BoundedReadError::InvalidPath)? else {
+        return Err(BoundedReadError::InvalidPath);
+    };
+    if !matches!(components.next(), Some(Component::RootDir)) {
+        return Err(BoundedReadError::InvalidPath);
+    }
+    let mut anchor = PathBuf::from(prefix.as_os_str());
+    anchor.push(Path::new(r"\"));
+    let mut directory =
+        Dir::open_ambient_dir(anchor, ambient_authority()).map_err(BoundedReadError::Io)?;
+    for component in components {
+        let Component::Normal(component) = component else {
+            return Err(BoundedReadError::InvalidPath);
+        };
+        directory = directory
+            .open_dir_nofollow(component)
+            .map_err(BoundedReadError::Io)?;
+    }
+    Ok(directory)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_absolute_directory_nofollow(_path: &Path) -> Result<Dir, BoundedReadError> {
+    Err(BoundedReadError::Io(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "root capabilities are unavailable on this platform",
+    )))
+}
+
+fn directory_identity(directory: &Dir) -> Result<StableFileIdentity, BoundedReadError> {
+    stable_file_identity(
+        &directory
+            .try_clone()
+            .map_err(BoundedReadError::Io)?
+            .into_std_file(),
+    )
+    .map_err(BoundedReadError::Io)
+}
+
+impl RootCapability {
+    pub(crate) fn open(root: &Path) -> Result<Self, BoundedReadError> {
+        let requested_root = std::path::absolute(root).map_err(BoundedReadError::Io)?;
+        let metadata = std::fs::symlink_metadata(&requested_root).map_err(BoundedReadError::Io)?;
+        if metadata.file_type().is_symlink() || !metadata.file_type().is_dir() {
+            return Err(BoundedReadError::NotRegular);
+        }
+        let canonical_root = requested_root
+            .canonicalize()
+            .map_err(BoundedReadError::Io)?;
+        let directory = open_absolute_directory_nofollow(&canonical_root)?;
+        let identity = directory_identity(&directory)?;
+        let capability = Self {
+            requested_root,
+            canonical_root,
+            directory,
+            identity,
+        };
+        capability.verify()?;
+        Ok(capability)
+    }
+
+    pub(crate) fn canonical_root(&self) -> &Path {
+        &self.canonical_root
+    }
+
+    pub(crate) fn requested_root(&self) -> &Path {
+        &self.requested_root
+    }
+
+    fn relative(&self, path: &Path) -> Result<PathBuf, BoundedReadError> {
+        if path.is_absolute() {
+            relative_path(&self.canonical_root, path)
+                .or_else(|_| relative_path(&self.requested_root, path))
+        } else {
+            // Callers may pass either `src/lib.rs` or a path produced by
+            // `relative_root.join("src/lib.rs")`. Recognize the latter before
+            // treating the input as repository-relative, otherwise a relative
+            // root named `repo` would resolve `repo/src` as `repo/repo/src`.
+            let absolute = std::path::absolute(path).map_err(BoundedReadError::Io)?;
+            relative_path(&self.requested_root, &absolute)
+                .or_else(|_| relative_path(&self.canonical_root, &absolute))
+                .or_else(|_| relative_path(&self.requested_root, path))
+        }
+    }
+
+    pub(crate) fn verify(&self) -> Result<(), BoundedReadError> {
+        let metadata = std::fs::symlink_metadata(&self.requested_root)
+            .map_err(|_| BoundedReadError::SnapshotChanged)?;
+        if metadata.file_type().is_symlink() || !metadata.file_type().is_dir() {
+            return Err(BoundedReadError::SnapshotChanged);
+        }
+        let current_canonical = self
+            .requested_root
+            .canonicalize()
+            .map_err(|_| BoundedReadError::SnapshotChanged)?;
+        if current_canonical != self.canonical_root {
+            return Err(BoundedReadError::SnapshotChanged);
+        }
+        let current = open_absolute_directory_nofollow(&self.canonical_root)
+            .map_err(|_| BoundedReadError::SnapshotChanged)?;
+        if !directory_identity(&current)
+            .map_err(|_| BoundedReadError::SnapshotChanged)?
+            .same_object(self.identity)
+        {
+            return Err(BoundedReadError::SnapshotChanged);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn ensure_directory(&self, relative: &Path) -> Result<(), BoundedReadError> {
+        self.verify()?;
+        let relative = relative_path(&self.requested_root, relative)?;
+        let mut directory = self.directory.try_clone().map_err(BoundedReadError::Io)?;
+        for component in relative.components() {
+            let Component::Normal(component) = component else {
+                return Err(BoundedReadError::InvalidPath);
+            };
+            match directory.open_dir_nofollow(component) {
+                Ok(next) => directory = next,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    directory
+                        .create_dir(component)
+                        .map_err(BoundedReadError::Io)?;
+                    directory = directory
+                        .open_dir_nofollow(component)
+                        .map_err(BoundedReadError::Io)?;
+                }
+                Err(error) => return Err(BoundedReadError::Io(error)),
+            }
+        }
+        self.verify()
+    }
+}
+
+fn open_relative_nofollow(root: &Dir, relative: &Path) -> Result<std::fs::File, BoundedReadError> {
+    let components = relative
+        .components()
+        .map(|component| match component {
+            Component::Normal(value) => Ok(value.to_os_string()),
+            _ => Err(BoundedReadError::InvalidPath),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let (name, parents) = components
+        .split_last()
+        .ok_or(BoundedReadError::InvalidPath)?;
+
+    let mut parent = root.try_clone().map_err(BoundedReadError::Io)?;
+    for component in parents {
+        parent = parent
+            .open_dir_nofollow(component)
+            .map_err(|error| match error.kind() {
+                std::io::ErrorKind::NotADirectory => BoundedReadError::NotRegular,
+                _ => BoundedReadError::Io(error),
+            })?;
+    }
+
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    #[cfg(unix)]
+    {
+        use cap_std::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NONBLOCK);
+    }
+    parent
+        .open_with(name, &options)
+        .map(cap_std::fs::File::into_std)
+        .map_err(|error| match error.kind() {
+            std::io::ErrorKind::InvalidInput | std::io::ErrorKind::NotADirectory => {
+                BoundedReadError::NotRegular
+            }
+            _ => BoundedReadError::Io(error),
+        })
+}
+
+pub(crate) fn create_regular_file_with_capability(
+    root: &RootCapability,
+    path: &Path,
+) -> Result<(std::fs::File, StableFileIdentity), BoundedReadError> {
+    root.verify()?;
+    let relative = root.relative(path)?;
+    let components = relative
+        .components()
+        .map(|component| match component {
+            Component::Normal(value) => Ok(value.to_os_string()),
+            _ => Err(BoundedReadError::InvalidPath),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let (name, parents) = components
+        .split_last()
+        .ok_or(BoundedReadError::InvalidPath)?;
+    let mut parent = root.directory.try_clone().map_err(BoundedReadError::Io)?;
+    for component in parents {
+        parent = parent
+            .open_dir_nofollow(component)
+            .map_err(BoundedReadError::Io)?;
+    }
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .follow(FollowSymlinks::No);
+    let file = parent
+        .open_with(name, &options)
+        .map(cap_std::fs::File::into_std)
+        .map_err(BoundedReadError::Io)?;
+    let identity = stable_file_identity(&file).map_err(BoundedReadError::Io)?;
+    root.verify()?;
+    Ok((file, identity))
+}
+
+fn open_relative_directory_nofollow(root: &Dir, relative: &Path) -> Result<Dir, BoundedReadError> {
+    let mut directory = root.try_clone().map_err(BoundedReadError::Io)?;
+    if relative.as_os_str().is_empty() {
+        return Ok(directory);
+    }
+    for component in relative.components() {
+        let Component::Normal(component) = component else {
+            return Err(BoundedReadError::InvalidPath);
+        };
+        directory = directory
+            .open_dir_nofollow(component)
+            .map_err(|error| match error.kind() {
+                std::io::ErrorKind::NotADirectory => BoundedReadError::NotRegular,
+                _ => BoundedReadError::Io(error),
+            })?;
+    }
+    Ok(directory)
+}
+
+pub(crate) fn inspect_path_kind_with_capability(
+    root: &RootCapability,
+    path: &Path,
+    control: ReadControl<'_>,
+) -> Result<BoundedPathKind, BoundedReadError> {
+    control.check()?;
+    root.verify()?;
+    let relative = root.relative(path)?;
+    if open_relative_directory_nofollow(&root.directory, &relative).is_ok() {
+        root.verify()?;
+        return Ok(BoundedPathKind::Directory);
+    }
+    let file = match open_relative_nofollow(&root.directory, &relative) {
+        Ok(file) => file,
+        Err(BoundedReadError::NotRegular) => return Ok(BoundedPathKind::Other),
+        Err(error) => return Err(error),
+    };
+    let metadata = file.metadata().map_err(BoundedReadError::Io)?;
+    root.verify()?;
+    Ok(if metadata.file_type().is_file() {
+        BoundedPathKind::RegularFile
+    } else {
+        BoundedPathKind::Other
+    })
+}
+
+fn modified_millis(metadata: &std::fs::Metadata) -> i64 {
+    // Second precision misses edits made within the same index-run second.
+    metadata
+        .modified()
+        .ok()
+        .and_then(|value| value.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Read at most `read_limit` bytes while rejecting a file whose declared or
+/// observed length exceeds `max_bytes`. `read_limit == max_bytes` is a complete
+/// bounded read; a smaller value is useful for binary sniffing without a second
+/// unbounded admission path.
+pub(crate) fn read_regular_file(
+    root: &Path,
+    path: &Path,
+    max_bytes: u64,
+    read_limit: u64,
+    control: ReadControl<'_>,
+) -> Result<BoundedFile, BoundedReadError> {
+    let root = RootCapability::open(root)?;
+    read_regular_file_with_capability(&root, path, max_bytes, read_limit, control)
+}
+
+pub(crate) fn read_regular_file_with_capability(
+    root: &RootCapability,
+    path: &Path,
+    max_bytes: u64,
+    read_limit: u64,
+    control: ReadControl<'_>,
+) -> Result<BoundedFile, BoundedReadError> {
+    read_regular_file_expected(root, path, max_bytes, read_limit, control, None)
+}
+
+pub(crate) fn read_regular_file_expected(
+    root: &RootCapability,
+    path: &Path,
+    max_bytes: u64,
+    read_limit: u64,
+    control: ReadControl<'_>,
+    expected_identity: Option<StableFileIdentity>,
+) -> Result<BoundedFile, BoundedReadError> {
+    control.check()?;
+    root.verify()?;
+    let relative = root.relative(path)?;
+    let mut file = open_relative_nofollow(&root.directory, &relative)?;
+    let before = stable_file_identity(&file).map_err(BoundedReadError::Io)?;
+    if expected_identity.is_some_and(|expected| expected != before) {
+        return Err(BoundedReadError::SnapshotChanged);
+    }
+    let metadata = file.metadata().map_err(BoundedReadError::Io)?;
+    if !metadata.file_type().is_file() {
+        return Err(BoundedReadError::NotRegular);
+    }
+    if metadata.len() > max_bytes {
+        return Err(BoundedReadError::TooLarge {
+            size: metadata.len(),
+            limit: max_bytes,
+        });
+    }
+
+    let retained_limit = read_limit.min(max_bytes);
+    let capacity = usize::try_from(metadata.len().min(retained_limit)).unwrap_or(0);
+    let mut bytes = Vec::with_capacity(capacity);
+    let mut buffer = [0_u8; READ_CHUNK_BYTES];
+    while (bytes.len() as u64) < retained_limit {
+        control.check()?;
+        let remaining = usize::try_from(retained_limit - bytes.len() as u64)
+            .unwrap_or(usize::MAX)
+            .min(buffer.len());
+        let count = file
+            .read(&mut buffer[..remaining])
+            .map_err(BoundedReadError::Io)?;
+        if count == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buffer[..count]);
+    }
+    control.check()?;
+    let after = stable_file_identity(&file).map_err(BoundedReadError::Io)?;
+    let current = open_relative_nofollow(&root.directory, &relative)?;
+    let current_identity = stable_file_identity(&current).map_err(BoundedReadError::Io)?;
+    root.verify()?;
+    if before != after || after != current_identity {
+        return Err(BoundedReadError::SnapshotChanged);
+    }
+    Ok(BoundedFile {
+        bytes,
+        declared_len: metadata.len(),
+        modified_millis: modified_millis(&metadata),
+        identity: after,
+    })
+}
+
+pub(crate) fn copy_regular_file_with_capability(
+    root: &RootCapability,
+    path: &Path,
+    max_bytes: u64,
+    control: ReadControl<'_>,
+    expected_identity: Option<StableFileIdentity>,
+    destination: &mut dyn Write,
+) -> Result<BoundedFile, BoundedReadError> {
+    control.check()?;
+    root.verify()?;
+    let relative = root.relative(path)?;
+    let mut file = open_relative_nofollow(&root.directory, &relative)?;
+    let before = stable_file_identity(&file).map_err(BoundedReadError::Io)?;
+    if expected_identity.is_some_and(|expected| expected != before) {
+        return Err(BoundedReadError::SnapshotChanged);
+    }
+    let metadata = file.metadata().map_err(BoundedReadError::Io)?;
+    if !metadata.file_type().is_file() {
+        return Err(BoundedReadError::NotRegular);
+    }
+    if metadata.len() > max_bytes {
+        return Err(BoundedReadError::TooLarge {
+            size: metadata.len(),
+            limit: max_bytes,
+        });
+    }
+    let mut copied = 0_u64;
+    let mut buffer = [0_u8; READ_CHUNK_BYTES];
+    loop {
+        control.check()?;
+        let count = file.read(&mut buffer).map_err(BoundedReadError::Io)?;
+        if count == 0 {
+            break;
+        }
+        copied = copied
+            .checked_add(count as u64)
+            .ok_or(BoundedReadError::TooLarge {
+                size: u64::MAX,
+                limit: max_bytes,
+            })?;
+        if copied > max_bytes {
+            return Err(BoundedReadError::TooLarge {
+                size: copied,
+                limit: max_bytes,
+            });
+        }
+        destination
+            .write_all(&buffer[..count])
+            .map_err(BoundedReadError::Io)?;
+    }
+    if copied != metadata.len() {
+        return Err(BoundedReadError::SnapshotChanged);
+    }
+    control.check()?;
+    let after = stable_file_identity(&file).map_err(BoundedReadError::Io)?;
+    let current = open_relative_nofollow(&root.directory, &relative)?;
+    let current_identity = stable_file_identity(&current).map_err(BoundedReadError::Io)?;
+    root.verify()?;
+    if before != after || after != current_identity {
+        return Err(BoundedReadError::SnapshotChanged);
+    }
+    Ok(BoundedFile {
+        bytes: Vec::new(),
+        declared_len: copied,
+        modified_millis: modified_millis(&metadata),
+        identity: after,
+    })
+}
+
+/// Enumerate one repository-owned directory without following any path
+/// component. The caller supplies the aggregate entry cap so a walk can share
+/// one deterministic work limit across directories.
+pub(crate) fn read_directory_names(
+    root: &Path,
+    path: &Path,
+    remaining_entries: usize,
+    control: ReadControl<'_>,
+) -> Result<Vec<std::ffi::OsString>, BoundedReadError> {
+    let root = RootCapability::open(root)?;
+    read_directory_names_with_capability(&root, path, remaining_entries, control)
+}
+
+pub(crate) fn read_directory_names_with_capability(
+    root: &RootCapability,
+    path: &Path,
+    remaining_entries: usize,
+    control: ReadControl<'_>,
+) -> Result<Vec<std::ffi::OsString>, BoundedReadError> {
+    control.check()?;
+    root.verify()?;
+    let relative = if path == root.requested_root || path == root.canonical_root {
+        PathBuf::new()
+    } else {
+        root.relative(path)?
+    };
+    let directory = open_relative_directory_nofollow(&root.directory, &relative)?;
+    let before = stable_file_identity(
+        &directory
+            .try_clone()
+            .map_err(BoundedReadError::Io)?
+            .into_std_file(),
+    )
+    .map_err(BoundedReadError::Io)?;
+    let mut names = Vec::new();
+    for entry in directory.entries().map_err(BoundedReadError::Io)? {
+        control.check()?;
+        if names.len() >= remaining_entries {
+            return Err(BoundedReadError::TooLarge {
+                size: names.len().saturating_add(1) as u64,
+                limit: remaining_entries as u64,
+            });
+        }
+        names.push(entry.map_err(BoundedReadError::Io)?.file_name());
+    }
+    names.sort();
+    control.check()?;
+    let after = stable_file_identity(
+        &directory
+            .try_clone()
+            .map_err(BoundedReadError::Io)?
+            .into_std_file(),
+    )
+    .map_err(BoundedReadError::Io)?;
+    let current = open_relative_directory_nofollow(&root.directory, &relative)?;
+    let current_identity = stable_file_identity(
+        &current
+            .try_clone()
+            .map_err(BoundedReadError::Io)?
+            .into_std_file(),
+    )
+    .map_err(BoundedReadError::Io)?;
+    root.verify()?;
+    if before != after || after != current_identity {
+        return Err(BoundedReadError::SnapshotChanged);
+    }
+    Ok(names)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_reader_reads_regular_relative_file() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("src/lib.rs"), b"fn main() {}\n").unwrap();
+        let read = read_regular_file(
+            root.path(),
+            Path::new("src/lib.rs"),
+            1024,
+            1024,
+            ReadControl::default(),
+        )
+        .unwrap();
+        assert_eq!(read.bytes, b"fn main() {}\n");
+    }
+
+    #[test]
+    fn relative_root_joined_path_is_not_prefixed_twice() {
+        let current = std::env::current_dir().unwrap();
+        let root = tempfile::tempdir_in(&current).unwrap();
+        let relative_root = root.path().strip_prefix(&current).unwrap();
+        std::fs::create_dir(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("src/lib.rs"), b"fn main() {}\n").unwrap();
+
+        let capability = RootCapability::open(relative_root).unwrap();
+        let read = read_regular_file_with_capability(
+            &capability,
+            &relative_root.join("src/lib.rs"),
+            1024,
+            1024,
+            ReadControl::default(),
+        )
+        .unwrap();
+        assert_eq!(read.bytes, b"fn main() {}\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn root_replacement_with_symlink_fails_closed() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("root");
+        let moved = parent.path().join("moved");
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("safe.rs"), b"safe").unwrap();
+        std::fs::write(outside.path().join("safe.rs"), b"outside").unwrap();
+        let capability = RootCapability::open(&root).unwrap();
+
+        std::fs::rename(&root, &moved).unwrap();
+        symlink(outside.path(), &root).unwrap();
+        assert!(matches!(
+            read_regular_file_with_capability(
+                &capability,
+                &root.join("safe.rs"),
+                1024,
+                1024,
+                ReadControl::default(),
+            ),
+            Err(BoundedReadError::SnapshotChanged)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_reader_rejects_symlink_components_and_special_files() {
+        use std::os::unix::fs::{symlink, FileTypeExt};
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.rs"), b"secret").unwrap();
+        symlink(outside.path(), root.path().join("linked")).unwrap();
+        assert!(read_regular_file(
+            root.path(),
+            Path::new("linked/secret.rs"),
+            1024,
+            1024,
+            ReadControl::default(),
+        )
+        .is_err());
+
+        let fifo = root.path().join("pipe.rs");
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        assert!(std::fs::symlink_metadata(&fifo)
+            .unwrap()
+            .file_type()
+            .is_fifo());
+        assert!(matches!(
+            read_regular_file(
+                root.path(),
+                Path::new("pipe.rs"),
+                1024,
+                1024,
+                ReadControl::default(),
+            ),
+            Err(BoundedReadError::NotRegular)
+        ));
+    }
+}

--- a/mcp/servers/mmcg/src/diff.rs
+++ b/mcp/servers/mmcg/src/diff.rs
@@ -28,6 +28,7 @@
 //! - Per-file resolution: a symbol moved `a.py`→`b.py` shows as removed-from-a
 //!   + added-to-b, not "moved".
 
+use crate::bounded_fs::{read_regular_file, BoundedReadError, ReadControl, RootCapability};
 use crate::indexer::{extractor_for_path, parse_blob, MAX_INDEXABLE_FILE_SIZE};
 use crate::store::{Store, Symbol};
 use serde::Serialize;
@@ -46,15 +47,12 @@ use std::time::{Duration, Instant};
 
 pub const CHANGE_FILE_LIMIT: usize = 10_000;
 pub const GIT_OUTPUT_LIMIT: usize = 4 * 1024 * 1024;
+const MAX_GIT_REF_BYTES: usize = 1024;
 const CAT_FILE_RESPONSE_OVERHEAD: usize = 128;
 const BASELINE_BLOB_BATCH_OUTPUT_LIMIT: usize =
     MAX_INDEXABLE_FILE_SIZE as usize + CAT_FILE_RESPONSE_OVERHEAD;
 const BASELINE_BLOB_TOTAL_LIMIT: usize = 64 * 1024 * 1024;
 const GIT_TIMEOUT: Duration = Duration::from_secs(10);
-/// Default `run_git` / `git_show_blob` subprocess deadline when
-/// `MMCG_GIT_TIMEOUT_MS` is unset — distinct from `GIT_TIMEOUT` above, which
-/// bounds the separate `run_bounded_git` worktree-diff path.
-const DEFAULT_RUN_GIT_TIMEOUT_MS: u64 = 30_000;
 /// Must stay a real `sleep`. `park_timeout` returns instantly when the thread
 /// holds an unpark token, and the sibling drain threads talk over `mpsc`, which
 /// parks and unparks this very thread — a stray token turns the wait into a
@@ -68,7 +66,6 @@ type SelectedSymbolKeys = (BTreeSet<SymbolKey>, BTreeSet<SymbolKey>);
 thread_local! {
     static TEST_GIT_INVOCATION: RefCell<Option<(std::path::PathBuf, Vec<OsString>)>> = const { RefCell::new(None) };
     static TEST_GIT_TIMEOUT: RefCell<Option<Duration>> = const { RefCell::new(None) };
-    static TEST_RUN_GIT_TIMEOUT: RefCell<Option<Duration>> = const { RefCell::new(None) };
 }
 
 fn git_timeout() -> Duration {
@@ -77,22 +74,6 @@ fn git_timeout() -> Duration {
         return timeout;
     }
     GIT_TIMEOUT
-}
-
-/// Deadline for `run_git` / `git_show_blob` — read from `MMCG_GIT_TIMEOUT_MS`
-/// (default 30,000ms) on every call so it can't go stale within a long-lived
-/// process; test-overridable via the same pattern as `git_timeout`.
-fn run_git_timeout() -> Duration {
-    #[cfg(test)]
-    if let Some(timeout) = TEST_RUN_GIT_TIMEOUT.with(|value| *value.borrow()) {
-        return timeout;
-    }
-    let ms = std::env::var("MMCG_GIT_TIMEOUT_MS")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|&value| value > 0)
-        .unwrap_or(DEFAULT_RUN_GIT_TIMEOUT_MS);
-    Duration::from_millis(ms)
 }
 
 fn git_command(args: &[&str]) -> Command {
@@ -245,16 +226,56 @@ pub fn symbols_changed_since(
     repo_root: &Path,
     git_ref: &str,
 ) -> Result<SymbolDiff, DiffError> {
-    validate_ref(repo_root, git_ref)?;
+    symbols_changed_since_controlled(store, repo_root, git_ref, None, None)
+}
 
-    let files_in_diff = git_diff_name_only(repo_root, git_ref)?;
-    Ok(symbol_diff_over_files(
-        store,
+pub(crate) fn symbols_changed_since_controlled(
+    store: &Store,
+    repo_root: &Path,
+    git_ref: &str,
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<SymbolDiff, DiffError> {
+    let deadline = deadline.or_else(|| Some(Instant::now() + git_timeout()));
+    let root = RootCapability::open(repo_root)
+        .map_err(|_| DiffError::GitFailed("snapshot_changed".into()))?;
+    let baseline_oid = resolve_commit_controlled(repo_root, git_ref, deadline, interrupted)
+        .map_err(|error| worktree_scope_error(git_ref, error))?;
+    let head_oid = resolve_head_controlled(repo_root, deadline, interrupted)
+        .map_err(|error| worktree_scope_error(git_ref, error))?;
+    let (files_in_diff, truncated) =
+        git_diff_name_only_controlled(repo_root, &baseline_oid, &head_oid, deadline, interrupted)
+            .map_err(|error| worktree_scope_error(git_ref, error))?;
+    let parseable_paths = files_in_diff
+        .iter()
+        .filter(|path| extractor_for_path(Path::new(path)).is_some())
+        .cloned()
+        .collect::<Vec<_>>();
+    let old_blobs = baseline_blobs_for_paths_controlled(
         repo_root,
-        git_ref,
+        &baseline_oid,
+        &parseable_paths,
+        deadline,
+        interrupted,
+    )
+    .map_err(|error| worktree_scope_error(git_ref, error))?;
+    let diff = symbol_diff_over_blobs(
+        store,
         git_ref,
         files_in_diff,
-    ))
+        truncated,
+        &old_blobs,
+        deadline,
+        interrupted,
+    )?;
+    let current_head = resolve_head_controlled(repo_root, deadline, interrupted)
+        .map_err(|error| worktree_scope_error(git_ref, error))?;
+    root.verify()
+        .map_err(|_| DiffError::GitFailed("snapshot_changed".into()))?;
+    if current_head != head_oid {
+        return Err(DiffError::GitFailed("snapshot_changed".into()));
+    }
+    Ok(diff)
 }
 
 /// Same symbol comparison as [`symbols_changed_since`], but the file scope is
@@ -275,48 +296,53 @@ pub fn symbols_changed_since_worktree(
     repo_root: &Path,
     git_ref: &str,
 ) -> Result<SymbolDiff, DiffError> {
-    let baseline_oid =
-        resolve_commit(repo_root, git_ref).map_err(|e| worktree_scope_error(git_ref, e))?;
-    let (files, _files_total, _truncated, _skipped_non_utf8) =
-        collect_worktree_paths(repo_root, &baseline_oid)
-            .map_err(|e| worktree_scope_error(git_ref, e))?;
-
-    // Blobs come from the resolved oid so the old side can't drift if the ref
-    // moves mid-audit; `git_ref` stays the caller-facing label.
-    let files_in_diff = files.into_iter().map(|file| file.path).collect();
-    Ok(symbol_diff_over_files(
+    symbols_changed_in_worktree_controlled(
         store,
         repo_root,
-        &baseline_oid,
         git_ref,
-        files_in_diff,
-    ))
+        Some(Instant::now() + git_timeout()),
+        None,
+    )
+    .map(|diff| diff.diff)
+    .map_err(|error| worktree_scope_error(git_ref, error))
 }
 
 fn worktree_scope_error(git_ref: &str, error: WorkingTreeDiffError) -> DiffError {
     match error {
         WorkingTreeDiffError::InvalidRef => DiffError::GitRefMissing(git_ref.to_string()),
-        other => DiffError::GitFailed(format!("worktree file scope: {other}")),
+        WorkingTreeDiffError::GitTimeout => DiffError::GitTimeout,
+        WorkingTreeDiffError::GitOutputLimit => DiffError::GitFailed("git_output_limit".into()),
+        WorkingTreeDiffError::SnapshotChanged => DiffError::GitFailed("snapshot_changed".into()),
+        WorkingTreeDiffError::IndexStale => DiffError::GitFailed("index_stale".into()),
+        WorkingTreeDiffError::GitUnavailable => DiffError::GitNotFound,
     }
 }
 
-/// `blob_ref` resolves the old side (`git show <blob_ref>:<path>`); `label` is
-/// what the caller asked for and is echoed back in [`SymbolDiff::git_ref`].
-fn symbol_diff_over_files(
+fn symbol_diff_over_blobs(
     store: &Store,
-    repo_root: &Path,
-    blob_ref: &str,
     label: &str,
     files_in_diff: Vec<String>,
-) -> SymbolDiff {
-    let truncated = files_in_diff.len() > CHANGE_FILE_LIMIT;
+    truncated: bool,
+    old_blobs: &BTreeMap<String, Option<Vec<u8>>>,
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<SymbolDiff, DiffError> {
     let mut added: Vec<SymbolRef> = Vec::new();
     let mut removed: Vec<SymbolRef> = Vec::new();
     let mut signature_changed: Vec<SignatureChange> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
 
-    for rel in files_in_diff.iter().take(CHANGE_FILE_LIMIT) {
-        match diff_file(store, repo_root, blob_ref, rel) {
+    for rel in &files_in_diff {
+        if interrupted.is_some_and(|check| check())
+            || deadline.is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            return Err(DiffError::GitTimeout);
+        }
+        match diff_file_from_blob(
+            store,
+            rel,
+            old_blobs.get(rel).and_then(|blob| blob.as_deref()),
+        ) {
             Ok(per_file) => {
                 added.extend(per_file.added);
                 removed.extend(per_file.removed);
@@ -331,7 +357,7 @@ fn symbol_diff_over_files(
     removed.sort_by(|a, b| (a.file.as_str(), a.line).cmp(&(b.file.as_str(), b.line)));
     signature_changed.sort_by(|a, b| (a.file.as_str(), &a.name).cmp(&(b.file.as_str(), &b.name)));
 
-    SymbolDiff {
+    Ok(SymbolDiff {
         git_ref: label.to_string(),
         files_in_diff,
         added,
@@ -339,7 +365,7 @@ fn symbol_diff_over_files(
         signature_changed,
         errors,
         truncated,
-    }
+    })
 }
 
 pub fn symbols_changed_in_worktree(
@@ -347,12 +373,43 @@ pub fn symbols_changed_in_worktree(
     repo_root: &Path,
     git_ref: &str,
 ) -> Result<WorkingTreeSymbolDiff, WorkingTreeDiffError> {
-    let baseline_oid = resolve_commit(repo_root, git_ref)?;
-    let head_oid = resolve_head(repo_root)?;
+    symbols_changed_in_worktree_controlled(store, repo_root, git_ref, None, None)
+}
+
+pub(crate) fn symbols_changed_in_worktree_controlled(
+    store: &Store,
+    repo_root: &Path,
+    git_ref: &str,
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<WorkingTreeSymbolDiff, WorkingTreeDiffError> {
+    let baseline_oid = resolve_commit_controlled(repo_root, git_ref, deadline, interrupted)?;
+    let head_oid = resolve_head_controlled(repo_root, deadline, interrupted)?;
     let (files, files_total, files_truncated, skipped_non_utf8_paths) =
-        collect_worktree_paths(repo_root, &baseline_oid)?;
-    let snapshot_token = working_tree_snapshot_token(repo_root, &head_oid, &files)?;
-    let old_blobs = baseline_blobs(repo_root, &baseline_oid, &files)?;
+        collect_worktree_paths_controlled(repo_root, &baseline_oid, deadline, interrupted)?;
+    let snapshot_token = working_tree_snapshot_token_controlled(
+        repo_root,
+        &head_oid,
+        &files,
+        deadline,
+        interrupted,
+    )?;
+    let paths = files
+        .iter()
+        .filter(|file| extractor_for_path(Path::new(&file.path)).is_some())
+        .map(|file| file.path.clone())
+        .collect::<Vec<_>>();
+    let mut old_blobs = files
+        .iter()
+        .map(|file| (file.path.clone(), None))
+        .collect::<BTreeMap<_, _>>();
+    old_blobs.extend(baseline_blobs_for_paths_controlled(
+        repo_root,
+        &baseline_oid,
+        &paths,
+        deadline,
+        interrupted,
+    )?);
 
     let mut added = Vec::new();
     let mut removed = Vec::new();
@@ -411,7 +468,25 @@ pub fn symbols_changed_in_worktree(
             }
         }
 
-        let current_bytes = std::fs::read(repo_root.join(rel)).ok();
+        let current_bytes = if file.status == "deleted" {
+            None
+        } else {
+            let control = ReadControl {
+                deadline,
+                interrupted,
+            };
+            Some(
+                read_regular_file(
+                    repo_root,
+                    Path::new(rel),
+                    MAX_INDEXABLE_FILE_SIZE,
+                    MAX_INDEXABLE_FILE_SIZE,
+                    control,
+                )
+                .map_err(working_tree_read_error)?
+                .bytes,
+            )
+        };
         let (selected_old, selected_new) = match (old_blob, current_bytes.as_deref()) {
             (Some(old), Some(current)) => {
                 deepest_changed_symbol_keys(old, current, &old_symbols, &new_symbols)
@@ -485,6 +560,16 @@ pub fn symbols_changed_in_worktree(
 
 fn line_chunks(bytes: &[u8]) -> Vec<&[u8]> {
     bytes.split_inclusive(|byte| *byte == b'\n').collect()
+}
+
+fn working_tree_read_error(error: BoundedReadError) -> WorkingTreeDiffError {
+    match error {
+        BoundedReadError::Interrupted | BoundedReadError::DeadlineExceeded => {
+            WorkingTreeDiffError::GitTimeout
+        }
+        BoundedReadError::TooLarge { .. } => WorkingTreeDiffError::IndexStale,
+        _ => WorkingTreeDiffError::SnapshotChanged,
+    }
 }
 
 fn deepest_changed_symbol_keys(
@@ -594,6 +679,7 @@ fn bounded_reader<R: Read + Send + 'static>(
     receiver
 }
 
+#[allow(dead_code)]
 fn run_bounded_git(
     repo: &Path,
     args: &[&str],
@@ -619,6 +705,17 @@ pub(crate) fn run_bounded_git_with_limit_until(
     deadline: Option<Instant>,
 ) -> Result<BoundedGitOutput, WorkingTreeDiffError> {
     run_bounded_git_controlled(repo, args, input, output_limit, deadline, None)
+}
+
+pub(crate) fn run_bounded_git_with_control(
+    repo: &Path,
+    args: &[&str],
+    input: Option<&[u8]>,
+    output_limit: usize,
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<BoundedGitOutput, WorkingTreeDiffError> {
+    run_bounded_git_controlled(repo, args, input, output_limit, deadline, interrupted)
 }
 
 fn run_bounded_git_controlled(
@@ -706,15 +803,32 @@ fn run_bounded_git_controlled(
     })
 }
 
+#[cfg(test)]
 fn resolve_commit(repo: &Path, git_ref: &str) -> Result<String, WorkingTreeDiffError> {
-    if git_ref.is_empty() || git_ref.starts_with('-') || git_ref.contains('\0') {
+    resolve_commit_controlled(repo, git_ref, None, None)
+}
+
+fn resolve_commit_controlled(
+    repo: &Path,
+    git_ref: &str,
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<String, WorkingTreeDiffError> {
+    if git_ref.is_empty()
+        || git_ref.len() > MAX_GIT_REF_BYTES
+        || git_ref.starts_with('-')
+        || git_ref.contains('\0')
+    {
         return Err(WorkingTreeDiffError::InvalidRef);
     }
     let commit = format!("{git_ref}^{{commit}}");
-    let output = run_bounded_git(
+    let output = run_bounded_git_controlled(
         repo,
         &["rev-parse", "--verify", "--end-of-options", &commit],
         None,
+        GIT_OUTPUT_LIMIT,
+        deadline,
+        interrupted,
     )?;
     if !output.success {
         return Err(WorkingTreeDiffError::InvalidRef);
@@ -751,6 +865,66 @@ fn resolve_head_controlled(
     Ok(oid.trim().to_ascii_lowercase())
 }
 
+fn git_diff_name_only_controlled(
+    repo: &Path,
+    baseline_oid: &str,
+    head_oid: &str,
+    deadline: Option<Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<(Vec<String>, bool), WorkingTreeDiffError> {
+    let output = run_bounded_git_controlled(
+        repo,
+        &[
+            "-c",
+            "diff.external=",
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            baseline_oid,
+            head_oid,
+            "--",
+        ],
+        None,
+        GIT_OUTPUT_LIMIT,
+        deadline,
+        interrupted,
+    )?;
+    if !output.success {
+        return Err(WorkingTreeDiffError::InvalidRef);
+    }
+
+    let mut retained = BTreeSet::new();
+    let mut truncated = false;
+    for raw in nul_fields(&output.stdout) {
+        if interrupted.is_some_and(|check| check()) {
+            return Err(WorkingTreeDiffError::GitTimeout);
+        }
+        if is_mastermind_runtime_artifact(raw) {
+            continue;
+        }
+        let path = std::str::from_utf8(raw)
+            .map_err(|_| WorkingTreeDiffError::SnapshotChanged)?
+            .replace('\\', "/");
+        let parsed = Path::new(&path);
+        if parsed.is_absolute()
+            || parsed
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+        {
+            return Err(WorkingTreeDiffError::SnapshotChanged);
+        }
+        if retained.len() < CHANGE_FILE_LIMIT {
+            retained.insert(path);
+        } else if !retained.contains(&path) {
+            truncated = true;
+        }
+    }
+    Ok((retained.into_iter().collect(), truncated))
+}
+
 pub(crate) fn current_head_oid(repo: &Path) -> Result<String, WorkingTreeDiffError> {
     resolve_head(repo)
 }
@@ -761,6 +935,7 @@ fn nul_fields(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
         .filter(|field| !field.is_empty())
 }
 
+#[cfg(test)]
 fn collect_worktree_paths(
     repo: &Path,
     baseline_oid: &str,
@@ -871,6 +1046,7 @@ fn is_mastermind_runtime_artifact(path: &[u8]) -> bool {
     )
 }
 
+#[allow(dead_code)]
 fn baseline_blobs(
     repo: &Path,
     baseline_oid: &str,
@@ -894,6 +1070,7 @@ fn baseline_blobs(
 /// size of a large diff cannot trip the per-process output limit. Missing
 /// paths are returned as `None`, which is how temporal rewind represents files
 /// added after the baseline.
+#[allow(dead_code)]
 pub(crate) fn baseline_blobs_for_paths(
     repo: &Path,
     baseline_oid: &str,
@@ -1192,6 +1369,7 @@ pub(crate) fn validate_working_tree_snapshot_controlled(
     Ok(())
 }
 
+#[allow(dead_code)]
 pub(crate) fn working_tree_snapshot_token(
     repo: &Path,
     head_oid: &str,
@@ -1230,8 +1408,18 @@ fn working_tree_snapshot_token_controlled(
         digest.update(file.status.as_bytes());
         digest.update([0]);
         if file.status != "deleted" {
-            let bytes = std::fs::read(repo.join(&file.path))
-                .map_err(|_| WorkingTreeDiffError::SnapshotChanged)?;
+            let bytes = read_regular_file(
+                repo,
+                Path::new(&file.path),
+                MAX_INDEXABLE_FILE_SIZE,
+                MAX_INDEXABLE_FILE_SIZE,
+                ReadControl {
+                    deadline,
+                    interrupted,
+                },
+            )
+            .map_err(working_tree_read_error)?
+            .bytes;
             digest.update(Sha256::digest(bytes));
         }
     }
@@ -1244,11 +1432,10 @@ struct PerFileDiff {
     signature_changed: Vec<SignatureChange>,
 }
 
-fn diff_file(
+fn diff_file_from_blob(
     store: &Store,
-    repo_root: &Path,
-    git_ref: &str,
     rel_path: &str,
+    old_blob: Option<&[u8]>,
 ) -> Result<PerFileDiff, String> {
     let extractor = extractor_for_path(Path::new(rel_path));
 
@@ -1261,17 +1448,12 @@ fn diff_file(
         .filter(|s| s.kind != "module")
         .collect();
 
-    // Old side: parse blob at `git_ref`. Missing blob = file didn't exist at ref.
-    let old_blob = match git_show_blob(repo_root, git_ref, rel_path) {
-        Ok(Some(bytes)) => bytes,
-        Ok(None) => Vec::new(),
-        Err(e) => return Err(e),
-    };
-
-    let old_symbols: Vec<crate::store::PendingSymbol> = if old_blob.is_empty() {
+    // Old blobs were fetched in bounded `cat-file --batch` groups against one
+    // resolved commit. Missing means the file did not exist at the baseline.
+    let old_symbols: Vec<crate::store::PendingSymbol> = if old_blob.is_none_or(<[u8]>::is_empty) {
         Vec::new()
     } else if let Some(ext) = extractor {
-        let pending = parse_blob(rel_path, &old_blob, 0, ext.as_ref())
+        let pending = parse_blob(rel_path, old_blob.expect("checked above"), 0, ext.as_ref())
             .map_err(|e| format!("parse old blob: {e}"))?;
         pending
             .symbols
@@ -1344,119 +1526,6 @@ fn diff_file(
     })
 }
 
-// ----- git plumbing -------------------------------------------------------
-
-/// Spawn `command`, poll it with `try_wait` while draining stdout/stderr on
-/// background threads (so a full pipe can't masquerade as a hang), and kill
-/// it if it hasn't exited by `deadline`.
-fn run_with_deadline(
-    mut command: Command,
-    deadline: Duration,
-) -> Result<std::process::Output, DiffError> {
-    command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let start = Instant::now();
-    let mut child = command.spawn().map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            DiffError::GitNotFound
-        } else {
-            DiffError::GitFailed(e.to_string())
-        }
-    })?;
-    let stdout_pipe = child
-        .stdout
-        .take()
-        .ok_or_else(|| DiffError::GitFailed("no stdout pipe".to_string()))?;
-    let stderr_pipe = child
-        .stderr
-        .take()
-        .ok_or_else(|| DiffError::GitFailed("no stderr pipe".to_string()))?;
-    let stdout_rx = spawn_drain(stdout_pipe);
-    let stderr_rx = spawn_drain(stderr_pipe);
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) if start.elapsed() < deadline => {
-                std::thread::sleep(CHILD_POLL_INTERVAL);
-            }
-            Ok(None) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(DiffError::GitTimeout);
-            }
-            Err(e) => return Err(DiffError::GitFailed(e.to_string())),
-        }
-    };
-    let stdout = stdout_rx.recv().unwrap_or_default();
-    let stderr = stderr_rx.recv().unwrap_or_default();
-    Ok(std::process::Output {
-        status,
-        stdout,
-        stderr,
-    })
-}
-
-fn spawn_drain<R: Read + Send + 'static>(mut reader: R) -> mpsc::Receiver<Vec<u8>> {
-    let (sender, receiver) = mpsc::channel();
-    std::thread::spawn(move || {
-        let mut buffer = Vec::new();
-        let _ = reader.read_to_end(&mut buffer);
-        let _ = sender.send(buffer);
-    });
-    receiver
-}
-
-fn run_git(repo: &Path, args: &[&str]) -> Result<std::process::Output, DiffError> {
-    let mut command = git_command(args);
-    command.current_dir(repo);
-    run_with_deadline(command, run_git_timeout())
-}
-
-fn validate_ref(repo: &Path, git_ref: &str) -> Result<(), DiffError> {
-    let out = run_git(repo, &["rev-parse", "--verify", git_ref])?;
-    if !out.status.success() {
-        return Err(DiffError::GitRefMissing(git_ref.to_string()));
-    }
-    Ok(())
-}
-
-fn git_diff_name_only(repo: &Path, git_ref: &str) -> Result<Vec<String>, DiffError> {
-    let range = format!("{git_ref}..HEAD");
-    let out = run_git(repo, &["diff", "--name-only", &range])?;
-    if !out.status.success() {
-        return Err(DiffError::GitFailed(
-            String::from_utf8_lossy(&out.stderr).to_string(),
-        ));
-    }
-    let s = String::from_utf8_lossy(&out.stdout);
-    let mut files: Vec<String> = s
-        .lines()
-        .map(|l| l.trim().to_string())
-        .filter(|l| !l.is_empty())
-        .collect();
-    files.sort();
-    files.dedup();
-    Ok(files)
-}
-
-/// `Ok(None)` when the file didn't exist at `git_ref` (treated as "added in
-/// HEAD"). `Ok(Some(bytes))` is the raw blob content.
-fn git_show_blob(repo: &Path, git_ref: &str, rel_path: &str) -> Result<Option<Vec<u8>>, String> {
-    let spec = format!("{git_ref}:{rel_path}");
-    let mut command = git_command(&["show", &spec]);
-    command.current_dir(repo);
-    let out = run_with_deadline(command, run_git_timeout()).map_err(|e| e.to_string())?;
-    if !out.status.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr).to_string();
-        // git returns "fatal: path '...' does not exist in '<ref>'" for a new
-        // file. Treat as no-blob, not failure.
-        if stderr.contains("does not exist") || stderr.contains("exists on disk, but not in") {
-            return Ok(None);
-        }
-        return Err(format!("git show failed: {}", stderr.trim()));
-    }
-    Ok(Some(out.stdout))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1472,7 +1541,6 @@ mod tests {
         fn drop(&mut self) {
             TEST_GIT_INVOCATION.with(|value| value.borrow_mut().take());
             TEST_GIT_TIMEOUT.with(|value| value.borrow_mut().take());
-            TEST_RUN_GIT_TIMEOUT.with(|value| value.borrow_mut().take());
         }
     }
 
@@ -1485,7 +1553,6 @@ mod tests {
             ));
         });
         TEST_GIT_TIMEOUT.with(|value| *value.borrow_mut() = Some(timeout));
-        TEST_RUN_GIT_TIMEOUT.with(|value| *value.borrow_mut() = Some(timeout));
         GitInvocationGuard
     }
 
@@ -2010,28 +2077,6 @@ mod tests {
         let _ = fs::remove_file(pid_file);
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn git_timeout_kills_stuck_subprocess() {
-        // The fake `git` is a PATH shim that sleeps past the deadline.
-        let repo = env::temp_dir();
-        let _guard = override_git(
-            "python3",
-            &["-c", "import signal; signal.pause()"],
-            Duration::from_millis(50),
-        );
-
-        let started = Instant::now();
-        let result = run_git(&repo, &["ignored"]);
-        assert!(matches!(result, Err(DiffError::GitTimeout)));
-        assert!(started.elapsed() < Duration::from_secs(1));
-
-        let started = Instant::now();
-        let result = git_show_blob(&repo, "HEAD", "ignored.py");
-        assert!(result.is_err());
-        assert!(started.elapsed() < Duration::from_secs(1));
-    }
-
     #[test]
     fn symbols_changed_since_caps_file_loop() {
         let dir = init_repo("change_file_limit");
@@ -2092,6 +2137,30 @@ mod tests {
         let store = indexed_worktree(&dir);
         let error = symbols_changed_in_worktree(store.store(), &dir, "--help").unwrap_err();
         assert_eq!(error, WorkingTreeDiffError::InvalidRef);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn commit_resolver_rejects_oversized_and_non_commit_refs() {
+        let dir = init_repo("bounded_commit_ref");
+        write(&dir, "x.py", "def x():\n    pass\n");
+        run(&dir, &["add", "-A"]);
+        run(&dir, &["commit", "-q", "-m", "baseline"]);
+        assert_eq!(
+            resolve_commit(&dir, &"a".repeat(MAX_GIT_REF_BYTES + 1)),
+            Err(WorkingTreeDiffError::InvalidRef)
+        );
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD:x.py"])
+            .current_dir(&dir)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let blob = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(
+            resolve_commit(&dir, blob.trim()),
+            Err(WorkingTreeDiffError::InvalidRef)
+        );
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/mcp/servers/mmcg/src/indexer.rs
+++ b/mcp/servers/mmcg/src/indexer.rs
@@ -4,13 +4,17 @@
 //! walks the file tree, picks an extractor per extension, parses with tree-sitter
 //! in parallel via rayon, and serializes writes through one SQLite connection.
 
+use crate::bounded_fs::{
+    inspect_path_kind_with_capability, read_directory_names, read_directory_names_with_capability,
+    read_regular_file, read_regular_file_expected, read_regular_file_with_capability,
+    BoundedPathKind, BoundedReadError, ReadControl, RootCapability, StableFileIdentity,
+};
 use crate::store::{PendingFile, PendingSymbol, Store};
 use ignore::{IncrementalIgnore, WalkBuilder};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use tree_sitter::{Parser, Tree};
@@ -78,6 +82,10 @@ const BINARY_SNIFF_BYTES: u64 = 8 * 1024;
 const GIT_TRACKED_PATH_OUTPUT_LIMIT: usize = 64 * 1024 * 1024;
 const MAX_HISTORY_ARTIFACT_SIZE: u64 = 1024 * 1024;
 const MAX_HISTORY_ENTRIES: usize = 5_000;
+const MAX_HISTORY_AGGREGATE_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_HISTORY_DIRECTORY_ENTRIES: usize = 50_000;
+pub const AUTO_REFRESH_SOURCE_CANDIDATE_LIMIT: usize = 20_000;
+pub const AUTO_REFRESH_SOURCE_AGGREGATE_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Parsed files waiting for the single SQLite writer at once. This bounds peak
 /// memory without changing the existing parallel-parse/single-writer model.
@@ -193,6 +201,41 @@ pub struct Indexer {
     root: PathBuf,
 }
 
+struct ProjectHistorySnapshot {
+    entries: Vec<crate::store::ProjectHistoryEntry>,
+    stats: ProjectHistoryIndexStats,
+    inventory_token: String,
+}
+
+type HistoryCandidate = (PathBuf, &'static str);
+type HistoryCandidateInventory = (Vec<HistoryCandidate>, bool);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectHistoryFreshness {
+    Fresh,
+    Stale,
+    Incomplete,
+    SnapshotChanged,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct IndexLimits {
+    source_candidates: Option<usize>,
+    source_declared_bytes: Option<u64>,
+}
+
+impl IndexLimits {
+    pub(crate) const MANUAL: Self = Self {
+        source_candidates: None,
+        source_declared_bytes: None,
+    };
+
+    pub(crate) const AUTO_REFRESH: Self = Self {
+        source_candidates: Some(AUTO_REFRESH_SOURCE_CANDIDATE_LIMIT),
+        source_declared_bytes: Some(AUTO_REFRESH_SOURCE_AGGREGATE_BYTES),
+    };
+}
+
 impl Indexer {
     pub fn new(root: impl Into<PathBuf>) -> Self {
         Self { root: root.into() }
@@ -248,6 +291,15 @@ impl Indexer {
     ///
     /// Files in the index but gone from disk are purged at the end. Writes to `store`.
     pub fn index_all(&self, store: &mut Store, force_full: bool) -> Result<IndexStats, IndexError> {
+        self.index_all_with_limits(store, force_full, IndexLimits::MANUAL)
+    }
+
+    pub(crate) fn index_all_with_limits(
+        &self,
+        store: &mut Store,
+        force_full: bool,
+        limits: IndexLimits,
+    ) -> Result<IndexStats, IndexError> {
         let start = SystemTime::now();
         ensure_indexing_active(store)?;
         self.bind_or_validate_index_root(store)?;
@@ -262,9 +314,24 @@ impl Indexer {
                 .map_err(|error| IndexError::Other(error.to_string()))?
                 > 0;
         let force_full = force_full || !extractor_contract_current;
+        let root_capability = if limits == IndexLimits::MANUAL {
+            None
+        } else {
+            Some(RootCapability::open(&self.root).map_err(index_error_from_read)?)
+        };
 
         // Phase 1: walk filesystem
-        let candidates = source_candidates(&self.root);
+        let candidates = {
+            let interrupted = || store.work_interrupted();
+            let control = ReadControl {
+                deadline: store.request_deadline(),
+                interrupted: Some(&interrupted),
+            };
+            match (root_capability.as_ref(), limits.source_candidates) {
+                (Some(root), Some(limit)) => source_candidates_bounded(root, limit, control)?,
+                _ => source_candidates_controlled(&self.root, None, control)?,
+            }
+        };
         ensure_indexing_active(store)?;
 
         let mut stats = IndexStats {
@@ -277,6 +344,8 @@ impl Indexer {
         let mut to_parse: Vec<PathBuf> = Vec::new();
         let mut current_paths: std::collections::HashSet<String> =
             std::collections::HashSet::with_capacity(candidates.len());
+        let mut admitted_identities: HashMap<PathBuf, StableFileIdentity> = HashMap::new();
+        let mut declared_source_bytes = 0_u64;
 
         for path in &candidates {
             ensure_indexing_active(store)?;
@@ -290,8 +359,19 @@ impl Indexer {
                 push_path_sample(&mut stats.skipped_paths, &rel);
                 continue;
             }
-            match source_admission(path) {
-                Ok(()) => {}
+            let admission = {
+                let interrupted = || store.work_interrupted();
+                let control = ReadControl {
+                    deadline: store.request_deadline(),
+                    interrupted: Some(&interrupted),
+                };
+                match root_capability.as_ref() {
+                    Some(root) => source_admission_with_capability(root, path, control),
+                    None => source_admission_controlled(&self.root, path, control),
+                }
+            };
+            let admitted = match admission {
+                Ok(admitted) => admitted,
                 Err(IndexError::Skipped(IndexSkipReason::Binary)) => {
                     stats.files_skipped_binary += 1;
                     push_path_sample(&mut stats.skipped_binary_paths, &rel);
@@ -302,20 +382,32 @@ impl Indexer {
                     push_path_sample(&mut stats.skipped_too_large_paths, &rel);
                     continue;
                 }
+                Err(error @ (IndexError::Cancelled | IndexError::DeadlineExceeded))
+                | Err(error @ IndexError::LimitExceeded { .. }) => return Err(error),
                 Err(_) => {
                     stats.files_failed += 1;
                     continue;
                 }
+            };
+            declared_source_bytes = declared_source_bytes
+                .checked_add(admitted.declared_len)
+                .ok_or(IndexError::LimitExceeded {
+                    dimension: "source_declared_bytes",
+                    cap: limits.source_declared_bytes.unwrap_or(u64::MAX),
+                })?;
+            if limits
+                .source_declared_bytes
+                .is_some_and(|cap| declared_source_bytes > cap)
+            {
+                return Err(IndexError::LimitExceeded {
+                    dimension: "source_declared_bytes",
+                    cap: limits.source_declared_bytes.unwrap_or(u64::MAX),
+                });
             }
             current_paths.insert(rel.clone());
 
             if !force_full {
-                let fs_mtime = path
-                    .metadata()
-                    .and_then(|m| m.modified())
-                    .ok()
-                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                    .map(|d| d.as_millis() as i64);
+                let fs_mtime = Some(admitted.modified_millis);
 
                 if let (Some(fs_mt), Ok(Some(stored_mt))) = (fs_mtime, store.file_mtime(&rel)) {
                     if fs_mt <= stored_mt {
@@ -325,6 +417,9 @@ impl Indexer {
                 }
             }
 
+            if limits != IndexLimits::MANUAL {
+                admitted_identities.insert(path.clone(), admitted.identity);
+            }
             to_parse.push(path.clone());
         }
 
@@ -333,16 +428,47 @@ impl Indexer {
         // collection retained every PendingFile until parsing the whole repository.
         for batch in to_parse.chunks(PARSE_BATCH_SIZE) {
             ensure_indexing_active(store)?;
-            let parsed: Vec<(PathBuf, Result<PendingFile, IndexError>)> = batch
-                .par_iter()
-                .filter_map(|path| {
-                    let extractor = extractor_for_path(path)?;
-                    Some((
-                        path.clone(),
-                        parse_one(path, &self.root, extractor.as_ref()),
-                    ))
-                })
-                .collect();
+            let parsed: Vec<(PathBuf, Result<PendingFile, IndexError>)> = if limits
+                == IndexLimits::MANUAL
+            {
+                batch
+                    .par_iter()
+                    .filter_map(|path| {
+                        let extractor = extractor_for_path(path)?;
+                        Some((
+                            path.clone(),
+                            parse_one(path, &self.root, extractor.as_ref()),
+                        ))
+                    })
+                    .collect()
+            } else {
+                batch
+                    .iter()
+                    .filter_map(|path| {
+                        let extractor = extractor_for_path(path)?;
+                        let interrupted = || store.work_interrupted();
+                        let Some(expected_identity) = admitted_identities.get(path).copied() else {
+                            return Some((path.clone(), Err(IndexError::SnapshotChanged)));
+                        };
+                        Some((
+                            path.clone(),
+                            parse_one_controlled(
+                                path,
+                                &self.root,
+                                root_capability
+                                    .as_ref()
+                                    .expect("automatic refresh pins its root"),
+                                expected_identity,
+                                extractor.as_ref(),
+                                ReadControl {
+                                    deadline: store.request_deadline(),
+                                    interrupted: Some(&interrupted),
+                                },
+                            ),
+                        ))
+                    })
+                    .collect()
+            };
             ensure_indexing_active(store)?;
 
             for (path, outcome) in parsed {
@@ -372,6 +498,8 @@ impl Indexer {
                         stats.files_skipped_too_large += 1;
                         push_path_sample(&mut stats.skipped_too_large_paths, &rel);
                     }
+                    Err(error @ (IndexError::Cancelled | IndexError::DeadlineExceeded))
+                    | Err(error @ IndexError::LimitExceeded { .. }) => return Err(error),
                     Err(_) => stats.files_failed += 1,
                 }
             }
@@ -428,7 +556,9 @@ impl Indexer {
     pub fn index_task_specs(&self, store: &mut Store) -> Result<u32, IndexError> {
         ensure_indexing_active(store)?;
         let tasks_dir = self.root.join(".mastermind").join("tasks");
-        if !tasks_dir.is_dir() {
+        if !std::fs::symlink_metadata(&tasks_dir).is_ok_and(|metadata| {
+            metadata.file_type().is_dir() && !metadata.file_type().is_symlink()
+        }) {
             // No `.mastermind/tasks/` — clear any stale entries from a prior run too.
             store
                 .replace_task_specs(&[])
@@ -437,20 +567,40 @@ impl Indexer {
         }
 
         let mut entries: Vec<crate::store::TaskSpecEntry> = Vec::new();
-        for dirent in std::fs::read_dir(&tasks_dir).map_err(|e| IndexError::Io(e.to_string()))? {
+        let interrupted = || store.work_interrupted();
+        let control = ReadControl {
+            deadline: store.request_deadline(),
+            interrupted: Some(&interrupted),
+        };
+        let names = read_directory_names(&self.root, &tasks_dir, MAX_HISTORY_ENTRIES, control)
+            .map_err(index_error_from_read)?;
+        for name in names {
             ensure_indexing_active(store)?;
-            let dirent = dirent.map_err(|e| IndexError::Io(e.to_string()))?;
-            let path = dirent.path();
-            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            let Some(name) = name.to_str() else {
                 continue;
             };
+            let path = tasks_dir.join(name);
             // Per-task folders only. Bare top-level `.md` (legacy 0.6.x) and
             // `_`-prefixed names (shared assets, private scratch) are excluded.
-            if !path.is_dir() || name.starts_with('_') || name.starts_with('.') {
+            if name.starts_with('_')
+                || name.starts_with('.')
+                || !std::fs::symlink_metadata(&path).is_ok_and(|metadata| {
+                    metadata.file_type().is_dir() && !metadata.file_type().is_symlink()
+                })
+            {
                 continue;
             }
             let spec_path = path.join("spec.md");
-            let Ok(body) = std::fs::read_to_string(&spec_path) else {
+            let Ok(read) = read_regular_file(
+                &self.root,
+                &spec_path,
+                MAX_HISTORY_ARTIFACT_SIZE,
+                MAX_HISTORY_ARTIFACT_SIZE,
+                control,
+            ) else {
+                continue;
+            };
+            let Ok(body) = String::from_utf8(read.bytes) else {
                 continue;
             };
             let title = extract_spec_title(&body, name);
@@ -482,149 +632,199 @@ impl Indexer {
     ) -> Result<ProjectHistoryIndexStats, IndexError> {
         ensure_indexing_active(store)?;
         self.bind_or_validate_index_root(store)?;
-        let mut candidates: Vec<(PathBuf, &'static str)> = Vec::new();
+        let snapshot = {
+            let interrupted = || store.work_interrupted();
+            self.project_history_snapshot(ReadControl {
+                deadline: store.request_deadline(),
+                interrupted: Some(&interrupted),
+            })?
+        };
+        ensure_indexing_active(store)?;
+        store
+            .replace_project_history_snapshot(
+                &snapshot.entries,
+                snapshot.stats.skipped,
+                snapshot.stats.truncated,
+                &snapshot.inventory_token,
+            )
+            .map_err(|error| IndexError::Other(error.to_string()))?;
+        Ok(snapshot.stats)
+    }
+
+    pub(crate) fn project_history_freshness(
+        &self,
+        store: &Store,
+    ) -> Result<ProjectHistoryFreshness, IndexError> {
+        self.live_project_history_inventory(store)
+            .map(|(_, freshness)| freshness)
+    }
+
+    pub(crate) fn live_project_history_inventory(
+        &self,
+        store: &Store,
+    ) -> Result<(String, ProjectHistoryFreshness), IndexError> {
+        let interrupted = || store.work_interrupted();
+        let snapshot = match self.project_history_snapshot(ReadControl {
+            deadline: store.request_deadline(),
+            interrupted: Some(&interrupted),
+        }) {
+            Ok(snapshot) => snapshot,
+            Err(IndexError::SnapshotChanged) => {
+                return Ok((String::new(), ProjectHistoryFreshness::SnapshotChanged))
+            }
+            Err(error) => return Err(error),
+        };
+        let stored = store
+            .meta_value("project_history_inventory_token")
+            .map_err(|error| IndexError::Other(error.to_string()))?;
+        let freshness = if stored.as_deref() != Some(snapshot.inventory_token.as_str()) {
+            ProjectHistoryFreshness::Stale
+        } else if snapshot.stats.skipped > 0 || snapshot.stats.truncated {
+            ProjectHistoryFreshness::Incomplete
+        } else {
+            ProjectHistoryFreshness::Fresh
+        };
+        Ok((snapshot.inventory_token, freshness))
+    }
+
+    fn project_history_snapshot(
+        &self,
+        control: ReadControl<'_>,
+    ) -> Result<ProjectHistorySnapshot, IndexError> {
+        let root = RootCapability::open(&self.root).map_err(index_error_from_read)?;
+        let first = self.project_history_snapshot_once(&root, control)?;
+        control.check().map_err(index_error_from_read)?;
+        let second = self.project_history_snapshot_once(&root, control)?;
+        if first.inventory_token != second.inventory_token
+            || first.stats.indexed != second.stats.indexed
+            || first.stats.skipped != second.stats.skipped
+            || first.stats.truncated != second.stats.truncated
         {
-            let mut add_if_present = |path: PathBuf, kind: &'static str| {
-                if std::fs::symlink_metadata(&path).is_ok() {
-                    candidates.push((path, kind));
-                }
-            };
-            add_if_present(self.root.join("CONTEXT.md"), "context");
-            if let Ok(entries) = std::fs::read_dir(&self.root) {
-                for entry in entries.flatten() {
-                    ensure_indexing_active(store)?;
-                    let path = entry.path();
-                    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
-                        continue;
-                    };
-                    if name.starts_with("CONTEXT-archive-") && name.ends_with(".md") {
-                        add_if_present(path, "context");
-                    }
-                }
-            }
-
-            let tasks_dir = self.root.join(".mastermind").join("tasks");
-            add_if_present(tasks_dir.join("_lessons.md"), "lesson");
-            if tasks_dir.is_dir() {
-                for dirent in std::fs::read_dir(&tasks_dir)
-                    .map_err(|error| IndexError::Io(error.to_string()))?
-                {
-                    ensure_indexing_active(store)?;
-                    let dirent = dirent.map_err(|error| IndexError::Io(error.to_string()))?;
-                    let path = dirent.path();
-                    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
-                        continue;
-                    };
-                    let Ok(metadata) = std::fs::symlink_metadata(&path) else {
-                        continue;
-                    };
-                    if !metadata.file_type().is_dir()
-                        || metadata.file_type().is_symlink()
-                        || name.starts_with('_')
-                        || name.starts_with('.')
-                    {
-                        continue;
-                    }
-                    add_if_present(path.join("spec.md"), "task_spec");
-                    add_if_present(path.join("executor-report.md"), "executor_report");
-                    add_if_present(path.join("audit.md"), "audit");
-                    // Pre-0.39 tasks could keep release notes beside the spec.
-                    add_if_present(path.join("release-notes.md"), "release_notes");
-                }
-            }
-            let releases_dir = self.root.join(".mastermind").join("releases");
-            if let Ok(entries) = std::fs::read_dir(&releases_dir) {
-                for entry in entries.flatten() {
-                    ensure_indexing_active(store)?;
-                    let path = entry.path();
-                    let is_markdown =
-                        path.extension().and_then(|value| value.to_str()) == Some("md");
-                    if is_markdown {
-                        add_if_present(path, "release_notes");
-                    }
-                }
-            }
+            return Err(IndexError::SnapshotChanged);
         }
-        let mut decision_roots = [
-            "docs/adr",
-            "docs/adrs",
-            "docs/decisions",
-            "adr",
-            "adrs",
-            ".mastermind/decisions",
-        ]
-        .map(|relative| self.root.join(relative));
-        decision_roots.sort();
-        let mut decision_directories = 0usize;
-        let mut decision_truncated = false;
-        for decision_root in decision_roots {
-            ensure_indexing_active(store)?;
-            decision_truncated |= add_markdown_tree_candidates(
-                &decision_root,
-                "architecture_decision",
-                &mut candidates,
-                &mut decision_directories,
-            );
-        }
-        candidates.sort_by(|left, right| left.0.cmp(&right.0));
-        candidates.dedup_by(|left, right| left.0 == right.0);
-        let truncated = decision_truncated || candidates.len() > MAX_HISTORY_ENTRIES;
-        candidates.truncate(MAX_HISTORY_ENTRIES);
+        root.verify().map_err(index_error_from_read)?;
+        Ok(second)
+    }
 
+    fn project_history_snapshot_once(
+        &self,
+        root: &RootCapability,
+        control: ReadControl<'_>,
+    ) -> Result<ProjectHistorySnapshot, IndexError> {
+        let (mut candidates, mut truncated) = collect_project_history_candidates(root, control)?;
+        candidates
+            .sort_by(|left, right| (left.0.as_path(), left.1).cmp(&(right.0.as_path(), right.1)));
+        candidates.dedup_by(|left, right| left.0 == right.0 && left.1 == right.1);
+        if candidates.len() > MAX_HISTORY_ENTRIES {
+            truncated = true;
+            candidates.truncate(MAX_HISTORY_ENTRIES);
+        }
+
+        let mut digest = Sha256::new();
+        digest.update(b"mmcg-project-history-inventory-v1\0");
         let mut entries = Vec::new();
         let mut skipped = 0_u32;
+        let mut aggregate_bytes = 0_u64;
         for (path, kind) in candidates {
-            ensure_indexing_active(store)?;
-            let Ok(metadata) = std::fs::symlink_metadata(&path) else {
-                skipped += 1;
+            control.check().map_err(index_error_from_read)?;
+            let relative = path
+                .strip_prefix(root.canonical_root())
+                .map_err(|_| IndexError::SnapshotChanged)?
+                .to_string_lossy()
+                .replace('\\', "/");
+            digest.update(relative.as_bytes());
+            digest.update([0]);
+            digest.update(kind.as_bytes());
+            digest.update([0]);
+
+            let inspected = match read_regular_file_with_capability(
+                root,
+                &path,
+                MAX_HISTORY_ARTIFACT_SIZE,
+                0,
+                control,
+            ) {
+                Ok(file) => file,
+                Err(BoundedReadError::Interrupted) => return Err(IndexError::Cancelled),
+                Err(BoundedReadError::DeadlineExceeded) => {
+                    return Err(IndexError::DeadlineExceeded)
+                }
+                Err(BoundedReadError::SnapshotChanged) => return Err(IndexError::SnapshotChanged),
+                Err(error) => {
+                    skipped = skipped.saturating_add(1);
+                    digest.update(history_error_class(&error));
+                    digest.update([0]);
+                    continue;
+                }
+            };
+            let Some(next_aggregate) = aggregate_bytes.checked_add(inspected.declared_len) else {
+                truncated = true;
+                digest.update(b"aggregate_overflow\0");
                 continue;
             };
-            if !metadata.file_type().is_file()
-                || metadata.file_type().is_symlink()
-                || metadata.len() > MAX_HISTORY_ARTIFACT_SIZE
-            {
-                skipped += 1;
+            if next_aggregate > MAX_HISTORY_AGGREGATE_BYTES {
+                truncated = true;
+                digest.update(b"aggregate_omitted\0");
                 continue;
             }
-            let Ok(body) = std::fs::read_to_string(&path) else {
-                skipped += 1;
-                continue;
+            let read = match read_regular_file_expected(
+                root,
+                &path,
+                MAX_HISTORY_ARTIFACT_SIZE,
+                MAX_HISTORY_ARTIFACT_SIZE,
+                control,
+                Some(inspected.identity),
+            ) {
+                Ok(file) => file,
+                Err(BoundedReadError::Interrupted) => return Err(IndexError::Cancelled),
+                Err(BoundedReadError::DeadlineExceeded) => {
+                    return Err(IndexError::DeadlineExceeded)
+                }
+                Err(BoundedReadError::SnapshotChanged) => return Err(IndexError::SnapshotChanged),
+                Err(error) => {
+                    skipped = skipped.saturating_add(1);
+                    digest.update(history_error_class(&error));
+                    digest.update([0]);
+                    continue;
+                }
             };
+            let content_digest = Sha256::digest(&read.bytes);
+            digest.update(read.declared_len.to_le_bytes());
+            digest.update(content_digest);
+            digest.update([0]);
+            let body = match String::from_utf8(read.bytes) {
+                Ok(body) => body,
+                Err(_) => {
+                    skipped = skipped.saturating_add(1);
+                    digest.update(b"invalid_utf8\0");
+                    continue;
+                }
+            };
+            aggregate_bytes = next_aggregate;
             let fallback = path
                 .file_stem()
                 .and_then(|value| value.to_str())
                 .unwrap_or(kind);
             let title = extract_spec_title(&body, fallback);
-            let rel = path
-                .strip_prefix(&self.root)
-                .unwrap_or(&path)
-                .to_string_lossy()
-                .replace('\\', "/");
             entries.push(crate::store::ProjectHistoryEntry {
-                path: rel,
+                path: relative,
                 kind: kind.to_string(),
                 title,
                 body,
             });
         }
-        let count = entries.len() as u32;
-        ensure_indexing_active(store)?;
-        store
-            .replace_project_history(&entries)
-            .map_err(|error| IndexError::Other(error.to_string()))?;
-        store
-            .set_meta("project_history_skipped", &skipped.to_string())
-            .map_err(|error| IndexError::Other(error.to_string()))?;
-        store
-            .set_meta(
-                "project_history_truncated",
-                if truncated { "true" } else { "false" },
-            )
-            .map_err(|error| IndexError::Other(error.to_string()))?;
-        Ok(ProjectHistoryIndexStats {
-            indexed: count,
+        digest.update(skipped.to_le_bytes());
+        digest.update([u8::from(truncated)]);
+        digest.update(aggregate_bytes.to_le_bytes());
+        let stats = ProjectHistoryIndexStats {
+            indexed: entries.len() as u32,
             skipped,
             truncated,
+        };
+        Ok(ProjectHistorySnapshot {
+            entries,
+            stats,
+            inventory_token: crate::hex::encode(&digest.finalize()),
         })
     }
 
@@ -641,59 +841,258 @@ impl Indexer {
     }
 }
 
-fn add_markdown_tree_candidates(
-    root: &Path,
-    kind: &'static str,
-    candidates: &mut Vec<(PathBuf, &'static str)>,
-    visited_directories: &mut usize,
-) -> bool {
-    let metadata = match std::fs::symlink_metadata(root) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return false,
-        Err(_) => return true,
-    };
-    if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
-        return false;
+fn history_error_class(error: &BoundedReadError) -> &'static [u8] {
+    match error {
+        BoundedReadError::InvalidPath => b"invalid_path",
+        BoundedReadError::OutsideRoot => b"outside_root",
+        BoundedReadError::NotRegular => b"not_regular",
+        BoundedReadError::TooLarge { .. } => b"too_large",
+        BoundedReadError::SnapshotChanged => b"snapshot_changed",
+        BoundedReadError::Interrupted => b"cancelled",
+        BoundedReadError::DeadlineExceeded => b"deadline",
+        BoundedReadError::Io(_) => b"io",
     }
-    let mut pending = vec![root.to_path_buf()];
-    while let Some(directory) = pending.pop() {
-        if candidates.len() > MAX_HISTORY_ENTRIES || *visited_directories >= MAX_HISTORY_ENTRIES {
-            return true;
+}
+
+fn history_directory_names(
+    root: &RootCapability,
+    directory: &Path,
+    remaining_entries: usize,
+    control: ReadControl<'_>,
+) -> Result<Option<Vec<std::ffi::OsString>>, IndexError> {
+    match read_directory_names_with_capability(root, directory, remaining_entries, control) {
+        Ok(names) => Ok(Some(names)),
+        Err(BoundedReadError::Interrupted) => Err(IndexError::Cancelled),
+        Err(BoundedReadError::DeadlineExceeded) => Err(IndexError::DeadlineExceeded),
+        Err(BoundedReadError::SnapshotChanged) => Err(IndexError::SnapshotChanged),
+        Err(BoundedReadError::TooLarge { .. }) => Ok(None),
+        Err(_) => Ok(None),
+    }
+}
+
+fn history_path_kind(
+    root: &RootCapability,
+    path: &Path,
+    control: ReadControl<'_>,
+) -> Result<Option<BoundedPathKind>, IndexError> {
+    match inspect_path_kind_with_capability(root, path, control) {
+        Ok(kind) => Ok(Some(kind)),
+        Err(BoundedReadError::Interrupted) => Err(IndexError::Cancelled),
+        Err(BoundedReadError::DeadlineExceeded) => Err(IndexError::DeadlineExceeded),
+        Err(BoundedReadError::SnapshotChanged) => Err(IndexError::SnapshotChanged),
+        Err(BoundedReadError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(None)
         }
-        *visited_directories += 1;
-        let entries = match std::fs::read_dir(&directory) {
-            Ok(entries) => entries,
-            Err(_) => return true,
-        };
-        let mut entries = entries.filter_map(Result::ok).collect::<Vec<_>>();
-        entries.sort_by_key(std::fs::DirEntry::path);
-        let mut directories = Vec::new();
-        for entry in entries {
-            let path = entry.path();
-            let Ok(metadata) = std::fs::symlink_metadata(&path) else {
-                continue;
-            };
-            if metadata.file_type().is_symlink() {
-                continue;
+        Err(_) => Ok(Some(BoundedPathKind::Other)),
+    }
+}
+
+fn add_history_candidate(
+    root: &RootCapability,
+    candidates: &mut Vec<HistoryCandidate>,
+    path: PathBuf,
+    kind: &'static str,
+    control: ReadControl<'_>,
+) -> Result<(), IndexError> {
+    if history_path_kind(root, &path, control)? == Some(BoundedPathKind::RegularFile) {
+        candidates.push((path, kind));
+    }
+    Ok(())
+}
+
+fn collect_project_history_candidates(
+    root: &RootCapability,
+    control: ReadControl<'_>,
+) -> Result<HistoryCandidateInventory, IndexError> {
+    let root_path = root.canonical_root();
+    let mut candidates = Vec::new();
+    let mut truncated = false;
+    let mut directory_entries = 0usize;
+
+    add_history_candidate(
+        root,
+        &mut candidates,
+        root_path.join("CONTEXT.md"),
+        "context",
+        control,
+    )?;
+    match history_directory_names(
+        root,
+        root_path,
+        MAX_HISTORY_DIRECTORY_ENTRIES.saturating_sub(directory_entries),
+        control,
+    )? {
+        Some(names) => {
+            directory_entries = directory_entries.saturating_add(names.len());
+            for name in names {
+                control.check().map_err(index_error_from_read)?;
+                let Some(name) = name.to_str() else { continue };
+                if name.starts_with("CONTEXT-archive-") && name.ends_with(".md") {
+                    add_history_candidate(
+                        root,
+                        &mut candidates,
+                        root_path.join(name),
+                        "context",
+                        control,
+                    )?;
+                }
             }
-            if metadata.file_type().is_dir() {
-                directories.push(path);
-            } else if metadata.file_type().is_file()
+        }
+        None => truncated = true,
+    }
+
+    let tasks_dir = root_path.join(".mastermind").join("tasks");
+    add_history_candidate(
+        root,
+        &mut candidates,
+        tasks_dir.join("_lessons.md"),
+        "lesson",
+        control,
+    )?;
+    if history_path_kind(root, &tasks_dir, control)? == Some(BoundedPathKind::Directory) {
+        match history_directory_names(
+            root,
+            &tasks_dir,
+            MAX_HISTORY_DIRECTORY_ENTRIES.saturating_sub(directory_entries),
+            control,
+        )? {
+            Some(names) => {
+                directory_entries = directory_entries.saturating_add(names.len());
+                for name in names {
+                    control.check().map_err(index_error_from_read)?;
+                    let Some(name) = name.to_str() else { continue };
+                    if name.starts_with('_') || name.starts_with('.') {
+                        continue;
+                    }
+                    let path = tasks_dir.join(name);
+                    if history_path_kind(root, &path, control)? != Some(BoundedPathKind::Directory)
+                    {
+                        continue;
+                    }
+                    add_history_candidate(
+                        root,
+                        &mut candidates,
+                        path.join("spec.md"),
+                        "task_spec",
+                        control,
+                    )?;
+                    add_history_candidate(
+                        root,
+                        &mut candidates,
+                        path.join("executor-report.md"),
+                        "executor_report",
+                        control,
+                    )?;
+                    add_history_candidate(
+                        root,
+                        &mut candidates,
+                        path.join("audit.md"),
+                        "audit",
+                        control,
+                    )?;
+                    // Tasks created before 0.39 can keep release notes beside the spec.
+                    add_history_candidate(
+                        root,
+                        &mut candidates,
+                        path.join("release-notes.md"),
+                        "release_notes",
+                        control,
+                    )?;
+                }
+            }
+            None => truncated = true,
+        }
+    }
+
+    let releases_dir = root_path.join(".mastermind").join("releases");
+    if history_path_kind(root, &releases_dir, control)? == Some(BoundedPathKind::Directory) {
+        match history_directory_names(
+            root,
+            &releases_dir,
+            MAX_HISTORY_DIRECTORY_ENTRIES.saturating_sub(directory_entries),
+            control,
+        )? {
+            Some(names) => {
+                directory_entries = directory_entries.saturating_add(names.len());
+                for name in names {
+                    control.check().map_err(index_error_from_read)?;
+                    let path = releases_dir.join(name);
+                    if path
+                        .extension()
+                        .and_then(|value| value.to_str())
+                        .is_some_and(|value| value.eq_ignore_ascii_case("md"))
+                    {
+                        add_history_candidate(
+                            root,
+                            &mut candidates,
+                            path,
+                            "release_notes",
+                            control,
+                        )?;
+                    }
+                }
+            }
+            None => truncated = true,
+        }
+    }
+
+    let mut decision_roots = [
+        "docs/adr",
+        "docs/adrs",
+        "docs/decisions",
+        "adr",
+        "adrs",
+        ".mastermind/decisions",
+    ]
+    .map(|relative| root_path.join(relative));
+    decision_roots.sort();
+    let mut pending = decision_roots.to_vec();
+    let mut visited_directories = 0usize;
+    while let Some(directory) = pending.pop() {
+        control.check().map_err(index_error_from_read)?;
+        if candidates.len() > MAX_HISTORY_ENTRIES
+            || visited_directories >= MAX_HISTORY_ENTRIES
+            || directory_entries >= MAX_HISTORY_DIRECTORY_ENTRIES
+        {
+            truncated = true;
+            break;
+        }
+        let exists = history_path_kind(root, &directory, control)?;
+        if exists != Some(BoundedPathKind::Directory) {
+            continue;
+        }
+        let Some(names) = history_directory_names(
+            root,
+            &directory,
+            MAX_HISTORY_DIRECTORY_ENTRIES.saturating_sub(directory_entries),
+            control,
+        )?
+        else {
+            truncated = true;
+            continue;
+        };
+        visited_directories = visited_directories.saturating_add(1);
+        directory_entries = directory_entries.saturating_add(names.len());
+        let mut child_directories = Vec::new();
+        for name in names {
+            let path = directory.join(name);
+            let kind = history_path_kind(root, &path, control)?;
+            if kind == Some(BoundedPathKind::Directory) {
+                child_directories.push(path);
+            } else if kind == Some(BoundedPathKind::RegularFile)
                 && path
                     .extension()
                     .and_then(|value| value.to_str())
                     .is_some_and(|value| value.eq_ignore_ascii_case("md"))
             {
-                candidates.push((path, kind));
-                if candidates.len() > MAX_HISTORY_ENTRIES {
-                    return true;
-                }
+                candidates.push((path, "architecture_decision"));
             }
         }
-        directories.reverse();
-        pending.extend(directories);
+        child_directories.sort();
+        child_directories.reverse();
+        pending.extend(child_directories);
     }
-    false
+    Ok((candidates, truncated))
 }
 
 fn push_path_sample(samples: &mut Vec<String>, path: &str) {
@@ -727,11 +1126,20 @@ fn git_tracked_relative_paths(root: &Path) -> Vec<PathBuf> {
 pub(crate) fn tracked_relative_paths(
     root: &Path,
 ) -> Result<Vec<PathBuf>, crate::diff::WorkingTreeDiffError> {
-    let output = crate::diff::run_bounded_git_with_limit(
+    tracked_relative_paths_controlled(root, ReadControl::default())
+}
+
+fn tracked_relative_paths_controlled(
+    root: &Path,
+    control: ReadControl<'_>,
+) -> Result<Vec<PathBuf>, crate::diff::WorkingTreeDiffError> {
+    let output = crate::diff::run_bounded_git_with_control(
         root,
         &["ls-files", "--cached", "-z", "--"],
         None,
         GIT_TRACKED_PATH_OUTPUT_LIMIT,
+        control.deadline,
+        control.interrupted,
     )?;
     if !output.success {
         return Err(crate::diff::WorkingTreeDiffError::GitUnavailable);
@@ -766,26 +1174,127 @@ fn source_walk_builder(root: &Path) -> WalkBuilder {
 /// All non-ignored files below `root`, in deterministic path order. Language
 /// filtering and content admission happen separately so stats stay truthful.
 pub(crate) fn source_candidates(root: &Path) -> Vec<PathBuf> {
-    let tracked = git_tracked_relative_paths(root);
-    let mut tracked_by_identity = HashMap::with_capacity(tracked.len());
-    for relative in &tracked {
-        let absolute = root.join(relative);
-        let identity = absolute.canonicalize().unwrap_or_else(|_| absolute.clone());
-        tracked_by_identity.insert(identity, absolute);
-    }
+    source_candidates_controlled(root, None, ReadControl::default()).unwrap_or_default()
+}
 
-    let mut paths: BTreeSet<PathBuf> = source_walk_builder(root)
-        .build()
-        .filter_map(Result::ok)
-        .filter(|entry| entry.file_type().is_some_and(|kind| kind.is_file()))
-        .map(|entry| {
-            let path = entry.into_path();
-            let identity = path.canonicalize().unwrap_or_else(|_| path.clone());
-            tracked_by_identity.get(&identity).cloned().unwrap_or(path)
-        })
-        .collect();
-    paths.extend(tracked.into_iter().map(|relative| root.join(relative)));
-    paths.into_iter().collect()
+pub(crate) fn source_candidates_bounded(
+    root: &RootCapability,
+    limit: usize,
+    control: ReadControl<'_>,
+) -> Result<Vec<PathBuf>, IndexError> {
+    control.check().map_err(index_error_from_read)?;
+    root.verify().map_err(index_error_from_read)?;
+    let output = crate::diff::run_bounded_git_with_control(
+        root.canonical_root(),
+        &[
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+        ],
+        None,
+        GIT_TRACKED_PATH_OUTPUT_LIMIT,
+        control.deadline,
+        control.interrupted,
+    )
+    .map_err(|error| match error {
+        crate::diff::WorkingTreeDiffError::GitTimeout
+            if control.interrupted.is_some_and(|check| check()) =>
+        {
+            IndexError::Cancelled
+        }
+        crate::diff::WorkingTreeDiffError::GitTimeout => IndexError::DeadlineExceeded,
+        crate::diff::WorkingTreeDiffError::GitOutputLimit => IndexError::LimitExceeded {
+            dimension: "source_candidates",
+            cap: limit as u64,
+        },
+        error => IndexError::Other(error.to_string()),
+    })?;
+    if !output.success {
+        return Err(IndexError::Other("git source inventory unavailable".into()));
+    }
+    let mut paths = BTreeSet::new();
+    for raw in output.stdout.split(|byte| *byte == 0) {
+        control.check().map_err(index_error_from_read)?;
+        if raw.is_empty() {
+            continue;
+        }
+        let relative = std::str::from_utf8(raw)
+            .map(PathBuf::from)
+            .map_err(|_| IndexError::SnapshotChanged)?;
+        if relative.is_absolute()
+            || relative
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+            || has_skipped_component(&relative)
+        {
+            continue;
+        }
+        paths.insert(root.canonical_root().join(relative));
+        if paths.len() > limit {
+            return Err(IndexError::LimitExceeded {
+                dimension: "source_candidates",
+                cap: limit as u64,
+            });
+        }
+    }
+    root.verify().map_err(index_error_from_read)?;
+    Ok(paths.into_iter().collect())
+}
+
+fn source_candidates_controlled(
+    root: &Path,
+    limit: Option<usize>,
+    control: ReadControl<'_>,
+) -> Result<Vec<PathBuf>, IndexError> {
+    if let Some(limit) = limit {
+        let root = RootCapability::open(root).map_err(index_error_from_read)?;
+        return source_candidates_bounded(&root, limit, control);
+    }
+    control.check().map_err(index_error_from_read)?;
+    let tracked = match tracked_relative_paths_controlled(root, control) {
+        Ok(paths) => paths,
+        Err(_) if limit.is_none() => Vec::new(),
+        Err(crate::diff::WorkingTreeDiffError::GitTimeout)
+            if control.interrupted.is_some_and(|check| check()) =>
+        {
+            return Err(IndexError::Cancelled);
+        }
+        Err(crate::diff::WorkingTreeDiffError::GitTimeout) => {
+            return Err(IndexError::DeadlineExceeded);
+        }
+        Err(error) => return Err(IndexError::Other(error.to_string())),
+    };
+    let mut paths = BTreeSet::new();
+    for relative in tracked {
+        control.check().map_err(index_error_from_read)?;
+        paths.insert(root.join(relative));
+        if limit.is_some_and(|cap| paths.len() > cap) {
+            return Err(IndexError::LimitExceeded {
+                dimension: "source_candidates",
+                cap: limit.unwrap_or(usize::MAX) as u64,
+            });
+        }
+    }
+    for entry in source_walk_builder(root).build() {
+        control.check().map_err(index_error_from_read)?;
+        let Ok(entry) = entry else {
+            continue;
+        };
+        if !entry.file_type().is_some_and(|kind| kind.is_file()) {
+            continue;
+        }
+        paths.insert(entry.into_path());
+        if limit.is_some_and(|cap| paths.len() > cap) {
+            return Err(IndexError::LimitExceeded {
+                dimension: "source_candidates",
+                cap: limit.unwrap_or(usize::MAX) as u64,
+            });
+        }
+    }
+    Ok(paths.into_iter().collect())
 }
 
 /// Stateful ignore matcher for watcher events. It applies the same gitignore
@@ -898,15 +1407,35 @@ pub(crate) fn parse_one(
     root: &Path,
     extractor: &dyn LanguageExtractor,
 ) -> Result<PendingFile, IndexError> {
-    let source = read_source_bounded(path)?;
-    // Milliseconds — second-precision missed edits within the same second as the
-    // previous index run. i64 millis covers ~292M years.
-    let mtime = std::fs::metadata(path)
-        .and_then(|m| m.modified())
-        .map_err(|e| IndexError::Io(e.to_string()))?
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
-        .unwrap_or(0);
+    let source = read_source_bounded(path, root, ReadControl::default())?;
+    let rel = path
+        .strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    parse_blob(&rel, &source.bytes, source.modified_millis, extractor)
+}
+
+fn parse_one_controlled(
+    path: &Path,
+    root: &Path,
+    root_capability: &RootCapability,
+    expected_identity: StableFileIdentity,
+    extractor: &dyn LanguageExtractor,
+    control: ReadControl<'_>,
+) -> Result<PendingFile, IndexError> {
+    let source = read_regular_file_expected(
+        root_capability,
+        path,
+        MAX_INDEXABLE_FILE_SIZE,
+        MAX_INDEXABLE_FILE_SIZE,
+        control,
+        Some(expected_identity),
+    )
+    .map_err(index_error_from_read)?;
+    if is_binary_content(&source.bytes[..source.bytes.len().min(BINARY_SNIFF_BYTES as usize)]) {
+        return Err(IndexError::Skipped(IndexSkipReason::Binary));
+    }
 
     let rel = path
         .strip_prefix(root)
@@ -914,55 +1443,73 @@ pub(crate) fn parse_one(
         .to_string_lossy()
         .replace('\\', "/");
 
-    parse_blob(&rel, &source, mtime, extractor)
+    parse_blob(&rel, &source.bytes, source.modified_millis, extractor)
 }
 
-pub(crate) fn source_admission(path: &Path) -> Result<(), IndexError> {
-    let metadata = path
-        .metadata()
-        .map_err(|error| IndexError::Io(error.to_string()))?;
-    if metadata.len() > MAX_INDEXABLE_FILE_SIZE {
-        return Err(IndexError::Skipped(IndexSkipReason::TooLarge {
-            size: metadata.len(),
-        }));
-    }
-    let mut file = std::fs::File::open(path).map_err(|error| IndexError::Io(error.to_string()))?;
-    let mut prefix = Vec::with_capacity(BINARY_SNIFF_BYTES as usize);
-    file.by_ref()
-        .take(BINARY_SNIFF_BYTES)
-        .read_to_end(&mut prefix)
-        .map_err(|error| IndexError::Io(error.to_string()))?;
-    if is_binary_content(&prefix) {
+pub(crate) fn source_admission_mtime(root: &Path, path: &Path) -> Result<i64, IndexError> {
+    source_admission_controlled(root, path, ReadControl::default()).map(|file| file.modified_millis)
+}
+
+pub(crate) fn source_admission_controlled(
+    root: &Path,
+    path: &Path,
+    control: ReadControl<'_>,
+) -> Result<crate::bounded_fs::BoundedFile, IndexError> {
+    let root = RootCapability::open(root).map_err(index_error_from_read)?;
+    source_admission_with_capability(&root, path, control)
+}
+
+pub(crate) fn source_admission_with_capability(
+    root: &RootCapability,
+    path: &Path,
+    control: ReadControl<'_>,
+) -> Result<crate::bounded_fs::BoundedFile, IndexError> {
+    let prefix = read_regular_file_with_capability(
+        root,
+        path,
+        MAX_INDEXABLE_FILE_SIZE,
+        BINARY_SNIFF_BYTES,
+        control,
+    )
+    .map_err(index_error_from_read)?;
+    if is_binary_content(&prefix.bytes) {
         return Err(IndexError::Skipped(IndexSkipReason::Binary));
     }
-    Ok(())
+    Ok(prefix)
 }
 
-fn read_source_bounded(path: &Path) -> Result<Vec<u8>, IndexError> {
-    let metadata = path
-        .metadata()
-        .map_err(|error| IndexError::Io(error.to_string()))?;
-    if metadata.len() > MAX_INDEXABLE_FILE_SIZE {
-        return Err(IndexError::Skipped(IndexSkipReason::TooLarge {
-            size: metadata.len(),
-        }));
-    }
-
-    let mut file = std::fs::File::open(path).map_err(|error| IndexError::Io(error.to_string()))?;
-    let mut source = Vec::with_capacity(metadata.len() as usize);
-    file.by_ref()
-        .take(MAX_INDEXABLE_FILE_SIZE + 1)
-        .read_to_end(&mut source)
-        .map_err(|error| IndexError::Io(error.to_string()))?;
-    if source.len() as u64 > MAX_INDEXABLE_FILE_SIZE {
-        return Err(IndexError::Skipped(IndexSkipReason::TooLarge {
-            size: source.len() as u64,
-        }));
-    }
-    if is_binary_content(&source[..source.len().min(BINARY_SNIFF_BYTES as usize)]) {
+fn read_source_bounded(
+    path: &Path,
+    root: &Path,
+    control: ReadControl<'_>,
+) -> Result<crate::bounded_fs::BoundedFile, IndexError> {
+    let source = read_regular_file(
+        root,
+        path,
+        MAX_INDEXABLE_FILE_SIZE,
+        MAX_INDEXABLE_FILE_SIZE,
+        control,
+    )
+    .map_err(index_error_from_read)?;
+    if is_binary_content(&source.bytes[..source.bytes.len().min(BINARY_SNIFF_BYTES as usize)]) {
         return Err(IndexError::Skipped(IndexSkipReason::Binary));
     }
     Ok(source)
+}
+
+pub(crate) fn index_error_from_read(error: BoundedReadError) -> IndexError {
+    match error {
+        BoundedReadError::TooLarge { size, .. } => {
+            IndexError::Skipped(IndexSkipReason::TooLarge { size })
+        }
+        BoundedReadError::Interrupted => IndexError::Cancelled,
+        BoundedReadError::DeadlineExceeded => IndexError::DeadlineExceeded,
+        BoundedReadError::SnapshotChanged
+        | BoundedReadError::OutsideRoot
+        | BoundedReadError::InvalidPath
+        | BoundedReadError::NotRegular => IndexError::SnapshotChanged,
+        BoundedReadError::Io(error) => IndexError::Io(error.to_string()),
+    }
 }
 
 pub(crate) fn is_binary_content(content: &[u8]) -> bool {
@@ -1054,6 +1601,10 @@ pub enum IndexError {
     Parse(String),
     Other(String),
     Skipped(IndexSkipReason),
+    SnapshotChanged,
+    Cancelled,
+    DeadlineExceeded,
+    LimitExceeded { dimension: &'static str, cap: u64 },
 }
 
 fn ensure_indexing_active(store: &Store) -> Result<(), IndexError> {
@@ -1076,6 +1627,12 @@ impl std::fmt::Display for IndexError {
             IndexError::Io(m) => write!(f, "io: {m}"),
             IndexError::Parse(m) => write!(f, "parse: {m}"),
             IndexError::Other(m) => write!(f, "other: {m}"),
+            IndexError::SnapshotChanged => write!(f, "snapshot changed during bounded read"),
+            IndexError::Cancelled => write!(f, "indexing cancelled"),
+            IndexError::DeadlineExceeded => write!(f, "indexing deadline exceeded"),
+            IndexError::LimitExceeded { dimension, cap } => {
+                write!(f, "refresh limit exceeded: {dimension} > {cap}")
+            }
             IndexError::Skipped(IndexSkipReason::Binary) => write!(f, "skipped binary source"),
             IndexError::Skipped(IndexSkipReason::TooLarge { size }) => write!(
                 f,
@@ -1716,6 +2273,154 @@ mod incremental_tests {
         assert_eq!(stats.files_failed, 0);
         assert_eq!(store.indexed_paths().unwrap().len(), PARSE_BATCH_SIZE + 1);
 
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_admission_rejects_symlink_and_fifo_without_following() {
+        use std::os::unix::fs::symlink;
+
+        let (dir, _db) = setup("source_admission_nofollow");
+        let outside = env::temp_dir().join(format!(
+            "mmcg-source-admission-outside-{}",
+            std::process::id()
+        ));
+        fs::write(&outside, "fn secret() {}\n").unwrap();
+        let linked = dir.join("linked.rs");
+        symlink(&outside, &linked).unwrap();
+        assert!(source_admission_controlled(&dir, &linked, ReadControl::default()).is_err());
+
+        let fifo = dir.join("pipe.rs");
+        let status = Command::new("mkfifo").arg(&fifo).status().unwrap();
+        assert!(status.success());
+        assert!(source_admission_controlled(&dir, &fifo, ReadControl::default()).is_err());
+        fs::remove_file(outside).ok();
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn auto_refresh_candidate_limit_is_fail_closed() {
+        let (dir, _db) = setup("auto_refresh_candidate_limit");
+        git(&dir, &["init"]);
+        fs::write(dir.join("a.rs"), "fn a() {}\n").unwrap();
+        fs::write(dir.join("b.rs"), "fn b() {}\n").unwrap();
+        git(&dir, &["add", "a.rs", "b.rs"]);
+        let db = dir.join(".mastermind/mmcg.db");
+        let mut store = Store::open(&db).unwrap();
+        let error = Indexer::new(&dir)
+            .index_all_with_limits(
+                &mut store,
+                false,
+                IndexLimits {
+                    source_candidates: Some(1),
+                    source_declared_bytes: Some(u64::MAX),
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            IndexError::LimitExceeded {
+                dimension: "source_candidates",
+                cap: 1
+            }
+        ));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn auto_refresh_aggregate_limit_is_fail_closed() {
+        let (dir, _db) = setup("auto_refresh_aggregate_limit");
+        git(&dir, &["init"]);
+        fs::write(dir.join("a.rs"), "fn a() {}\n").unwrap();
+        git(&dir, &["add", "a.rs"]);
+        let db = dir.join(".mastermind/mmcg.db");
+        let mut store = Store::open(&db).unwrap();
+        let error = Indexer::new(&dir)
+            .index_all_with_limits(
+                &mut store,
+                false,
+                IndexLimits {
+                    source_candidates: Some(100),
+                    source_declared_bytes: Some(1),
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            IndexError::LimitExceeded {
+                dimension: "source_declared_bytes",
+                cap: 1
+            }
+        ));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn automatic_parse_rejects_a_file_replaced_after_aggregate_admission() {
+        let (dir, _db) = setup("aggregate_admission_identity");
+        let path = dir.join("source.rs");
+        fs::write(&path, "pub fn admitted() {}\n").unwrap();
+        let root = RootCapability::open(&dir).unwrap();
+        let admitted =
+            source_admission_with_capability(&root, &path, ReadControl::default()).unwrap();
+
+        fs::write(&path, "pub fn replacement() {\n    let expanded = 1;\n}\n").unwrap();
+        let extractor = extractor_for_path(&path).unwrap();
+        assert!(matches!(
+            parse_one_controlled(
+                &path,
+                &dir,
+                &root,
+                admitted.identity,
+                extractor.as_ref(),
+                ReadControl::default(),
+            ),
+            Err(IndexError::SnapshotChanged)
+        ));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn history_freshness_detects_markdown_only_edit_add_rename_and_delete() {
+        let (dir, _db) = setup("history_freshness");
+        fs::create_dir_all(dir.join(".mastermind/tasks")).unwrap();
+        let context = dir.join("CONTEXT.md");
+        fs::write(&context, "# Context\ninitial\n").unwrap();
+        let db = dir.join(".mastermind/mmcg.db");
+        let mut store = Store::open(&db).unwrap();
+        let indexer = Indexer::new(&dir);
+        indexer.index_project_history(&mut store).unwrap();
+        assert_eq!(
+            indexer.project_history_freshness(&store).unwrap(),
+            ProjectHistoryFreshness::Fresh
+        );
+
+        fs::write(&context, "# Context\nedited\n").unwrap();
+        assert_eq!(
+            indexer.project_history_freshness(&store).unwrap(),
+            ProjectHistoryFreshness::Stale
+        );
+        indexer.index_project_history(&mut store).unwrap();
+        let archive = dir.join("CONTEXT-archive-1.md");
+        fs::write(&archive, "# Archive\nadded\n").unwrap();
+        assert_eq!(
+            indexer.project_history_freshness(&store).unwrap(),
+            ProjectHistoryFreshness::Stale
+        );
+        indexer.index_project_history(&mut store).unwrap();
+        let renamed = dir.join("CONTEXT-archive-2.md");
+        fs::rename(&archive, &renamed).unwrap();
+        assert_eq!(
+            indexer.project_history_freshness(&store).unwrap(),
+            ProjectHistoryFreshness::Stale
+        );
+        indexer.index_project_history(&mut store).unwrap();
+        fs::remove_file(renamed).unwrap();
+        assert_eq!(
+            indexer.project_history_freshness(&store).unwrap(),
+            ProjectHistoryFreshness::Stale
+        );
         fs::remove_dir_all(&dir).ok();
     }
 }

--- a/mcp/servers/mmcg/src/lens.rs
+++ b/mcp/servers/mmcg/src/lens.rs
@@ -635,6 +635,8 @@ fn validated_index_paths(
             ChangeImpactError::RootMismatch,
         ));
     }
+    let root_capability =
+        crate::bounded_fs::RootCapability::open(root).map_err(|_| LensError::IndexStale)?;
 
     let indexed_files = store
         .files_under(None, None)
@@ -655,18 +657,38 @@ fn validated_index_paths(
             return Err(LensError::IndexStale);
         }
         let source_path = root.join(relative);
-        let metadata = source_path.metadata().map_err(|_| LensError::IndexStale)?;
-        if !metadata.is_file() || metadata.len() > crate::indexer::MAX_INDEXABLE_FILE_SIZE {
-            return Err(LensError::IndexStale);
-        }
-        let source_mtime = metadata
-            .modified()
-            .ok()
-            .and_then(|mtime| mtime.duration_since(SystemTime::UNIX_EPOCH).ok())
-            .map(|duration| duration.as_millis() as i64);
-        if source_mtime != Some(indexed_file.indexed_at) {
-            let bytes = std::fs::read(&source_path).map_err(|_| LensError::IndexStale)?;
-            let digest = crate::hex::encode(&Sha256::digest(bytes));
+        let control = crate::bounded_fs::ReadControl {
+            deadline,
+            interrupted: None,
+        };
+        let inspected = crate::bounded_fs::read_regular_file_with_capability(
+            &root_capability,
+            &source_path,
+            crate::indexer::MAX_INDEXABLE_FILE_SIZE,
+            0,
+            control,
+        )
+        .map_err(|error| match error {
+            crate::bounded_fs::BoundedReadError::DeadlineExceeded => LensError::AnalysisTimeout,
+            _ => LensError::IndexStale,
+        })?;
+        if inspected.modified_millis != indexed_file.indexed_at {
+            let source = crate::bounded_fs::read_regular_file_expected(
+                &root_capability,
+                &source_path,
+                crate::indexer::MAX_INDEXABLE_FILE_SIZE,
+                crate::indexer::MAX_INDEXABLE_FILE_SIZE,
+                control,
+                Some(inspected.identity),
+            )
+            .map_err(|error| match error {
+                crate::bounded_fs::BoundedReadError::DeadlineExceeded => LensError::AnalysisTimeout,
+                _ => LensError::IndexStale,
+            })?;
+            if source.declared_len != inspected.declared_len {
+                return Err(LensError::IndexStale);
+            }
+            let digest = crate::hex::encode(&Sha256::digest(source.bytes));
             let stored_digest = store
                 .file_content_sha256(&indexed_path)
                 .map_err(|_| LensError::IndexStale)?;
@@ -701,8 +723,15 @@ fn validated_index_paths(
         if indexed_paths.contains(&normalized) {
             continue;
         }
-        match crate::indexer::source_admission(&root.join(&relative)) {
-            Ok(()) => return Err(LensError::IndexStale),
+        match crate::indexer::source_admission_with_capability(
+            &root_capability,
+            &root.join(&relative),
+            crate::bounded_fs::ReadControl {
+                deadline,
+                interrupted: None,
+            },
+        ) {
+            Ok(_) => return Err(LensError::IndexStale),
             Err(crate::indexer::IndexError::Skipped(_)) => {}
             Err(_) => return Err(LensError::IndexStale),
         }
@@ -715,6 +744,7 @@ fn read_audit_narrative(
     root: &Path,
     expected_binding: &AuditNarrativeBinding,
     valid_components: &HashSet<String>,
+    deadline: Option<Instant>,
 ) -> Option<AuditNarrative> {
     const MAX_BYTES: u64 = 256 * 1024;
     const CAP_SUMMARY: usize = 2000;
@@ -730,16 +760,28 @@ fn read_audit_narrative(
     const CAP_SCENARIO: usize = 600;
     const CAP_EVIDENCE: usize = 500;
 
-    let path = std::env::var("MMCG_AUDIT_NARRATIVE")
+    let configured = std::env::var("MMCG_AUDIT_NARRATIVE")
         .ok()
         .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| root.join(".mastermind").join("audit-narrative.json"));
-    let metadata = std::fs::symlink_metadata(&path).ok()?;
-    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() > MAX_BYTES {
-        return None;
-    }
-    let bytes = std::fs::read(&path).ok()?;
+        .map(PathBuf::from);
+    let path = match configured {
+        Some(path) if path.is_absolute() => path,
+        Some(path) => root.join(path),
+        None => root.join(".mastermind").join("audit-narrative.json"),
+    };
+    let capability = crate::bounded_fs::RootCapability::open(root).ok()?;
+    let bytes = crate::bounded_fs::read_regular_file_with_capability(
+        &capability,
+        &path,
+        MAX_BYTES,
+        MAX_BYTES,
+        crate::bounded_fs::ReadControl {
+            deadline,
+            interrupted: None,
+        },
+    )
+    .ok()?
+    .bytes;
     let raw: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
     if raw
         .get("schema_version")
@@ -1344,7 +1386,7 @@ fn build_snapshot_until(
         .iter()
         .map(|component| component.path.clone())
         .collect::<HashSet<_>>();
-    let narrative = read_audit_narrative(&root, &narrative_binding, &valid_components);
+    let narrative = read_audit_narrative(&root, &narrative_binding, &valid_components, deadline);
 
     let audit = LensAudit {
         dead_code: LensDeadCode {
@@ -2311,6 +2353,34 @@ mod tests {
             .iter()
             .any(|field| field == "binding"));
         assert_eq!(schema["$defs"]["binding"]["additionalProperties"], false);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn snapshot_rejects_a_symlinked_audit_narrative() {
+        use std::os::unix::fs::symlink;
+
+        let (repo, _index_dir, index_path) = fixture();
+        let mastermind = repo.path().join(".mastermind");
+        fs::create_dir_all(&mastermind).unwrap();
+        let store = Store::open_read_only(&index_path).unwrap();
+        let initial = build_snapshot(&store, repo.path(), &options()).unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let sidecar = outside.path().join("narrative.json");
+        fs::write(
+            &sidecar,
+            serde_json::to_vec(&serde_json::json!({
+                "schema_version": 1,
+                "binding": initial.audit.narrative_binding,
+                "summary": "must not cross the repository boundary"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        symlink(&sidecar, mastermind.join("audit-narrative.json")).unwrap();
+
+        let snapshot = build_snapshot(&store, repo.path(), &options()).unwrap();
+        assert!(snapshot.audit.narrative.is_none());
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/lib.rs
+++ b/mcp/servers/mmcg/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod audit_bundle;
 pub mod audit_spec;
+pub mod bounded_fs;
 pub mod context_doctor;
 pub mod diff;
 pub mod doctor;

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -1279,7 +1279,22 @@ fn run_cli_inner(
                 .map_err(|_| mmcg::queries::ChangeImpactError::IndexStale)?;
             let top =
                 usize::try_from(top).map_err(|_| mmcg::queries::ChangeImpactError::InvalidRef)?;
-            let response = impact_engine(&store, &root, &since, depth, top)?;
+            store.set_default_work_budget_ms(mmcg::store::query_budget_ms_from_env(
+                mmcg::store::DEFAULT_CLI_BUDGET_MS,
+            ));
+            let budget = store.default_work_budget();
+            let expired = store.push_work_budget(budget);
+            let response = if expired {
+                Err(mmcg::queries::ChangeImpactError::GitTimeout)
+            } else {
+                impact_engine(&store, &root, &since, depth, top)
+            };
+            let interrupted = store.take_interrupt_source();
+            store.pop_work_budget();
+            if interrupted.is_some() {
+                return Err("impact request exceeded its work budget".into());
+            }
+            let response = response?;
             print!(
                 "{}",
                 commands::query::render_change_impact(&response, format)?
@@ -1467,7 +1482,12 @@ fn run_cli_inner(
             )?;
         }
         Cmd::Serve => {
-            let store = Store::open(&index_path)?;
+            let managed_root = if index_override.is_none() {
+                Some(std::env::current_dir()?.canonicalize()?)
+            } else {
+                None
+            };
+            let store = Store::open_for_serve(&index_path, managed_root.as_deref())?;
             store.set_default_work_budget_ms(mmcg::store::query_budget_ms_from_env(
                 mmcg::store::DEFAULT_SERVE_BUDGET_MS,
             ));

--- a/mcp/servers/mmcg/src/mcp.rs
+++ b/mcp/servers/mmcg/src/mcp.rs
@@ -109,6 +109,11 @@ enum HandlerError {
         extractor_contract_current: bool,
         refresh_attempted: bool,
     },
+    RefreshLimit {
+        dimension: &'static str,
+        cap: u64,
+    },
+    SchemaIncompatible,
     Internal {
         class: &'static str,
     },
@@ -450,11 +455,10 @@ fn spawn_watchdog(
                 eprintln!("[mmcg] watchdog: parent {original_parent} is gone, exiting");
                 std::process::exit(0);
             }
-            let current = in_flight
+            let guard = in_flight
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone();
-            let Some(current) = current else {
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let Some(current) = guard.as_ref() else {
                 cancelled = None;
                 continue;
             };
@@ -467,6 +471,10 @@ fn spawn_watchdog(
                         current.id,
                         elapsed.as_millis()
                     );
+                    // The request-completion path clears `in_flight` and the
+                    // Store interrupt while holding this same mutex. Keep it
+                    // held through `cancel()` so a watchdog decision made for
+                    // request N cannot land after N is cleared and abort N+1.
                     cancel.cancel();
                     cancelled = Some(current.started);
                 }
@@ -575,7 +583,7 @@ where
             }
             ReaderMsg::Frame(frame) => frame,
         };
-        let response = match frame {
+        match frame {
             Frame::Line(line) if line.trim().is_empty() => continue,
             Frame::Line(line) => {
                 let trimmed = line.trim();
@@ -583,6 +591,8 @@ where
                 // that races ahead of `in_flight` being set is harmless — the
                 // reader will simply see no matching in-flight id and skip.
                 let request_id = peek_request_id(trimmed);
+                let tool_version = peek_tool_call_protocol(trimmed, state);
+                let outer_budget = tool_version.map(|_| store.default_work_budget());
                 if let Some(id) = &request_id {
                     *in_flight
                         .lock()
@@ -591,17 +601,57 @@ where
                         started: Instant::now(),
                     });
                 }
-                let response = handle_line(&mut state, store, trimmed);
-                if request_id.is_some() {
-                    *in_flight
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                if let Some(budget) = outer_budget {
+                    let _ = store.push_work_budget(budget);
                 }
-                response
+                let response = handle_line(&mut state, store, trimmed);
+
+                // Encode while the tool request's outer budget is still
+                // active. A cancel or deadline reached during serde's writes
+                // becomes the same structured tool result as an interrupt in
+                // the handler rather than escaping as a partial JSON frame.
+                let mut encoded = response.as_ref().map(|response| {
+                    if outer_budget.is_some() {
+                        encode_response_controlled(store, response)
+                    } else {
+                        encode_response(response)
+                    }
+                });
+
+                if request_id.is_some() {
+                    let mut guard = in_flight
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    let interrupt = if outer_budget.is_some() {
+                        let _ = store.work_interrupted();
+                        store.take_interrupt_source()
+                    } else {
+                        // Cancelling a fast non-tool request such as
+                        // `tools/list` must not bleed into the next request.
+                        let _ = store.take_interrupt_source();
+                        None
+                    };
+                    *guard = None;
+                    if let Some(budget) = outer_budget {
+                        store.pop_work_budget();
+                        if let (Some(id), Some(version), Some(interrupt)) =
+                            (request_id.clone(), tool_version, interrupt)
+                        {
+                            encoded = Some(encode_response(&interrupted_tool_response(
+                                id, version, interrupt, budget,
+                            )));
+                        }
+                    }
+                    drop(guard);
+                }
+
+                if let Some(encoded) = encoded {
+                    write_encoded_response(&mut output, &encoded?)?;
+                }
             }
             Frame::InvalidUtf8 => {
                 eprintln!("[mmcg] parse error class=invalid_utf8");
-                Some(err(Value::Null, -32700, "Parse error".into()))
+                write_response(&mut output, &err(Value::Null, -32700, "Parse error".into()))?;
             }
             Frame::TooLarge(size) => {
                 eprintln!("[mmcg] protocol error class=frame_too_large bytes={size}");
@@ -611,9 +661,6 @@ where
                 )?;
                 return Ok(());
             }
-        };
-        if let Some(response) = response {
-            write_response(&mut output, &response)?;
         }
     }
     Ok(())
@@ -626,6 +673,37 @@ fn peek_request_id(line: &str) -> Option<Value> {
     let value: Value = serde_json::from_str(line).ok()?;
     let id = value.get("id")?.clone();
     valid_request_id(&id).then_some(id)
+}
+
+/// Return the exact wire-version only for a request that will enter
+/// `handle_tools_call`. The transport uses this to own one budget across the
+/// handler and final JSON encoding without changing errors for malformed or
+/// not-yet-initialized requests.
+fn peek_tool_call_protocol(line: &str, state: SessionState) -> Option<ProtocolVersion> {
+    let value: Value = serde_json::from_str(line).ok()?;
+    if value.get("method")?.as_str()? != "tools/call" {
+        return None;
+    }
+    let id = value.get("id")?;
+    if !valid_request_id(id) {
+        return None;
+    }
+    let params = value.get("params").cloned().unwrap_or_else(|| json!({}));
+    let has_meta = params.get("_meta").is_some();
+    let declares_protocol = params
+        .get("_meta")
+        .and_then(Value::as_object)
+        .is_some_and(|meta| meta.contains_key(PROTOCOL_VERSION_META_KEY));
+    let stateless = declares_protocol || (state == SessionState::Cold && has_meta);
+    if stateless {
+        validate_stateless_request_meta(&params)
+            .ok()
+            .map(|_| ProtocolVersion::Stateless)
+    } else if state.is_ready() {
+        state.protocol()
+    } else {
+        None
+    }
 }
 
 /// Extract the target request id from an MCP cancel notification
@@ -684,11 +762,89 @@ fn read_frame<R: BufRead>(input: &mut R) -> io::Result<Option<Frame>> {
     }))
 }
 
-fn write_response<W: Write>(output: &mut W, response: &JsonRpcResponse) -> io::Result<()> {
-    let encoded = serde_json::to_string(response)
+fn encode_response(response: &JsonRpcResponse) -> io::Result<Vec<u8>> {
+    let encoded = serde_json::to_vec(response)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-    writeln!(output, "{encoded}")?;
+    if encoded.len() > MCP_RESULT_MAX {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "JSON-RPC response exceeds 8 MiB",
+        ));
+    }
+    Ok(encoded)
+}
+
+struct ControlledResponseWriter<'a> {
+    store: &'a Store,
+    bytes: Vec<u8>,
+}
+
+impl Write for ControlledResponseWriter<'_> {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if self.store.work_interrupted() {
+            // `Write::write_all` retries `Interrupted` forever. Use a
+            // non-retryable transport-local error; the request finalizer
+            // reads the Store's authoritative interrupt source and emits the
+            // structured cancelled/work-limit result.
+            return Err(io::Error::other("request interrupted during JSON encoding"));
+        }
+        if self.bytes.len().saturating_add(bytes.len()) > MCP_RESULT_MAX {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "JSON-RPC response exceeds 8 MiB",
+            ));
+        }
+        self.bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn encode_response_controlled(store: &Store, response: &JsonRpcResponse) -> io::Result<Vec<u8>> {
+    let mut writer = ControlledResponseWriter {
+        store,
+        bytes: Vec::new(),
+    };
+    serde_json::to_writer(&mut writer, response).map_err(|error| {
+        io::Error::new(
+            error.io_error_kind().unwrap_or(io::ErrorKind::InvalidData),
+            error,
+        )
+    })?;
+    if store.work_interrupted() {
+        return Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "request interrupted after JSON encoding",
+        ));
+    }
+    Ok(writer.bytes)
+}
+
+fn interrupted_tool_response(
+    id: Value,
+    version: ProtocolVersion,
+    interrupt: InterruptSource,
+    budget: WorkBudget,
+) -> JsonRpcResponse {
+    let payload = match interrupt {
+        InterruptSource::Cancel => cancelled_payload(),
+        InterruptSource::Budget => work_limit_payload(budget),
+    };
+    let result = tool_result(version, payload, true).expect("static interrupt result serializes");
+    ok(id, result)
+}
+
+fn write_encoded_response<W: Write>(output: &mut W, encoded: &[u8]) -> io::Result<()> {
+    output.write_all(encoded)?;
+    output.write_all(b"\n")?;
     output.flush()
+}
+
+fn write_response<W: Write>(output: &mut W, response: &JsonRpcResponse) -> io::Result<()> {
+    write_encoded_response(output, &encode_response(response)?)
 }
 
 fn handle_line(state: &mut SessionState, store: &mut Store, line: &str) -> Option<JsonRpcResponse> {
@@ -1023,31 +1179,6 @@ fn invoke_tool(
     }
 }
 
-fn invoke_tool_with_budget(
-    tool: &ToolDef,
-    tool_name: &str,
-    store: &mut Store,
-    arguments: &Value,
-    impact_engine: Option<&queries::ImpactEngine<'_>>,
-    budget: WorkBudget,
-) -> (Option<Result<Value, HandlerError>>, Option<InterruptSource>) {
-    let already_expired = store.push_work_budget(budget);
-    let handled = if already_expired {
-        None
-    } else {
-        Some(invoke_tool(
-            tool,
-            tool_name,
-            store,
-            arguments,
-            impact_engine,
-        ))
-    };
-    let interrupt = store.take_interrupt_source();
-    store.pop_work_budget();
-    (handled, interrupt)
-}
-
 fn handle_tools_call_inner(
     version: ProtocolVersion,
     store: &mut Store,
@@ -1075,21 +1206,31 @@ fn handle_tools_call_inner(
         .find(|tool| tool.name == tool_name)
         .ok_or_else(|| ToolCallError::InvalidParams("Unknown tool".into()))?;
 
-    // Every tool dispatch runs inside the work-budget guard — the single
-    // owner of the connection's progress handler. A pre-expired budget (e.g.
-    // a zero budget installed by a test) short-circuits before the handler
-    // ever runs, so coverage doesn't depend on a query being slow enough to
-    // trip the in-flight progress-handler check.
+    // One outer guard owns the full request lifetime. First dispatch, managed
+    // refresh, retry, Git/filesystem work, and result serialization all consume
+    // the same absolute deadline; no phase receives a reset duration.
+    let owns_request_guard = store.work_budget_depth() == 0;
     let budget = store.default_work_budget();
-    let (mut handled, mut interrupt) =
-        invoke_tool_with_budget(tool, tool_name, store, &arguments, impact_engine, budget);
+    let already_expired = store.push_work_budget(budget);
+    let mut handled = if already_expired {
+        None
+    } else {
+        Some(invoke_tool(
+            tool,
+            tool_name,
+            store,
+            &arguments,
+            impact_engine,
+        ))
+    };
 
     // Argument parsing happens before each structural handler checks
     // freshness, preserving precise invalid-argument errors without indexing.
     // A validated stale call gets one refresh outside the narrow query budget,
     // then one retry. The request watchdog and client cancellation still bound
     // both indexing and the retried query.
-    let stale_index = if interrupt.is_none() && tool_requires_fresh_index(tool_name) {
+    let stale_index = if store.interrupt_source().is_none() && tool_requires_fresh_index(tool_name)
+    {
         match handled.as_ref() {
             Some(Err(HandlerError::IndexStale {
                 stale_files,
@@ -1104,52 +1245,67 @@ fn handle_tools_call_inner(
     let mut refresh_completed = false;
     if let Some((stale_files, extractor_contract_current)) = stale_index {
         let refresh = refresh_stale_index(store, stale_files, extractor_contract_current);
-        interrupt = store.take_interrupt_source();
-        if interrupt.is_none() {
+        if store.interrupt_source().is_none() {
             match refresh {
                 Ok(()) => {
                     refresh_completed = true;
-                    (handled, interrupt) = invoke_tool_with_budget(
+                    handled = Some(invoke_tool(
                         tool,
                         tool_name,
                         store,
                         &arguments,
                         impact_engine,
-                        budget,
-                    );
+                    ));
                 }
                 Err(error) => handled = Some(Err(error)),
             }
         }
     }
 
-    match handled {
+    let mut result = match handled {
         Some(Ok(payload)) => tool_result(version, payload, false),
-        Some(Err(handler_error)) => match interrupt {
-            Some(InterruptSource::Cancel) => tool_result(version, cancelled_payload(), true),
-            Some(InterruptSource::Budget) => tool_result(version, work_limit_payload(budget), true),
-            None => match handler_error {
-                HandlerError::InvalidArguments(message) => {
-                    tool_result(version, json!({ "error": message }), true)
-                }
-                HandlerError::IndexStale {
+        Some(Err(handler_error)) => match handler_error {
+            HandlerError::InvalidArguments(message) => {
+                tool_result(version, json!({ "error": message }), true)
+            }
+            HandlerError::IndexStale {
+                stale_files,
+                extractor_contract_current,
+                refresh_attempted,
+            } => tool_result(
+                version,
+                index_stale_payload(
                     stale_files,
                     extractor_contract_current,
-                    refresh_attempted,
-                } => tool_result(
-                    version,
-                    index_stale_payload(
-                        stale_files,
-                        extractor_contract_current,
-                        refresh_attempted || refresh_completed,
-                    ),
-                    true,
+                    refresh_attempted || refresh_completed,
                 ),
-                HandlerError::Internal { class } => Err(ToolCallError::Internal { class }),
-            },
+                true,
+            ),
+            HandlerError::RefreshLimit { dimension, cap } => {
+                tool_result(version, refresh_limit_payload(dimension, cap), true)
+            }
+            HandlerError::SchemaIncompatible => {
+                tool_result(version, schema_incompatible_payload(), true)
+            }
+            HandlerError::Internal { class } => Err(ToolCallError::Internal { class }),
         },
         None => tool_result(version, work_limit_payload(budget), true),
+    };
+
+    if store.interrupt_source().is_none() {
+        let _ = store.work_interrupted();
     }
+    if let Some(interrupt) = store.interrupt_source() {
+        result = match interrupt {
+            InterruptSource::Cancel => tool_result(version, cancelled_payload(), true),
+            InterruptSource::Budget => tool_result(version, work_limit_payload(budget), true),
+        };
+    }
+    store.pop_work_budget();
+    if owns_request_guard {
+        let _ = store.take_interrupt_source();
+    }
+    result
 }
 
 fn index_stale_payload(
@@ -1183,28 +1339,85 @@ fn index_stale_error(
     }
 }
 
+fn refresh_limit_payload(dimension: &'static str, cap: u64) -> Value {
+    json!({
+        "code": "refresh_limit_exceeded",
+        "dimension": dimension,
+        "cap": cap,
+        "guidance": "run `mastermind index .` manually or narrow the repository source inventory"
+    })
+}
+
+fn schema_incompatible_payload() -> Value {
+    json!({
+        "code": "schema_incompatible",
+        "guidance": "rebuild the managed ROOT/.mastermind/mmcg.db index; custom indexes are never migrated by the MCP server"
+    })
+}
+
 fn safe_index_status(store: &Store) -> Result<queries::StatusResponse, HandlerError> {
-    if let Some(root) = managed_auto_refresh_root(store) {
-        if crate::indexer::validate_index_root(store, &root).is_err() {
-            return Ok(queries::StatusResponse {
-                db_path: store.db_path().to_string_lossy().to_string(),
-                symbol_count: store
-                    .symbol_count()
-                    .map_err(|error| HandlerError::internal("symbol_count_query", error))?,
-                file_count: store
-                    .file_count()
-                    .map_err(|error| HandlerError::internal("file_count_query", error))?,
-                stale_files: 1,
-                extractor_contract_current: store
-                    .extractor_contract_current()
-                    .map_err(|error| HandlerError::internal("extractor_contract_query", error))?,
-            });
+    let symbol_count = store
+        .symbol_count()
+        .map_err(|error| HandlerError::internal("symbol_count_query", error))?;
+    let file_count = store
+        .file_count()
+        .map_err(|error| HandlerError::internal("file_count_query", error))?;
+    let extractor_contract_current = store
+        .extractor_contract_current()
+        .map_err(|error| HandlerError::internal("extractor_contract_query", error))?;
+    let root = store
+        .meta_value("index_root")
+        .map_err(|error| HandlerError::internal("index_root_query", error))?
+        .map(PathBuf::from)
+        .and_then(|root| root.canonicalize().ok());
+    let stale_files = match root {
+        Some(root)
+            if store
+                .serve_root()
+                .is_some_and(|authorized| authorized != root.as_path()) =>
+        {
+            1
         }
-    }
-    queries::status(store).map_err(|error| HandlerError::internal("index_freshness_query", error))
+        Some(root) => {
+            let interrupted = || store.work_interrupted();
+            match crate::workflow_status::stale_paths_controlled(
+                store,
+                &root,
+                100,
+                crate::indexer::AUTO_REFRESH_SOURCE_CANDIDATE_LIMIT,
+                crate::indexer::AUTO_REFRESH_SOURCE_AGGREGATE_BYTES,
+                crate::bounded_fs::ReadControl {
+                    deadline: store.request_deadline(),
+                    interrupted: Some(&interrupted),
+                },
+            ) {
+                Ok(paths) => paths.len(),
+                Err(crate::indexer::IndexError::LimitExceeded { dimension, cap }) => {
+                    return Err(HandlerError::RefreshLimit { dimension, cap })
+                }
+                Err(crate::indexer::IndexError::Cancelled)
+                | Err(crate::indexer::IndexError::DeadlineExceeded) => {
+                    return Err(HandlerError::internal(
+                        "freshness_interrupted",
+                        "request interrupted",
+                    ))
+                }
+                Err(_) => 1,
+            }
+        }
+        None => 1,
+    };
+    Ok(queries::StatusResponse {
+        db_path: store.db_path().to_string_lossy().to_string(),
+        symbol_count,
+        file_count,
+        stale_files,
+        extractor_contract_current,
+    })
 }
 
 fn ensure_fresh_index(store: &Store) -> Result<(), HandlerError> {
+    ensure_schema_compatible(store)?;
     let status = safe_index_status(store)?;
     if status.stale_files > 0 || !status.extractor_contract_current {
         return Err(index_stale_error(
@@ -1216,18 +1429,18 @@ fn ensure_fresh_index(store: &Store) -> Result<(), HandlerError> {
     Ok(())
 }
 
+fn ensure_schema_compatible(store: &Store) -> Result<(), HandlerError> {
+    match store.schema_current() {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(HandlerError::SchemaIncompatible),
+        Err(error) => Err(HandlerError::internal("schema_compatibility_query", error)),
+    }
+}
+
 /// Derive refresh authority from the canonical managed database location, not
 /// from mutable index metadata that could redirect automatic filesystem reads.
 fn managed_auto_refresh_root(store: &Store) -> Option<PathBuf> {
-    let db_path = store.db_path().canonicalize().ok()?;
-    if db_path.file_name()? != OsStr::new("mmcg.db") {
-        return None;
-    }
-    let state_dir = db_path.parent()?;
-    if state_dir.file_name()? != OsStr::new(".mastermind") {
-        return None;
-    }
-    state_dir.parent()?.canonicalize().ok()
+    store.managed_root().map(std::path::Path::to_path_buf)
 }
 
 fn refresh_stale_index(
@@ -1243,13 +1456,30 @@ fn refresh_stale_index(
         ));
     };
 
-    let refresh = crate::indexer::Indexer::new(root).index_all(store, false);
-    if !matches!(refresh, Ok(stats) if stats.files_failed == 0) {
-        return Err(index_stale_error(
-            stale_files,
-            extractor_contract_current,
-            true,
-        ));
+    let refresh = crate::indexer::Indexer::new(root).index_all_with_limits(
+        store,
+        false,
+        crate::indexer::IndexLimits::AUTO_REFRESH,
+    );
+    match refresh {
+        Ok(stats) if stats.files_failed == 0 => {}
+        Err(crate::indexer::IndexError::LimitExceeded { dimension, cap }) => {
+            return Err(HandlerError::RefreshLimit { dimension, cap });
+        }
+        Err(crate::indexer::IndexError::Cancelled)
+        | Err(crate::indexer::IndexError::DeadlineExceeded) => {
+            return Err(HandlerError::internal(
+                "refresh_interrupted",
+                "request interrupted",
+            ));
+        }
+        _ => {
+            return Err(index_stale_error(
+                stale_files,
+                extractor_contract_current,
+                true,
+            ));
+        }
     }
     Ok(())
 }
@@ -1937,31 +2167,54 @@ fn handle_api_surface(store: &mut Store, args: &Value) -> Result<Value, HandlerE
 }
 
 fn changed_since_root(
+    store: &Store,
     root_arg: Option<&str>,
-    db_path: &std::path::Path,
 ) -> Result<std::path::PathBuf, HandlerError> {
-    let root = match root_arg {
-        Some(s) => std::path::PathBuf::from(s),
-        None => {
-            let db = db_path
-                .canonicalize()
-                .map_err(|error| HandlerError::internal("changed_since_root", error))?;
-            db.parent()
-                .and_then(|d| d.parent())
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-        }
-    };
-    root.canonicalize()
-        .map_err(|error| HandlerError::internal("changed_since_root", error))
+    let stored = store
+        .meta_value("index_root")
+        .map_err(|error| HandlerError::internal("changed_since_root", error))?
+        .map(std::path::PathBuf::from)
+        .ok_or_else(|| HandlerError::InvalidArguments("index_stale".into()))?
+        .canonicalize()
+        .map_err(|_| HandlerError::InvalidArguments("root_mismatch".into()))?;
+    let requested = root_arg
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| stored.clone())
+        .canonicalize()
+        .map_err(|_| HandlerError::InvalidArguments("root_mismatch".into()))?;
+    if requested != stored {
+        return Err(HandlerError::InvalidArguments("root_mismatch".into()));
+    }
+    Ok(stored)
 }
 
 fn handle_symbols_changed_since(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
     let git_ref = str_arg(args, "git_ref")?;
-    let root = changed_since_root(opt_str_arg(args, "root"), store.db_path())?;
+    let root = changed_since_root(store, opt_str_arg(args, "root"))?;
     ensure_fresh_index(store)?;
-    let diff = queries::symbols_changed_since(store, &root, git_ref)
-        .map_err(|error| HandlerError::internal("git_diff", error))?;
+    let interrupted = || store.work_interrupted();
+    let diff = queries::symbols_changed_since_controlled(
+        store,
+        &root,
+        git_ref,
+        store.request_deadline(),
+        Some(&interrupted),
+    )
+    .map_err(|error| match error {
+        crate::diff::DiffError::GitRefMissing(_) => {
+            HandlerError::InvalidArguments("invalid_ref".into())
+        }
+        crate::diff::DiffError::GitTimeout => HandlerError::InvalidArguments("git_timeout".into()),
+        crate::diff::DiffError::GitFailed(code)
+            if matches!(
+                code.as_str(),
+                "git_output_limit" | "snapshot_changed" | "index_stale"
+            ) =>
+        {
+            HandlerError::InvalidArguments(code)
+        }
+        error => HandlerError::internal("git_diff", error),
+    })?;
     serde_json::to_value(diff).map_err(|error| HandlerError::internal("serialize_response", error))
 }
 
@@ -1987,6 +2240,7 @@ fn handle_tasks(store: &mut Store, args: &Value) -> Result<Value, HandlerError> 
         .and_then(|n| u32::try_from(n).ok())
         .unwrap_or(10)
         .clamp(1, 50);
+    ensure_schema_compatible(store)?;
     let r = queries::tasks(store, query, top)
         .map_err(|error| HandlerError::internal("tasks_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
@@ -2001,6 +2255,7 @@ fn handle_history(store: &mut Store, args: &Value) -> Result<Value, HandlerError
         .and_then(|value| u32::try_from(value).ok())
         .unwrap_or(10)
         .clamp(1, 50);
+    ensure_schema_compatible(store)?;
     let response = queries::history(store, query, kind, top)
         .map_err(|error| HandlerError::internal("history_query", error))?;
     serde_json::to_value(response)
@@ -2188,6 +2443,7 @@ fn handle_facts(store: &mut Store, args: &Value) -> Result<Value, HandlerError> 
             .and_then(|value| usize::try_from(value).ok())
             .ok_or_else(|| HandlerError::InvalidArguments("Invalid argument: top".into()))?,
     };
+    ensure_schema_compatible(store)?;
     let result = crate::facts::snapshot(store, path, top)
         .map_err(|error| HandlerError::internal("fact_query", error))?;
     serde_json::to_value(result)
@@ -2198,6 +2454,7 @@ fn handle_team_map(store: &mut Store, args: &Value) -> Result<Value, HandlerErro
     let manifest = str_arg(args, "manifest")?;
     let manifest = crate::facts::normalize_fact_path(manifest)
         .map_err(|_| HandlerError::InvalidArguments("Invalid argument: manifest".into()))?;
+    ensure_schema_compatible(store)?;
     let root = store
         .meta_value("index_root")
         .map_err(|error| HandlerError::internal("team_index_root", error))?
@@ -2227,7 +2484,7 @@ fn impact_arguments(
 ) -> Result<(String, std::path::PathBuf, u32, usize), HandlerError> {
     let since = str_arg(args, "since")?.to_string();
     let root = match args.get("root") {
-        None => changed_since_root(None, store.db_path())?,
+        None => changed_since_root(store, None)?,
         Some(Value::String(value)) => std::path::PathBuf::from(value)
             .canonicalize()
             .map_err(|_| HandlerError::InvalidArguments("root_mismatch".to_string()))?,
@@ -2325,12 +2582,14 @@ fn handle_recent_changes(store: &mut Store, args: &Value) -> Result<Value, Handl
     let since = str_arg(args, "since")?;
     queries::parse_duration(since)
         .map_err(|_| HandlerError::InvalidArguments("Invalid argument: since".into()))?;
+    ensure_schema_compatible(store)?;
     let r = queries::recent_changes(store, since)
         .map_err(|error| HandlerError::internal("recent_changes_query", error))?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
 }
 
 fn handle_status(store: &mut Store, _args: &Value) -> Result<Value, HandlerError> {
+    ensure_schema_compatible(store)?;
     let r = safe_index_status(store)?;
     serde_json::to_value(r).map_err(|error| HandlerError::internal("serialize_response", error))
 }
@@ -2344,6 +2603,7 @@ fn handle_scratchpad_append(store: &mut Store, args: &Value) -> Result<Value, Ha
             "Scratchpad body exceeds 8 KiB".into(),
         ));
     }
+    ensure_schema_compatible(store)?;
     let (id, ts) = store
         .scratchpad_append(agent, kind, body)
         .map_err(|error| HandlerError::internal("scratchpad_write", error))?;
@@ -2359,6 +2619,7 @@ fn handle_scratchpad_read(store: &mut Store, args: &Value) -> Result<Value, Hand
         .and_then(|v| v.as_u64())
         .unwrap_or(20)
         .min(200) as u32;
+    ensure_schema_compatible(store)?;
     let r = store
         .scratchpad_read(since, agent, kind, limit)
         .map_err(|error| HandlerError::internal("scratchpad_read", error))?;
@@ -2367,6 +2628,7 @@ fn handle_scratchpad_read(store: &mut Store, args: &Value) -> Result<Value, Hand
 
 fn handle_change_class(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
     let file = str_arg(args, "file")?;
+    ensure_schema_compatible(store)?;
     let root = std::env::current_dir()
         .map_err(|error| HandlerError::internal("change_class_root", error))?;
     let r = queries::classify_change(store, &root, file)
@@ -2386,6 +2648,12 @@ mod tests {
 
     fn fresh_test_store() -> (tempfile::TempDir, Store) {
         let root = tempfile::tempdir().unwrap();
+        let status = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(root.path())
+            .status()
+            .unwrap();
+        assert!(status.success());
         let mut store = Store::open(root.path().join("mmcg.db")).unwrap();
         crate::indexer::Indexer::new(root.path())
             .index_all(&mut store, true)
@@ -2844,10 +3112,12 @@ mod tests {
             }),
             json!(2),
         );
-        let error = internal.error.unwrap();
-        assert_eq!(error.code, -32603);
-        assert_eq!(error.message, "Internal tool error");
-        assert!(!error.message.contains("/path/that/does/not/exist"));
+        let result = internal.result.unwrap();
+        assert_eq!(result["isError"], true);
+        assert_eq!(unwrap_content(&result)["error"], "index_stale");
+        assert!(!serde_json::to_string(&result)
+            .unwrap()
+            .contains("/path/that/does/not/exist"));
 
         let _ = std::fs::remove_file(&path);
     }
@@ -2868,9 +3138,9 @@ mod tests {
             "name": "mmcg_symbols_changed_since",
             "arguments": { "git_ref": "HEAD", "root": SENTINEL }
         });
-        let typed_error =
-            handle_tools_call(ProtocolVersion::Current, &mut store, &params).unwrap_err();
-        let typed_debug = format!("{typed_error:?}");
+        let typed = handle_tools_call(ProtocolVersion::Current, &mut store, &params).unwrap();
+        let typed_debug = serde_json::to_string(&typed).unwrap();
+        assert_eq!(unwrap_content(&typed)["error"], "index_stale");
         assert!(!typed_debug.contains(SENTINEL));
         assert!(!typed_debug.contains("No such file"));
 
@@ -2879,7 +3149,10 @@ mod tests {
         let public_diagnostic = serde_json::to_string(&public_error).unwrap();
         assert!(!public_diagnostic.contains(SENTINEL));
         assert!(!public_diagnostic.contains("No such file"));
-        assert_eq!(public_error.error.unwrap().message, "Internal tool error");
+        assert_eq!(
+            unwrap_content(&public_error.result.unwrap())["error"],
+            "index_stale"
+        );
 
         let _ = std::fs::remove_file(&path);
     }
@@ -3064,10 +3337,7 @@ mod tests {
             .contains("Markdown"));
         assert_eq!(result["skipped_artifacts"], 0);
         assert_eq!(result["truncated"], false);
-        assert!(result["freshness"]
-            .as_str()
-            .unwrap()
-            .contains("not checked"));
+        assert_eq!(result["freshness"], "stale");
         let _ = std::fs::remove_file(&path);
     }
 
@@ -3212,7 +3482,7 @@ mod tests {
         run(&["commit", "-q", "-m", "baseline"]);
         std::fs::write(root.join("src/app.py"), "def value():\n    return 2\n").unwrap();
         let db = root.join(".mastermind/mmcg.db");
-        let mut store = crate::store::Store::open(db).unwrap();
+        let mut store = crate::store::Store::open_for_serve(&db, Some(&root)).unwrap();
         crate::indexer::Indexer::new(&root)
             .index_all(&mut store, true)
             .unwrap();
@@ -3231,6 +3501,58 @@ mod tests {
         )
         .unwrap();
         assert_eq!(actual, expected);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn change_impact_local_graph_limit_remains_a_successful_mcp_payload() {
+        let (root, mut store) = impact_fixture("local-graph-limit");
+        for index in 0..256 {
+            let caller = store
+                .insert_symbol(
+                    &format!("dense_caller_{index}"),
+                    "function",
+                    "src/generated.py",
+                    index + 1,
+                    index + 1,
+                    None,
+                    None,
+                )
+                .unwrap();
+            store
+                .insert_edge(caller, None, "value", "calls", index + 1)
+                .unwrap();
+        }
+        let _local_budget = crate::store::override_impact_precision_budget(WorkBudget {
+            deadline: None,
+            op_ticks: Some(1),
+        });
+
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({
+                "name": "mmcg_change_impact",
+                "arguments": {
+                    "since": "HEAD",
+                    "root": root.to_string_lossy(),
+                    "depth": 3,
+                    "top": 100
+                }
+            }),
+        )
+        .unwrap();
+        assert_eq!(result["isError"], false);
+        let payload = unwrap_content(&result);
+        assert_eq!(payload["schema_version"], 1);
+        assert!(payload["precision_notes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|note| note == "graph_work_limit"));
+        assert_eq!(payload["impact"]["truncated"], true);
+        assert_eq!(payload["impact"]["truncation_reason"], "work_limit");
+        assert_eq!(store.interrupt_source(), None);
         std::fs::remove_dir_all(root).ok();
     }
 
@@ -3500,18 +3822,29 @@ mod tests {
     }
 
     #[test]
-    fn changed_since_root_defaults_to_repo_root_from_db_path() {
+    fn changed_since_root_is_bound_to_index_identity() {
         let tmp = tempfile::tempdir().unwrap();
         let mastermind = tmp.path().join(".mastermind");
         std::fs::create_dir_all(&mastermind).unwrap();
         let db = mastermind.join("mmcg.db");
-        std::fs::write(&db, b"").unwrap();
+        let store = Store::open(&db).unwrap();
+        store
+            .set_meta(
+                "index_root",
+                tmp.path().canonicalize().unwrap().to_str().unwrap(),
+            )
+            .unwrap();
 
-        let root = changed_since_root(None, &db).unwrap();
+        let root = changed_since_root(&store, None).unwrap();
         assert_eq!(root, tmp.path().canonicalize().unwrap());
 
-        let explicit = changed_since_root(Some(tmp.path().to_str().unwrap()), &db).unwrap();
+        let explicit = changed_since_root(&store, Some(tmp.path().to_str().unwrap())).unwrap();
         assert_eq!(explicit, tmp.path().canonicalize().unwrap());
+        let unrelated = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            changed_since_root(&store, Some(unrelated.path().to_str().unwrap())),
+            Err(HandlerError::InvalidArguments(message)) if message == "root_mismatch"
+        ));
     }
 
     #[test]
@@ -3869,6 +4202,56 @@ mod tests {
             .is_empty());
 
         std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn external_incompatible_index_is_byte_preserved_and_has_no_sidecars() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = directory.path().join("repository/.mastermind");
+        std::fs::create_dir_all(&state).unwrap();
+        let path = state.join("mmcg.db");
+        {
+            let connection = rusqlite::Connection::open(&path).unwrap();
+            connection
+                .execute_batch(
+                    "CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                     INSERT INTO meta(key, value) VALUES ('schema_version', 'old');
+                     CREATE TABLE sentinel(value TEXT NOT NULL);
+                     INSERT INTO sentinel(value) VALUES ('preserve-me');",
+                )
+                .unwrap();
+        }
+        let before = std::fs::read(&path).unwrap();
+        let mut store = crate::store::Store::open_for_serve(&path, None).unwrap();
+        let invalid = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_search", "arguments": {} }),
+        )
+        .unwrap();
+        let invalid_payload = unwrap_content(&invalid);
+        assert_eq!(invalid["isError"], true);
+        assert!(invalid_payload["error"]
+            .as_str()
+            .is_some_and(|message| message.contains("name")));
+        let response = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_search", "arguments": { "name": "anything" } }),
+        )
+        .unwrap();
+        let payload = unwrap_content(&response);
+        assert_eq!(response["isError"], true);
+        assert_eq!(payload["code"], "schema_incompatible");
+        drop(store);
+        assert_eq!(std::fs::read(&path).unwrap(), before);
+        let sidecar = |suffix: &str| {
+            let mut value = path.as_os_str().to_os_string();
+            value.push(suffix);
+            PathBuf::from(value)
+        };
+        assert!(!sidecar("-wal").exists());
+        assert!(!sidecar("-shm").exists());
     }
 
     #[test]
@@ -4243,9 +4626,6 @@ mod tests {
     #[test]
     fn serve_io_late_cancel_does_not_abort_next_request() {
         let (_tmp, mut store) = fresh_test_store();
-        store
-            .insert_symbol("solo", "function", "src/solo.rs", 1, 2, None, None)
-            .unwrap();
 
         // `ping` (id 1) finishes near-instantly; a cancel notification for id
         // 1 arrives only after a delay, by which point request 1 has long
@@ -4253,7 +4633,7 @@ mod tests {
         let ping = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{}}"#;
         let stale_cancel =
             r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}}"#;
-        let next_call = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"mmcg_impact","arguments":{"name":"solo"}}}"#;
+        let next_call = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"mmcg_status","arguments":{}}}"#;
 
         let mut bytes = format!("{INITIALIZE_LINE}\n{INITIALIZED_LINE}\n{ping}\n").into_bytes();
         let delay_at = bytes.len();

--- a/mcp/servers/mmcg/src/queries.rs
+++ b/mcp/servers/mmcg/src/queries.rs
@@ -4,7 +4,8 @@
 //! and JSON serialization for the MCP layer.
 
 use crate::store::{
-    FileEntry, MapBoundaryMatch, MapBoundaryScope, ProjectHistoryHit, Store, Symbol, TaskSpecHit,
+    FileEntry, InterruptSource, MapBoundaryMatch, MapBoundaryScope, ProjectHistoryHit, Store,
+    Symbol, TaskSpecHit,
 };
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -440,14 +441,37 @@ pub fn history(
     kind: Option<&str>,
     top: u32,
 ) -> rusqlite::Result<HistorySearchResponse> {
-    let observed = store.search_project_history(query, kind, top)?;
-    let skipped_artifacts = store
-        .meta_value("project_history_skipped")?
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(0);
-    let truncated = store
-        .meta_value("project_history_truncated")?
-        .is_some_and(|value| value == "true");
+    let data_version_before = store.data_version()?;
+    store.begin_read_snapshot()?;
+    let snapshot = (|| {
+        let observed = store.search_project_history(query, kind, top)?;
+        let skipped_artifacts = store
+            .meta_value("project_history_skipped")?
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(0);
+        let truncated = store
+            .meta_value("project_history_truncated")?
+            .is_some_and(|value| value == "true");
+        let freshness = store
+            .meta_value("index_root")?
+            .map(PathBuf::from)
+            .map(|root| crate::indexer::Indexer::new(root).project_history_freshness(store))
+            .map(|result| match result {
+                Ok(crate::indexer::ProjectHistoryFreshness::Fresh) => "fresh",
+                Ok(crate::indexer::ProjectHistoryFreshness::Stale) => "stale",
+                Ok(crate::indexer::ProjectHistoryFreshness::Incomplete) => "incomplete",
+                Ok(crate::indexer::ProjectHistoryFreshness::SnapshotChanged) => "snapshot_changed",
+                Err(_) => "incomplete",
+            })
+            .unwrap_or("stale");
+        Ok::<_, rusqlite::Error>((observed, skipped_artifacts, truncated, freshness))
+    })();
+    let end_result = store.end_read_snapshot();
+    let (observed, skipped_artifacts, truncated, mut freshness) = snapshot?;
+    end_result?;
+    if store.data_version()? != data_version_before {
+        freshness = "snapshot_changed";
+    }
     Ok(HistorySearchResponse {
         query: query.to_string(),
         kind: kind.map(str::to_string),
@@ -457,7 +481,7 @@ pub fn history(
         source_of_truth: "Markdown artifacts at the returned paths; this FTS index is derived",
         skipped_artifacts,
         truncated,
-        freshness: "not checked by this query; run mastermind index after Markdown changes",
+        freshness,
     })
 }
 
@@ -480,6 +504,16 @@ pub fn symbols_changed_since(
     git_ref: &str,
 ) -> Result<crate::diff::SymbolDiff, crate::diff::DiffError> {
     crate::diff::symbols_changed_since(store, repo_root, git_ref)
+}
+
+pub(crate) fn symbols_changed_since_controlled(
+    store: &Store,
+    repo_root: &std::path::Path,
+    git_ref: &str,
+    deadline: Option<std::time::Instant>,
+    interrupted: Option<&dyn Fn() -> bool>,
+) -> Result<crate::diff::SymbolDiff, crate::diff::DiffError> {
+    crate::diff::symbols_changed_since_controlled(store, repo_root, git_ref, deadline, interrupted)
 }
 
 pub const CHANGE_SEED_LIMIT: usize = 200;
@@ -725,6 +759,98 @@ impl std::fmt::Display for ChangeImpactError {
 
 impl std::error::Error for ChangeImpactError {}
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CheckedSnapshotToken {
+    data_version: u64,
+    structural_worktree_token: String,
+    history_inventory_token: String,
+}
+
+struct StoreReadSnapshot<'a> {
+    store: &'a Store,
+    active: bool,
+}
+
+impl<'a> StoreReadSnapshot<'a> {
+    fn begin(store: &'a Store) -> rusqlite::Result<Self> {
+        store.begin_read_snapshot()?;
+        Ok(Self {
+            store,
+            active: true,
+        })
+    }
+
+    fn finish(mut self) -> rusqlite::Result<()> {
+        self.store.end_read_snapshot()?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for StoreReadSnapshot<'_> {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = self.store.end_read_snapshot();
+        }
+    }
+}
+
+fn history_snapshot_error(error: crate::indexer::IndexError) -> ChangeImpactError {
+    match error {
+        crate::indexer::IndexError::Cancelled | crate::indexer::IndexError::DeadlineExceeded => {
+            ChangeImpactError::GitTimeout
+        }
+        crate::indexer::IndexError::SnapshotChanged => ChangeImpactError::SnapshotChanged,
+        _ => ChangeImpactError::IndexStale,
+    }
+}
+
+pub(crate) fn checked_snapshot_token(
+    store: &Store,
+    repository_root: &Path,
+    structural_worktree_token: &str,
+) -> Result<CheckedSnapshotToken, ChangeImpactError> {
+    let data_version = store
+        .data_version()
+        .map_err(|_| ChangeImpactError::SnapshotChanged)?;
+    let (history_inventory_token, freshness) = crate::indexer::Indexer::new(repository_root)
+        .live_project_history_inventory(store)
+        .map_err(history_snapshot_error)?;
+    if freshness == crate::indexer::ProjectHistoryFreshness::SnapshotChanged {
+        return Err(ChangeImpactError::SnapshotChanged);
+    }
+    Ok(CheckedSnapshotToken {
+        data_version,
+        structural_worktree_token: structural_worktree_token.to_string(),
+        history_inventory_token,
+    })
+}
+
+fn validate_checked_snapshot(
+    store: &Store,
+    repository_root: &Path,
+    expected: &CheckedSnapshotToken,
+    structural_worktree_token: &str,
+) -> Result<(), ChangeImpactError> {
+    if structural_worktree_token != expected.structural_worktree_token
+        || store
+            .data_version()
+            .map_err(|_| ChangeImpactError::SnapshotChanged)?
+            != expected.data_version
+    {
+        return Err(ChangeImpactError::SnapshotChanged);
+    }
+    let (history_inventory_token, freshness) = crate::indexer::Indexer::new(repository_root)
+        .live_project_history_inventory(store)
+        .map_err(history_snapshot_error)?;
+    if freshness == crate::indexer::ProjectHistoryFreshness::SnapshotChanged
+        || history_inventory_token != expected.history_inventory_token
+    {
+        return Err(ChangeImpactError::SnapshotChanged);
+    }
+    Ok(())
+}
+
 impl From<crate::diff::WorkingTreeDiffError> for ChangeImpactError {
     fn from(error: crate::diff::WorkingTreeDiffError) -> Self {
         match error {
@@ -950,6 +1076,20 @@ fn work_limited_collection<T>(items: Vec<T>) -> Collection<T> {
     }
 }
 
+fn consume_graph_precision_interrupt(
+    store: &Store,
+    had_parent_budget: bool,
+    interrupt_before: Option<InterruptSource>,
+) -> bool {
+    match store.interrupt_source() {
+        None => true,
+        Some(InterruptSource::Budget) if !had_parent_budget && interrupt_before.is_none() => {
+            store.consume_budget_interrupt()
+        }
+        Some(InterruptSource::Budget | InterruptSource::Cancel) => false,
+    }
+}
+
 pub fn change_impact(
     store: &Store,
     requested_root: &Path,
@@ -965,6 +1105,11 @@ pub fn change_impact(
         .map_err(|_| ChangeImpactError::RootMismatch)?;
     let repository_root =
         owning_repository(&requested_root).ok_or(ChangeImpactError::RootMismatch)?;
+    let data_version_before = store
+        .data_version()
+        .map_err(|_| ChangeImpactError::SnapshotChanged)?;
+    let read_snapshot =
+        StoreReadSnapshot::begin(store).map_err(|_| ChangeImpactError::SnapshotChanged)?;
     let stored_root = store
         .meta_value("index_root")
         .map_err(|_| ChangeImpactError::IndexStale)?
@@ -975,6 +1120,8 @@ pub fn change_impact(
     if stored_root != repository_root {
         return Err(ChangeImpactError::RootMismatch);
     }
+    let root_capability = crate::bounded_fs::RootCapability::open(&repository_root)
+        .map_err(|_| ChangeImpactError::SnapshotChanged)?;
     let scope = requested_root
         .strip_prefix(&repository_root)
         .ok()
@@ -982,15 +1129,39 @@ pub fn change_impact(
         .map(|value| value.to_string_lossy().replace('\\', "/"))
         .unwrap_or_else(|| ".".to_string());
 
-    let working = crate::diff::symbols_changed_in_worktree(store, &repository_root, git_ref)?;
+    let interrupted = || store.work_interrupted();
+    let working = crate::diff::symbols_changed_in_worktree_controlled(
+        store,
+        &repository_root,
+        git_ref,
+        store.request_deadline(),
+        Some(&interrupted),
+    )?;
     for file in &working.files {
         if file.status == "deleted"
             || crate::indexer::extractor_for_path(Path::new(&file.path)).is_none()
         {
             continue;
         }
-        let bytes = std::fs::read(repository_root.join(&file.path))
-            .map_err(|_| ChangeImpactError::SnapshotChanged)?;
+        let bytes = crate::bounded_fs::read_regular_file_with_capability(
+            &root_capability,
+            Path::new(&file.path),
+            crate::indexer::MAX_INDEXABLE_FILE_SIZE,
+            crate::indexer::MAX_INDEXABLE_FILE_SIZE,
+            crate::bounded_fs::ReadControl {
+                deadline: store.request_deadline(),
+                interrupted: Some(&interrupted),
+            },
+        )
+        .map_err(|error| match error {
+            crate::bounded_fs::BoundedReadError::TooLarge { .. } => ChangeImpactError::IndexStale,
+            crate::bounded_fs::BoundedReadError::Interrupted
+            | crate::bounded_fs::BoundedReadError::DeadlineExceeded => {
+                ChangeImpactError::GitTimeout
+            }
+            _ => ChangeImpactError::SnapshotChanged,
+        })?
+        .bytes;
         let digest = crate::hex::encode(&Sha256::digest(bytes));
         let stored = store
             .file_content_sha256(&file.path)
@@ -1054,33 +1225,34 @@ pub fn change_impact(
         .into_iter()
         .collect();
 
-    let data_version_before = store
-        .data_version()
-        .map_err(|_| ChangeImpactError::SnapshotChanged)?;
-    store
-        .begin_read_snapshot()
-        .map_err(|_| ChangeImpactError::SnapshotChanged)?;
+    let checked_snapshot =
+        checked_snapshot_token(store, &repository_root, &working.snapshot_token)?;
 
     let mut precision_notes = vec!["focused_tests_do_not_replace_full_gate".to_string()];
     let graph_seed_overflow = seed_names.len() > CHANGE_SEED_LIMIT;
-    let graph_rows = if seed_names.is_empty() || graph_seed_overflow {
-        Vec::new()
+    let graph_had_parent_budget = store.work_budget_depth() > 0;
+    let graph_interrupt_before = store.interrupt_source();
+    let (graph_rows, graph_budget_exhausted) = if seed_names.is_empty() || graph_seed_overflow {
+        (Vec::new(), false)
     } else {
         match store.impact_of_many(&seed_names, max_depth, IMPACT_WORK_LIMIT, None) {
-            Ok(rows) => rows,
+            Ok(rows) => (rows, false),
             Err(rusqlite::Error::SqliteFailure(error, _))
-                if error.code == rusqlite::ErrorCode::OperationInterrupted =>
+                if error.code == rusqlite::ErrorCode::OperationInterrupted
+                    && consume_graph_precision_interrupt(
+                        store,
+                        graph_had_parent_budget,
+                        graph_interrupt_before,
+                    ) =>
             {
                 precision_notes.push("graph_work_limit".to_string());
-                Vec::new()
+                (Vec::new(), true)
             }
-            Err(_) => {
-                let _ = store.end_read_snapshot();
-                return Err(ChangeImpactError::SnapshotChanged);
-            }
+            Err(_) => return Err(ChangeImpactError::SnapshotChanged),
         }
     };
-    let graph_overflow = graph_seed_overflow || graph_rows.len() >= IMPACT_WORK_LIMIT;
+    let graph_overflow =
+        graph_seed_overflow || graph_budget_exhausted || graph_rows.len() >= IMPACT_WORK_LIMIT;
     if graph_seed_overflow {
         precision_notes.push("changed_seed_work_limit".to_string());
     } else if graph_rows.len() >= IMPACT_WORK_LIMIT {
@@ -1348,25 +1520,36 @@ pub fn change_impact(
 
     #[cfg(test)]
     run_impact_test_hook(ImpactTestStage::BeforeDataVersionRecheck);
-    store
-        .end_read_snapshot()
+    read_snapshot
+        .finish()
         .map_err(|_| ChangeImpactError::SnapshotChanged)?;
-    let data_version_after = store
+    if store
         .data_version()
-        .map_err(|_| ChangeImpactError::SnapshotChanged)?;
-    if data_version_before != data_version_after {
+        .map_err(|_| ChangeImpactError::SnapshotChanged)?
+        != data_version_before
+    {
         return Err(ChangeImpactError::SnapshotChanged);
     }
     #[cfg(test)]
     run_impact_test_hook(ImpactTestStage::BeforeGitSnapshotRecheck);
-    if crate::diff::current_head_oid(&repository_root)? != working.head_oid {
-        return Err(ChangeImpactError::SnapshotChanged);
-    }
-    let rechecked =
-        crate::diff::symbols_changed_in_worktree(store, &repository_root, &working.baseline_oid)?;
-    if rechecked.snapshot_token != working.snapshot_token || rechecked.files != working.files {
-        return Err(ChangeImpactError::SnapshotChanged);
-    }
+    crate::diff::validate_working_tree_snapshot_controlled(
+        &repository_root,
+        &working.baseline_oid,
+        &working.head_oid,
+        &working.files,
+        &working.snapshot_token,
+        store.request_deadline(),
+        Some(&interrupted),
+    )?;
+    validate_checked_snapshot(
+        store,
+        &repository_root,
+        &checked_snapshot,
+        &working.snapshot_token,
+    )?;
+    root_capability
+        .verify()
+        .map_err(|_| ChangeImpactError::SnapshotChanged)?;
 
     precision_notes.sort();
     precision_notes.dedup();
@@ -4115,6 +4298,50 @@ mod tests {
         assert!(limited.truncated);
         assert_eq!(limited.total, None);
         assert_eq!(limited.truncation_reason.as_deref(), Some("work_limit"));
+    }
+
+    #[test]
+    fn unguarded_change_impact_recovers_its_local_graph_budget() {
+        let root = impact_repo(
+            "unguarded_local_graph_limit",
+            &[("src/app.py", "def value():\n    return 1\n")],
+        );
+        write_impact_file(&root, "src/app.py", "def value():\n    return 2\n");
+        let store = index_impact(&root, "unguarded_local_graph_limit");
+        for index in 0..256 {
+            let caller = store
+                .insert_symbol(
+                    &format!("dense_caller_{index}"),
+                    "function",
+                    "src/generated.py",
+                    index + 1,
+                    index + 1,
+                    None,
+                    None,
+                )
+                .unwrap();
+            store
+                .insert_edge(caller, None, "value", "calls", index + 1)
+                .unwrap();
+        }
+        let _local_budget =
+            crate::store::override_impact_precision_budget(crate::store::WorkBudget {
+                deadline: None,
+                op_ticks: Some(1),
+            });
+
+        let response = change_impact(&store, &root, "HEAD", 3, 100).unwrap();
+        assert!(response
+            .precision_notes
+            .iter()
+            .any(|note| note == "graph_work_limit"));
+        assert!(response.impact.truncated);
+        assert_eq!(
+            response.impact.truncation_reason.as_deref(),
+            Some("work_limit")
+        );
+        assert_eq!(store.interrupt_source(), None);
+        std::fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/store.rs
+++ b/mcp/servers/mmcg/src/store.rs
@@ -19,7 +19,7 @@ use rusqlite::{
 use serde::{Deserialize, Serialize};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
@@ -28,7 +28,6 @@ use std::time::{Duration, Instant};
 const SCHEMA_VERSION: &str = "7";
 const READ_ONLY_SNAPSHOT_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const READ_ONLY_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(60);
-const SNAPSHOT_COPY_BUFFER_BYTES: usize = 1024 * 1024;
 
 fn row_u64(row: &rusqlite::Row<'_>, index: usize) -> SqlResult<u64> {
     let value = row.get::<_, i64>(index)?;
@@ -64,6 +63,42 @@ impl WorkBudget {
             }
         }
     }
+}
+
+fn impact_precision_budget() -> WorkBudget {
+    #[cfg(test)]
+    if let Some(budget) = IMPACT_PRECISION_BUDGET_OVERRIDE.with(Cell::get) {
+        return budget;
+    }
+    WorkBudget {
+        deadline: Some(Duration::from_secs(2)),
+        op_ticks: Some(250_000),
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    static IMPACT_PRECISION_BUDGET_OVERRIDE: Cell<Option<WorkBudget>> = const { Cell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) struct ImpactPrecisionBudgetOverride {
+    previous: Option<WorkBudget>,
+}
+
+#[cfg(test)]
+impl Drop for ImpactPrecisionBudgetOverride {
+    fn drop(&mut self) {
+        IMPACT_PRECISION_BUDGET_OVERRIDE.with(|slot| slot.set(self.previous));
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn override_impact_precision_budget(
+    budget: WorkBudget,
+) -> ImpactPrecisionBudgetOverride {
+    let previous = IMPACT_PRECISION_BUDGET_OVERRIDE.with(|slot| slot.replace(Some(budget)));
+    ImpactPrecisionBudgetOverride { previous }
 }
 
 /// Which mechanism raised a `SQLITE_INTERRUPT`-shaped error on the connection:
@@ -532,12 +567,14 @@ pub struct Store {
     ops_counter: Arc<AtomicU64>,
     interrupt_source: Arc<AtomicU8>,
     default_budget: Cell<WorkBudget>,
+    managed_root: Option<PathBuf>,
+    serve_root: Option<PathBuf>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 struct SourceFileState {
     len: u64,
-    modified: Option<std::time::SystemTime>,
+    identity: crate::bounded_fs::StableFileIdentity,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -596,68 +633,75 @@ fn sqlite_sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
     PathBuf::from(value)
 }
 
-fn source_file_state(path: &Path) -> SqlResult<SourceFileState> {
-    let metadata = std::fs::metadata(path).map_err(|error| sqlite_io_error("read index", error))?;
+fn sqlite_bounded_error(
+    context: &str,
+    error: crate::bounded_fs::BoundedReadError,
+) -> rusqlite::Error {
+    match error {
+        crate::bounded_fs::BoundedReadError::TooLarge { .. } => sqlite_snapshot_too_large(),
+        crate::bounded_fs::BoundedReadError::SnapshotChanged => sqlite_snapshot_changed(),
+        crate::bounded_fs::BoundedReadError::DeadlineExceeded
+        | crate::bounded_fs::BoundedReadError::Interrupted => sqlite_snapshot_timeout(),
+        crate::bounded_fs::BoundedReadError::Io(error) => sqlite_io_error(context, error),
+        error => sqlite_io_error(
+            context,
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string()),
+        ),
+    }
+}
+
+fn source_file_state(
+    root: &crate::bounded_fs::RootCapability,
+    path: &Path,
+    control: crate::bounded_fs::ReadControl<'_>,
+) -> SqlResult<SourceFileState> {
+    let file =
+        crate::bounded_fs::read_regular_file_with_capability(root, path, u64::MAX, 0, control)
+            .map_err(|error| sqlite_bounded_error("read index", error))?;
     Ok(SourceFileState {
-        len: metadata.len(),
-        modified: metadata.modified().ok(),
+        len: file.declared_len,
+        identity: file.identity,
     })
 }
 
-fn optional_source_file_state(path: &Path) -> SqlResult<Option<SourceFileState>> {
-    match std::fs::metadata(path) {
-        Ok(metadata) => Ok(Some(SourceFileState {
-            len: metadata.len(),
-            modified: metadata.modified().ok(),
+fn optional_source_file_state(
+    root: &crate::bounded_fs::RootCapability,
+    path: &Path,
+    control: crate::bounded_fs::ReadControl<'_>,
+) -> SqlResult<Option<SourceFileState>> {
+    match crate::bounded_fs::read_regular_file_with_capability(root, path, u64::MAX, 0, control) {
+        Ok(file) => Ok(Some(SourceFileState {
+            len: file.declared_len,
+            identity: file.identity,
         })),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(sqlite_io_error("read index sidecar", error)),
+        Err(crate::bounded_fs::BoundedReadError::Io(error))
+            if error.kind() == std::io::ErrorKind::NotFound =>
+        {
+            Ok(None)
+        }
+        Err(error) => Err(sqlite_bounded_error("read index sidecar", error)),
     }
 }
 
 fn index_file_state(db_path: &Path) -> SqlResult<IndexFileState> {
-    Ok(IndexFileState {
-        database: source_file_state(db_path)?,
-        wal: optional_source_file_state(&sqlite_sidecar_path(db_path, "-wal"))?,
-    })
+    index_file_state_with_control(db_path, crate::bounded_fs::ReadControl::default())
 }
 
-fn copy_file_bounded(
-    source: &Path,
-    destination: &Path,
-    budget: SnapshotCopyBudget,
-    copied: &mut u64,
-) -> SqlResult<()> {
-    if Instant::now() >= budget.deadline {
-        return Err(sqlite_snapshot_timeout());
-    }
-    let mut input = std::fs::File::open(source)
-        .map_err(|error| sqlite_io_error("open index snapshot source", error))?;
-    let mut output = std::fs::File::create(destination)
-        .map_err(|error| sqlite_io_error("create private index snapshot", error))?;
-    let mut buffer = vec![0u8; SNAPSHOT_COPY_BUFFER_BYTES];
-    loop {
-        if Instant::now() >= budget.deadline {
-            return Err(sqlite_snapshot_timeout());
-        }
-        let read_len = input
-            .read(&mut buffer)
-            .map_err(|error| sqlite_io_error("read index snapshot source", error))?;
-        if read_len == 0 {
-            break;
-        }
-        let read_bytes = u64::try_from(read_len).map_err(|_| sqlite_snapshot_too_large())?;
-        *copied = copied
-            .checked_add(read_bytes)
-            .filter(|value| *value <= budget.max_bytes)
-            .ok_or_else(sqlite_snapshot_too_large)?;
-        output
-            .write_all(&buffer[..read_len])
-            .map_err(|error| sqlite_io_error("write private index snapshot", error))?;
-    }
-    output
-        .flush()
-        .map_err(|error| sqlite_io_error("flush private index snapshot", error))
+fn index_file_state_with_control(
+    db_path: &Path,
+    control: crate::bounded_fs::ReadControl<'_>,
+) -> SqlResult<IndexFileState> {
+    let absolute = std::path::absolute(db_path)
+        .map_err(|error| sqlite_io_error("resolve index path", error))?;
+    let parent = absolute
+        .parent()
+        .ok_or_else(|| rusqlite::Error::InvalidPath(absolute.clone()))?;
+    let root = crate::bounded_fs::RootCapability::open(parent)
+        .map_err(|error| sqlite_bounded_error("open index parent", error))?;
+    Ok(IndexFileState {
+        database: source_file_state(&root, &absolute, control)?,
+        wal: optional_source_file_state(&root, &sqlite_sidecar_path(&absolute, "-wal"), control)?,
+    })
 }
 
 fn copy_index_snapshot(
@@ -667,7 +711,21 @@ fn copy_index_snapshot(
     if Instant::now() >= budget.deadline {
         return Err(sqlite_snapshot_timeout());
     }
-    let before = index_file_state(db_path)?;
+    let absolute = std::path::absolute(db_path)
+        .map_err(|error| sqlite_io_error("resolve index path", error))?;
+    let parent = absolute
+        .parent()
+        .ok_or_else(|| rusqlite::Error::InvalidPath(absolute.clone()))?;
+    let root = crate::bounded_fs::RootCapability::open(parent)
+        .map_err(|error| sqlite_bounded_error("open index parent", error))?;
+    let control = crate::bounded_fs::ReadControl {
+        deadline: Some(budget.deadline),
+        interrupted: None,
+    };
+    let before = IndexFileState {
+        database: source_file_state(&root, &absolute, control)?,
+        wal: optional_source_file_state(&root, &sqlite_sidecar_path(&absolute, "-wal"), control)?,
+    };
     let expected_bytes = before
         .database
         .len
@@ -680,19 +738,57 @@ fn copy_index_snapshot(
         .prefix("mastermind-lens-index-")
         .tempdir()
         .map_err(|error| sqlite_io_error("create private index snapshot", error))?;
-    let file_name = db_path
+    let file_name = absolute
         .file_name()
-        .ok_or_else(|| rusqlite::Error::InvalidPath(db_path.to_path_buf()))?;
+        .ok_or_else(|| rusqlite::Error::InvalidPath(absolute.clone()))?;
     let snapshot_path = snapshot_dir.path().join(file_name);
-    let source_wal = sqlite_sidecar_path(db_path, "-wal");
+    let source_wal = sqlite_sidecar_path(&absolute, "-wal");
     let snapshot_wal = sqlite_sidecar_path(&snapshot_path, "-wal");
 
-    let mut copied = 0;
-    copy_file_bounded(db_path, &snapshot_path, budget, &mut copied)?;
+    let mut copied = 0_u64;
+    let mut database_output = std::fs::File::create(&snapshot_path)
+        .map_err(|error| sqlite_io_error("create private index snapshot", error))?;
+    let database = crate::bounded_fs::copy_regular_file_with_capability(
+        &root,
+        &absolute,
+        budget.max_bytes,
+        control,
+        Some(before.database.identity),
+        &mut database_output,
+    )
+    .map_err(|error| sqlite_bounded_error("copy index snapshot", error))?;
+    database_output
+        .flush()
+        .map_err(|error| sqlite_io_error("flush private index snapshot", error))?;
+    copied = copied
+        .checked_add(database.declared_len)
+        .filter(|value| *value <= budget.max_bytes)
+        .ok_or_else(sqlite_snapshot_too_large)?;
     if before.wal.as_ref().is_some_and(|wal| wal.len > 0) {
-        copy_file_bounded(&source_wal, &snapshot_wal, budget, &mut copied)?;
+        let mut wal_output = std::fs::File::create(&snapshot_wal)
+            .map_err(|error| sqlite_io_error("create private WAL snapshot", error))?;
+        let wal = crate::bounded_fs::copy_regular_file_with_capability(
+            &root,
+            &source_wal,
+            budget.max_bytes.saturating_sub(copied),
+            control,
+            before.wal.as_ref().map(|wal| wal.identity),
+            &mut wal_output,
+        )
+        .map_err(|error| sqlite_bounded_error("copy index WAL snapshot", error))?;
+        wal_output
+            .flush()
+            .map_err(|error| sqlite_io_error("flush private WAL snapshot", error))?;
+        copied
+            .checked_add(wal.declared_len)
+            .filter(|value| *value <= budget.max_bytes)
+            .ok_or_else(sqlite_snapshot_too_large)?;
     }
-    if index_file_state(db_path)? == before {
+    let after = IndexFileState {
+        database: source_file_state(&root, &absolute, control)?,
+        wal: optional_source_file_state(&root, &sqlite_sidecar_path(&absolute, "-wal"), control)?,
+    };
+    if after == before {
         return Ok((snapshot_dir, snapshot_path));
     }
     Err(sqlite_snapshot_changed())
@@ -712,6 +808,7 @@ fn open_private_index_snapshot(
     Ok((connection, snapshot_dir))
 }
 
+#[cfg(test)]
 fn encode_sqlite_uri_path(path: &[u8]) -> Vec<u8> {
     const HEX: &[u8; 16] = b"0123456789ABCDEF";
     let mut encoded = Vec::with_capacity(path.len());
@@ -741,36 +838,7 @@ fn encode_sqlite_uri_path(path: &[u8]) -> Vec<u8> {
     encoded
 }
 
-#[cfg(unix)]
-fn immutable_sqlite_uri(db_path: &Path) -> SqlResult<PathBuf> {
-    use std::ffi::OsString;
-    use std::os::unix::ffi::{OsStrExt, OsStringExt};
-
-    let absolute = std::path::absolute(db_path)
-        .map_err(|_| rusqlite::Error::InvalidPath(db_path.to_path_buf()))?;
-    let mut uri = b"file:".to_vec();
-    uri.extend(encode_sqlite_uri_path(absolute.as_os_str().as_bytes()));
-    uri.extend_from_slice(b"?mode=ro&immutable=1&cache=private");
-    Ok(PathBuf::from(OsString::from_vec(uri)))
-}
-
-#[cfg(not(unix))]
-fn immutable_sqlite_uri(db_path: &Path) -> SqlResult<PathBuf> {
-    let absolute = std::path::absolute(db_path)
-        .map_err(|_| rusqlite::Error::InvalidPath(db_path.to_path_buf()))?;
-    let text = absolute
-        .to_str()
-        .ok_or_else(|| rusqlite::Error::InvalidPath(absolute.clone()))?;
-    let path = windows_sqlite_uri_path(text)
-        .ok_or_else(|| rusqlite::Error::InvalidPath(absolute.clone()))?;
-    let mut uri = b"file:".to_vec();
-    uri.extend(path);
-    uri.extend_from_slice(b"?mode=ro&immutable=1&cache=private");
-    let uri = String::from_utf8(uri).map_err(|_| rusqlite::Error::InvalidPath(absolute))?;
-    Ok(PathBuf::from(uri))
-}
-
-#[cfg(any(test, not(unix)))]
+#[cfg(test)]
 fn windows_sqlite_uri_path(text: &str) -> Option<Vec<u8>> {
     if text
         .get(..8)
@@ -790,7 +858,151 @@ fn windows_sqlite_uri_path(text: &str) -> Option<Vec<u8>> {
     Some(path)
 }
 
+fn connection_index_root(connection: &Connection) -> SqlResult<Option<String>> {
+    let meta_exists = connection
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='meta'",
+            [],
+            |_| Ok(true),
+        )
+        .optional()?
+        .unwrap_or(false);
+    if !meta_exists {
+        return Ok(None);
+    }
+    connection
+        .query_row("SELECT value FROM meta WHERE key='index_root'", [], |row| {
+            row.get(0)
+        })
+        .optional()
+}
+
 impl Store {
+    /// MCP serving may refresh only the canonical repository-owned index.
+    /// Explicit custom paths are opened through the non-mutating snapshot
+    /// reader, including when their schema is incompatible.
+    pub fn open_for_serve(
+        db_path: impl AsRef<Path>,
+        managed_root: Option<&Path>,
+    ) -> SqlResult<Self> {
+        let db_path = db_path.as_ref();
+        let Some(managed_root) = managed_root else {
+            return Self::open_read_only(db_path);
+        };
+        let root = crate::bounded_fs::RootCapability::open(managed_root)
+            .map_err(|error| sqlite_bounded_error("open managed repository root", error))?;
+        let expected = root.canonical_root().join(".mastermind/mmcg.db");
+        let requested_expected = root.requested_root().join(".mastermind/mmcg.db");
+        let selected = std::path::absolute(db_path)
+            .map_err(|error| sqlite_io_error("resolve managed index", error))?;
+        if selected != expected && selected != requested_expected {
+            let mut store = Self::open_read_only(&selected)?;
+            store.serve_root = Some(root.canonical_root().to_path_buf());
+            return Ok(store);
+        }
+        root.ensure_directory(Path::new(".mastermind"))
+            .map_err(|error| sqlite_bounded_error("create managed index directory", error))?;
+        let state =
+            crate::bounded_fs::RootCapability::open(&root.canonical_root().join(".mastermind"))
+                .map_err(|error| sqlite_bounded_error("open managed index directory", error))?;
+        let existing_identity = match crate::bounded_fs::read_regular_file_with_capability(
+            &state,
+            &expected,
+            u64::MAX,
+            0,
+            crate::bounded_fs::ReadControl::default(),
+        ) {
+            Ok(file) => Some(file.identity),
+            Err(crate::bounded_fs::BoundedReadError::Io(error))
+                if error.kind() == std::io::ErrorKind::NotFound =>
+            {
+                None
+            }
+            Err(error) => return Err(sqlite_bounded_error("inspect managed index", error)),
+        };
+        if existing_identity.is_some() {
+            let mut snapshot = Self::open_read_only(&expected)?;
+            let authorized = snapshot
+                .meta_value("index_root")?
+                .and_then(|stored| PathBuf::from(stored).canonicalize().ok())
+                .is_some_and(|stored| stored == root.canonical_root());
+            if !authorized {
+                snapshot.serve_root = Some(root.canonical_root().to_path_buf());
+                return Ok(snapshot);
+            }
+            drop(snapshot);
+        }
+        let mut created_file = None;
+        let expected_identity = match existing_identity {
+            Some(identity) => identity,
+            None => {
+                let (file, identity) =
+                    crate::bounded_fs::create_regular_file_with_capability(&state, &expected)
+                        .map_err(|error| sqlite_bounded_error("create managed index", error))?;
+                created_file = Some(file);
+                identity
+            }
+        };
+        let connection = Connection::open_with_flags(
+            &expected,
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX
+                | OpenFlags::SQLITE_OPEN_NOFOLLOW,
+        )?;
+        root.verify()
+            .map_err(|error| sqlite_bounded_error("verify managed repository root", error))?;
+        state
+            .verify()
+            .map_err(|error| sqlite_bounded_error("verify managed index directory", error))?;
+        let opened_file = crate::bounded_fs::read_regular_file_with_capability(
+            &state,
+            &expected,
+            u64::MAX,
+            0,
+            crate::bounded_fs::ReadControl::default(),
+        )
+        .map_err(|error| sqlite_bounded_error("verify managed index identity", error))?;
+        let identity_matches = if existing_identity.is_some() {
+            opened_file.identity == expected_identity
+        } else {
+            opened_file.identity.same_object(expected_identity)
+        };
+        if !identity_matches {
+            return Err(sqlite_snapshot_changed());
+        }
+        drop(created_file);
+        if existing_identity.is_some() {
+            let authorized = connection_index_root(&connection)?
+                .and_then(|stored| PathBuf::from(stored).canonicalize().ok())
+                .is_some_and(|stored| stored == root.canonical_root());
+            if !authorized {
+                drop(connection);
+                let mut store = Self::open_read_only(&expected)?;
+                store.serve_root = Some(root.canonical_root().to_path_buf());
+                return Ok(store);
+            }
+        }
+        connection.execute_batch(
+            r#"
+            PRAGMA foreign_keys = ON;
+            PRAGMA journal_mode = WAL;
+            PRAGMA synchronous = NORMAL;
+            PRAGMA busy_timeout = 5000;
+            PRAGMA cache_size = -65536;
+            "#,
+        )?;
+        let mut store = Self::from_connection(connection, expected, None);
+        store.managed_root = Some(root.canonical_root().to_path_buf());
+        store.serve_root = Some(root.canonical_root().to_path_buf());
+        store.init_schema()?;
+        root.verify()
+            .map_err(|error| sqlite_bounded_error("verify managed repository root", error))?;
+        state
+            .verify()
+            .map_err(|error| sqlite_bounded_error("verify managed index directory", error))?;
+        Ok(store)
+    }
+
     pub fn open(db_path: impl AsRef<Path>) -> SqlResult<Self> {
         let db_path = db_path.as_ref().to_path_buf();
         if let Some(parent) = db_path.parent() {
@@ -822,9 +1034,9 @@ impl Store {
     /// a database, creates WAL/SHM sidecars, changes journal settings, or runs
     /// schema initialization. A missing or outdated index remains an explicit
     /// operator error instead of a read-only command mutating repository state
-    /// while diagnosing it. A checkpointed database uses an immutable direct
-    /// connection. An active WAL is copied into a private temporary snapshot so
-    /// uncheckpointed rows remain visible without touching the source sidecars.
+    /// while diagnosing it. The database and active WAL are copied through
+    /// no-follow handles into one bounded private snapshot, so source sidecars
+    /// remain untouched and special files cannot block SQLite startup.
     /// Long-running callers must reject a result if the source database or WAL
     /// changes during the query, as Lens does around each refresh.
     pub fn open_read_only(db_path: impl AsRef<Path>) -> SqlResult<Self> {
@@ -836,37 +1048,10 @@ impl Store {
         request_deadline: Option<Instant>,
     ) -> SqlResult<Self> {
         let requested_path = db_path.as_ref();
-        let db_path = requested_path
-            .canonicalize()
+        let db_path = std::path::absolute(requested_path)
             .map_err(|error| sqlite_io_error("resolve read-only index", error))?;
         let snapshot_budget = SnapshotCopyBudget::for_request(request_deadline);
-        let before = index_file_state(&db_path)?;
-        let (conn, snapshot_dir) = if before.wal.as_ref().is_some_and(|wal| wal.len > 0) {
-            let (conn, snapshot_dir) = open_private_index_snapshot(&db_path, snapshot_budget)?;
-            (conn, Some(snapshot_dir))
-        } else {
-            match immutable_sqlite_uri(&db_path) {
-                Ok(uri) => {
-                    let conn = Connection::open_with_flags(
-                        &uri,
-                        OpenFlags::SQLITE_OPEN_READ_ONLY
-                            | OpenFlags::SQLITE_OPEN_URI
-                            | OpenFlags::SQLITE_OPEN_NO_MUTEX
-                            | OpenFlags::SQLITE_OPEN_PRIVATE_CACHE,
-                    )?;
-                    if index_file_state(&db_path)? != before {
-                        return Err(sqlite_snapshot_changed());
-                    }
-                    (conn, None)
-                }
-                Err(rusqlite::Error::InvalidPath(_)) => {
-                    let (conn, snapshot_dir) =
-                        open_private_index_snapshot(&db_path, snapshot_budget)?;
-                    (conn, Some(snapshot_dir))
-                }
-                Err(error) => return Err(error),
-            }
-        };
+        let (conn, snapshot_dir) = open_private_index_snapshot(&db_path, snapshot_budget)?;
         conn.execute_batch(
             r#"
             PRAGMA foreign_keys = ON;
@@ -875,7 +1060,7 @@ impl Store {
             PRAGMA query_only = ON;
             "#,
         )?;
-        Ok(Self::from_connection(conn, db_path, snapshot_dir))
+        Ok(Self::from_connection(conn, db_path, Some(snapshot_dir)))
     }
 
     /// Clone the exact connection snapshot into a private writable database.
@@ -899,7 +1084,15 @@ impl Store {
             .prefix("mastermind-temporal-index-")
             .tempdir()
             .map_err(|error| sqlite_io_error("create temporal index snapshot", error))?;
-        let snapshot_path = snapshot_dir.path().join("mmcg.db");
+        // A managed source connection carries SQLITE_OPEN_NOFOLLOW. SQLite
+        // applies that policy to `VACUUM INTO` as well, so canonicalize the
+        // private directory first on systems where the temp root (for example
+        // macOS `/var`) is itself a symlink.
+        let snapshot_path = snapshot_dir
+            .path()
+            .canonicalize()
+            .map_err(|error| sqlite_io_error("resolve temporal index snapshot", error))?
+            .join("mmcg.db");
         let query_only = self
             .conn
             .query_row("PRAGMA query_only", [], |row| row.get::<_, i64>(0))?
@@ -939,7 +1132,27 @@ impl Store {
     }
 
     pub fn schema_current(&self) -> SqlResult<bool> {
+        let meta_exists: bool = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='meta'",
+                [],
+                |_| Ok(true),
+            )
+            .optional()?
+            .unwrap_or(false);
+        if !meta_exists {
+            return Ok(false);
+        }
         Ok(self.meta_value("schema_version")?.as_deref() == Some(SCHEMA_VERSION))
+    }
+
+    pub(crate) fn managed_root(&self) -> Option<&Path> {
+        self.managed_root.as_deref()
+    }
+
+    pub(crate) fn serve_root(&self) -> Option<&Path> {
+        self.serve_root.as_deref()
     }
 
     fn from_connection(
@@ -955,6 +1168,8 @@ impl Store {
             ops_counter: Arc::new(AtomicU64::new(0)),
             interrupt_source: Arc::new(AtomicU8::new(INTERRUPT_NONE)),
             default_budget: Cell::new(WorkBudget::from_millis(DEFAULT_SERVE_BUDGET_MS)),
+            managed_root: None,
+            serve_root: None,
         }
     }
 
@@ -987,6 +1202,20 @@ impl Store {
                 cap.saturating_sub(used)
             }),
         }
+    }
+
+    /// Absolute deadline of the active outer request. Filesystem and Git work
+    /// consume this exact deadline instead of converting the default duration
+    /// into a fresh allowance for each phase.
+    pub(crate) fn request_deadline(&self) -> Option<Instant> {
+        self.guard_stack
+            .borrow()
+            .last()
+            .and_then(|frame| frame.deadline)
+    }
+
+    pub(crate) fn work_budget_depth(&self) -> usize {
+        self.guard_stack.borrow().len()
     }
 
     /// Cooperative check for non-SQL phases inside a guarded graph request.
@@ -1129,6 +1358,34 @@ impl Store {
         result
     }
 
+    /// Run a deliberately narrower, recoverable precision budget below an
+    /// already-active request guard. If only this local frame expires, consume
+    /// its budget marker after restoring the still-live parent. Request expiry
+    /// and cancellation remain marked for the transport to map normally.
+    fn with_local_work_budget<T>(
+        &self,
+        budget: WorkBudget,
+        f: impl FnOnce() -> SqlResult<T>,
+    ) -> SqlResult<T> {
+        let had_parent = self.work_budget_depth() > 0;
+        let interrupt_before = self.interrupt_source.load(Ordering::SeqCst);
+        let result = self.with_work_budget(budget, f);
+        let parent_expired = self
+            .guard_stack
+            .borrow()
+            .last()
+            .is_some_and(|frame| frame.expired(&self.ops_counter));
+        if had_parent && interrupt_before == INTERRUPT_NONE && !parent_expired {
+            let _ = self.interrupt_source.compare_exchange(
+                INTERRUPT_BUDGET,
+                INTERRUPT_NONE,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            );
+        }
+        result
+    }
+
     fn interrupted_error() -> rusqlite::Error {
         rusqlite::Error::SqliteFailure(
             rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_INTERRUPT),
@@ -1146,6 +1403,27 @@ impl Store {
             INTERRUPT_CANCEL => Some(InterruptSource::Cancel),
             _ => None,
         }
+    }
+
+    pub(crate) fn interrupt_source(&self) -> Option<InterruptSource> {
+        match self.interrupt_source.load(Ordering::SeqCst) {
+            INTERRUPT_BUDGET => Some(InterruptSource::Budget),
+            INTERRUPT_CANCEL => Some(InterruptSource::Cancel),
+            _ => None,
+        }
+    }
+
+    /// Consume a handled budget marker without clearing a cancel that won the
+    /// race. Reserved for recoverable local precision limits.
+    pub(crate) fn consume_budget_interrupt(&self) -> bool {
+        self.interrupt_source
+            .compare_exchange(
+                INTERRUPT_BUDGET,
+                INTERRUPT_NONE,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_ok()
     }
 
     /// A cloneable, cross-thread handle that marks the interrupt source as
@@ -2483,6 +2761,20 @@ impl Store {
         rows.next()?.map(|r| r.get(0)).transpose()
     }
 
+    pub(crate) fn file_mtimes_bounded(&self, cap: usize) -> SqlResult<Option<Vec<(String, i64)>>> {
+        let fetch = cap.saturating_add(1).min(i64::MAX as usize) as i64;
+        let mut statement = self
+            .conn
+            .prepare("SELECT path, indexed_at FROM files ORDER BY path LIMIT ?1")?;
+        let rows = statement.query_map([fetch], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        let mut entries = rows.collect::<SqlResult<Vec<_>>>()?;
+        if entries.len() > cap {
+            return Ok(None);
+        }
+        entries.shrink_to_fit();
+        Ok(Some(entries))
+    }
+
     /// Stored structural fingerprint for a file path, or `None` if never indexed.
     /// Files indexed before 0.28 return `Some("")` (column backfilled with `''`);
     /// callers should treat that as `first-seen`.
@@ -2782,11 +3074,8 @@ impl Store {
             None => SqlValue::Null,
         });
 
-        let budget = WorkBudget {
-            deadline: Some(Duration::from_secs(2)),
-            op_ticks: Some(250_000),
-        };
-        self.with_work_budget(budget, || {
+        let budget = impact_precision_budget();
+        self.with_local_work_budget(budget, || {
             let mut statement = self.conn.prepare(&sql)?;
             let rows = statement.query_map(rusqlite::params_from_iter(values), |row| {
                 Ok(SeedImpact {
@@ -3833,6 +4122,19 @@ impl Store {
     /// this after scanning the supported Markdown sources, which also removes
     /// stale rows after a rename or deletion.
     pub fn replace_project_history(&mut self, entries: &[ProjectHistoryEntry]) -> SqlResult<()> {
+        self.replace_project_history_snapshot(entries, 0, false, "")
+    }
+
+    /// Replace the derived history rows and their inventory contract in one
+    /// transaction. Readers can therefore never observe a new FTS corpus with
+    /// the previous freshness token (or the reverse).
+    pub(crate) fn replace_project_history_snapshot(
+        &mut self,
+        entries: &[ProjectHistoryEntry],
+        skipped: u32,
+        truncated: bool,
+        inventory_token: &str,
+    ) -> SqlResult<()> {
         let tx = self.conn.unchecked_transaction()?;
         tx.execute("DELETE FROM project_history_fts", [])?;
         {
@@ -3843,6 +4145,23 @@ impl Store {
             for entry in entries {
                 stmt.execute(params![entry.path, entry.kind, entry.title, entry.body])?;
             }
+        }
+        for (key, value) in [
+            ("project_history_skipped", skipped.to_string()),
+            (
+                "project_history_truncated",
+                if truncated { "true" } else { "false" }.to_string(),
+            ),
+            (
+                "project_history_inventory_token",
+                inventory_token.to_string(),
+            ),
+        ] {
+            tx.execute(
+                "INSERT INTO meta(key, value) VALUES (?1, ?2)
+                 ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                params![key, value],
+            )?;
         }
         tx.commit()
     }
@@ -4380,6 +4699,8 @@ mod tests {
     use super::*;
     use std::collections::{BTreeMap, BTreeSet};
     use std::env;
+    #[cfg(unix)]
+    use std::process::Command;
 
     /// Unique path per test — parallel tests can't share the file.
     fn tmp_db(test_name: &str) -> PathBuf {
@@ -4654,7 +4975,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn read_only_open_follows_a_symlink_to_the_active_wal() {
+    fn read_only_open_rejects_a_symlinked_database() {
         use std::os::unix::fs::symlink;
 
         let directory = tempfile::tempdir().unwrap();
@@ -4675,16 +4996,108 @@ mod tests {
         symlink(&path, &alias).unwrap();
         let before = directory_bytes(directory.path());
 
-        let read_only = Store::open_read_only(&alias).unwrap();
-        assert!(read_only
-            .search_symbols("only_in_target_wal", None, None)
-            .unwrap()
-            .iter()
-            .any(|symbol| symbol.name == "only_in_target_wal"));
-        drop(read_only);
+        assert!(Store::open_read_only(&alias).is_err());
 
         assert_eq!(directory_bytes(directory.path()), before);
         drop(writer);
+    }
+
+    #[test]
+    fn managed_serve_open_authorizes_only_the_repository_index() {
+        let root = tempfile::tempdir().unwrap();
+        let expected = root.path().join(".mastermind/mmcg.db");
+        let managed = Store::open_for_serve(&expected, Some(root.path())).unwrap();
+        let canonical_root = root.path().canonicalize().unwrap();
+
+        assert_eq!(managed.managed_root(), Some(canonical_root.as_path()));
+        assert_eq!(managed.serve_root(), Some(canonical_root.as_path()));
+        assert!(managed.schema_current().unwrap());
+        assert!(expected.is_file());
+    }
+
+    #[test]
+    fn managed_serve_open_preserves_mismatched_existing_database() {
+        let root = tempfile::tempdir().unwrap();
+        let unrelated = tempfile::tempdir().unwrap();
+        let state = root.path().join(".mastermind");
+        std::fs::create_dir(&state).unwrap();
+        let expected = state.join("mmcg.db");
+        {
+            let source = Store::open(&expected).unwrap();
+            source
+                .set_meta(
+                    "index_root",
+                    unrelated.path().canonicalize().unwrap().to_str().unwrap(),
+                )
+                .unwrap();
+            source
+                .insert_symbol("preserved", "function", "src/lib.rs", 1, 2, None, None)
+                .unwrap();
+        }
+        let before = directory_bytes(&state);
+
+        let served = Store::open_for_serve(&expected, Some(root.path())).unwrap();
+        let canonical_root = root.path().canonicalize().unwrap();
+        assert!(served.managed_root().is_none());
+        assert_eq!(served.serve_root(), Some(canonical_root.as_path()));
+        assert_eq!(served.symbol_count().unwrap(), 1);
+        assert!(served
+            .insert_symbol("forbidden", "function", "src/lib.rs", 3, 4, None, None)
+            .is_err());
+        drop(served);
+
+        assert_eq!(directory_bytes(&state), before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_serve_open_rejects_symlinked_state_and_database() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let victim = tempfile::tempdir().unwrap();
+        symlink(victim.path(), root.path().join(".mastermind")).unwrap();
+        let expected = root.path().join(".mastermind/mmcg.db");
+        assert!(Store::open_for_serve(&expected, Some(root.path())).is_err());
+        assert!(std::fs::read_dir(victim.path()).unwrap().next().is_none());
+
+        let root = tempfile::tempdir().unwrap();
+        let state = root.path().join(".mastermind");
+        std::fs::create_dir(&state).unwrap();
+        let victim_path = victim.path().join("victim.db");
+        {
+            let victim_store = Store::open(&victim_path).unwrap();
+            victim_store.set_meta("sentinel", "unchanged").unwrap();
+        }
+        let before = std::fs::read(&victim_path).unwrap();
+        let expected = state.join("mmcg.db");
+        symlink(&victim_path, &expected).unwrap();
+        assert!(Store::open_for_serve(&expected, Some(root.path())).is_err());
+        assert_eq!(std::fs::read(&victim_path).unwrap(), before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_serve_open_rejects_fifo_without_blocking() {
+        use std::os::unix::fs::FileTypeExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let state = root.path().join(".mastermind");
+        std::fs::create_dir(&state).unwrap();
+        let expected = state.join("mmcg.db");
+        assert!(Command::new("mkfifo")
+            .arg(&expected)
+            .status()
+            .unwrap()
+            .success());
+        assert!(std::fs::symlink_metadata(&expected)
+            .unwrap()
+            .file_type()
+            .is_fifo());
+
+        let started = Instant::now();
+        assert!(Store::open_for_serve(&expected, Some(root.path())).is_err());
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
 
     #[test]
@@ -6279,6 +6692,59 @@ mod tests {
         );
         store.pop_work_budget();
         store.pop_work_budget();
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn local_precision_budget_clears_only_its_own_interrupt_marker() {
+        fn long_query(store: &Store) -> SqlResult<i64> {
+            store
+                .conn
+                .prepare(
+                    "WITH RECURSIVE cnt(x) AS (
+                         SELECT 1
+                         UNION ALL
+                         SELECT x + 1 FROM cnt WHERE x < 100000000
+                     )
+                     SELECT count(*) FROM cnt",
+                )?
+                .query_row([], |row| row.get(0))
+        }
+
+        let path = tmp_db("local_precision_budget_marker");
+        let store = Store::open(&path).unwrap();
+
+        assert!(!store.push_work_budget(WorkBudget {
+            deadline: None,
+            op_ticks: Some(1_000),
+        }));
+        let local = store.with_local_work_budget(
+            WorkBudget {
+                deadline: None,
+                op_ticks: Some(1),
+            },
+            || long_query(&store),
+        );
+        assert_sqlite_interrupted(&local);
+        assert_eq!(store.interrupt_source(), None);
+        assert!(!store.work_interrupted());
+        store.pop_work_budget();
+
+        assert!(!store.push_work_budget(WorkBudget {
+            deadline: None,
+            op_ticks: Some(1),
+        }));
+        let inherited = store.with_local_work_budget(
+            WorkBudget {
+                deadline: None,
+                op_ticks: Some(1_000),
+            },
+            || long_query(&store),
+        );
+        assert_sqlite_interrupted(&inherited);
+        assert_eq!(store.interrupt_source(), Some(InterruptSource::Budget));
+        store.pop_work_budget();
+        assert_eq!(store.take_interrupt_source(), Some(InterruptSource::Budget));
         std::fs::remove_file(&path).ok();
     }
 

--- a/mcp/servers/mmcg/src/workflow_status.rs
+++ b/mcp/servers/mmcg/src/workflow_status.rs
@@ -4100,30 +4100,25 @@ pub(crate) fn stale_paths(root: &Path, db: &Path, cap: usize) -> Option<Vec<Stri
         if crate::indexer::extractor_for_path(&path).is_none() {
             continue;
         }
-        let admission_failed = match crate::indexer::source_admission(&path) {
-            Ok(()) => false,
+        let admitted_mtime = match crate::indexer::source_admission_mtime(root, &path) {
+            Ok(mtime) => Some(mtime),
             Err(crate::indexer::IndexError::Skipped(_)) => continue,
-            Err(_) => true,
+            Err(_) => None,
         };
         let Ok(relative) = path.strip_prefix(root) else {
             continue;
         };
         let relative = relative.to_string_lossy().replace('\\', "/");
         seen.insert(relative.clone());
-        if admission_failed {
+        if admitted_mtime.is_none() {
             stale.push(relative);
             if stale.len() >= cap {
                 return Some(stale);
             }
             continue;
         }
-        let fs_mtime = path
-            .metadata()
-            .and_then(|m| m.modified())
-            .ok()
-            .and_then(|mtime| mtime.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|duration| duration.as_millis() as i64);
-        if fs_mtime.is_some_and(|mtime| indexed.get(&relative).is_none_or(|stored| mtime > *stored))
+        if admitted_mtime
+            .is_some_and(|mtime| indexed.get(&relative).is_none_or(|stored| mtime > *stored))
         {
             stale.push(relative);
             if stale.len() >= cap {
@@ -4132,7 +4127,11 @@ pub(crate) fn stale_paths(root: &Path, db: &Path, cap: usize) -> Option<Vec<Stri
         }
     }
     for indexed_path in indexed.keys() {
-        if !seen.contains(indexed_path) && !root.join(indexed_path).exists() {
+        let remains_regular =
+            std::fs::symlink_metadata(root.join(indexed_path)).is_ok_and(|metadata| {
+                metadata.file_type().is_file() && !metadata.file_type().is_symlink()
+            });
+        if !seen.contains(indexed_path) && !remains_regular {
             stale.push(indexed_path.clone());
             if stale.len() >= cap {
                 break;
@@ -4141,6 +4140,124 @@ pub(crate) fn stale_paths(root: &Path, db: &Path, cap: usize) -> Option<Vec<Stri
     }
     stale.sort();
     Some(stale)
+}
+
+pub(crate) fn stale_paths_controlled(
+    store: &crate::store::Store,
+    root: &Path,
+    cap: usize,
+    source_cap: usize,
+    source_bytes_cap: u64,
+    control: crate::bounded_fs::ReadControl<'_>,
+) -> Result<Vec<String>, crate::indexer::IndexError> {
+    if cap == 0 {
+        return Ok(Vec::new());
+    }
+    control
+        .check()
+        .map_err(crate::indexer::index_error_from_read)?;
+    let root_capability = crate::bounded_fs::RootCapability::open(root)
+        .map_err(crate::indexer::index_error_from_read)?;
+    let indexed_entries = store
+        .file_mtimes_bounded(source_cap)
+        .map_err(|error| crate::indexer::IndexError::Other(error.to_string()))?
+        .ok_or(crate::indexer::IndexError::LimitExceeded {
+            dimension: "source_candidates",
+            cap: source_cap as u64,
+        })?;
+    let indexed: HashMap<String, i64> = indexed_entries.into_iter().collect();
+    let candidates =
+        crate::indexer::source_candidates_bounded(&root_capability, source_cap, control)?;
+    let mut declared_bytes = 0_u64;
+    let mut seen = HashSet::new();
+    let mut stale = Vec::new();
+    for path in candidates {
+        control
+            .check()
+            .map_err(crate::indexer::index_error_from_read)?;
+        if crate::indexer::extractor_for_path(&path).is_none() {
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root_capability.canonical_root())
+            .map_err(|_| crate::indexer::IndexError::SnapshotChanged)?
+            .to_string_lossy()
+            .replace('\\', "/");
+        let admitted = match crate::indexer::source_admission_with_capability(
+            &root_capability,
+            &path,
+            control,
+        ) {
+            Ok(file) => file,
+            Err(crate::indexer::IndexError::Skipped(_)) => continue,
+            Err(crate::indexer::IndexError::Cancelled) => {
+                return Err(crate::indexer::IndexError::Cancelled)
+            }
+            Err(crate::indexer::IndexError::DeadlineExceeded) => {
+                return Err(crate::indexer::IndexError::DeadlineExceeded)
+            }
+            Err(crate::indexer::IndexError::LimitExceeded { dimension, cap }) => {
+                return Err(crate::indexer::IndexError::LimitExceeded { dimension, cap })
+            }
+            Err(_) => {
+                stale.push(relative.clone());
+                seen.insert(relative);
+                if stale.len() >= cap {
+                    return Ok(stale);
+                }
+                continue;
+            }
+        };
+        declared_bytes = declared_bytes.checked_add(admitted.declared_len).ok_or(
+            crate::indexer::IndexError::LimitExceeded {
+                dimension: "source_declared_bytes",
+                cap: source_bytes_cap,
+            },
+        )?;
+        if declared_bytes > source_bytes_cap {
+            return Err(crate::indexer::IndexError::LimitExceeded {
+                dimension: "source_declared_bytes",
+                cap: source_bytes_cap,
+            });
+        }
+        seen.insert(relative.clone());
+        if indexed
+            .get(&relative)
+            .is_none_or(|stored| admitted.modified_millis > *stored)
+        {
+            stale.push(relative);
+            if stale.len() >= cap {
+                return Ok(stale);
+            }
+        }
+    }
+    for indexed_path in indexed.keys() {
+        control
+            .check()
+            .map_err(crate::indexer::index_error_from_read)?;
+        if seen.contains(indexed_path) {
+            continue;
+        }
+        let remains_regular = crate::bounded_fs::read_regular_file_with_capability(
+            &root_capability,
+            Path::new(indexed_path),
+            u64::MAX,
+            0,
+            control,
+        )
+        .is_ok();
+        if !remains_regular {
+            stale.push(indexed_path.clone());
+            if stale.len() >= cap {
+                break;
+            }
+        }
+    }
+    root_capability
+        .verify()
+        .map_err(crate::indexer::index_error_from_read)?;
+    stale.sort();
+    Ok(stale)
 }
 
 fn scan_install(root: &Path) -> InstallInfo {


### PR DESCRIPTION
Builds on #82, which is now merged.

Summary:
- automatically refresh stale repository-owned indexes for structural MCP tools
- keep explicit custom indexes read-only and fail stale without mutation
- add bounded no-follow source, history, Lens, SQLite snapshot, and Git reads
- carry one request deadline and cancellation signal through refresh, retry, and JSON encoding
- bind change impact to SQLite, source, history, HEAD, and worktree freshness

Verification:
- just check
- focused source admission, history freshness, auto refresh, external index, and change impact suites
- independent critical review: ship it
- comment audit: clean

No merge, release, tag, publish, or deploy is included.