### PR TITLE
Add local symbol concept search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `mmcg_concept` and `mastermind concept` now return a bounded schema-v1 set of
+  local symbol candidates from normalized names, repository paths, and
+  declaration shapes. Fixed quoted-AND FTS5 retrieval uses no embeddings,
+  model calls, network access, source bodies, comments, literals, or defaults;
+  managed indexes refresh once on extractor or normalization drift, while
+  custom external indexes remain read-only and fail closed.
 - `mmcg_brief` and `mastermind brief` now build one deterministic,
   revision-bound planner/executor/auditor context packet. Role-specific prefix
   admission is capped and reports source, unsafe-content, and budget omissions;

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ excerpts.
 | Review the current change | Changed symbols, downstream reach, component crossings, candidate tests, and an evidence inspector |
 | Audit the architecture | Components, entry points, cycles, centrality, large-file pressure, ownership concentration, and change hotspots |
 | Keep boundaries enforceable | Repository policy checks with text, JSON, and SARIF output |
-| Give an agent real context | 29 bounded MCP tools, including one revision-bound role brief, over the same local graph |
+| Give an agent real context | 30 bounded MCP tools, including local concept search and one revision-bound role brief, over the same local graph |
 | Hand the review to anyone | A standalone offline Lens package with HTML, SARIF, summary, and a revision/evidence manifest |
 
 <table>
@@ -132,6 +132,7 @@ invent graph topology.
 ```bash
 mastermind impact --since main
 mastermind brief --role auditor --since main --budget-tokens 2000
+mastermind concept "payment retry handler" --top 10
 mastermind temporal --since main
 mastermind ui --since main --production-only
 ```
@@ -219,7 +220,7 @@ directory for manifest-scoped validation; add `--json` for the schema-v1 report.
 
 Mastermind supports Claude Code, Codex, Cursor, Continue, and generic MCP stdio
 clients. Setup is dry-run-first unless `--write` is present. The MCP surface has
-20 non-destructive queries that may refresh the managed derived index, 8
+21 non-destructive queries that may refresh the managed derived index, 8
 read-only tools, and one additive write to the local gitignored scratchpad.
 
 ## How it works

--- a/docs/integrations/generic-mcp.md
+++ b/docs/integrations/generic-mcp.md
@@ -13,7 +13,7 @@ dedicated Claude Code, Codex, Cursor, or Continue setup command applies.
 | transport | stdio |
 | command | `mastermind serve` |
 | protocol | MCP 2025-11-25; legacy 2024-11-05 |
-| tools | 29: 20 refreshable non-destructive queries, 8 read-only queries, 1 additive local write (see below) |
+| tools | 30: 21 refreshable non-destructive queries, 8 read-only queries, 1 additive local write (see below) |
 | resources | none |
 | prompts | none |
 
@@ -68,7 +68,7 @@ The `--index` flag is global and must come before `serve`.
 
 ## What the client receives
 
-- Symbol discovery: `mmcg_search`, `mmcg_outline`, `mmcg_files`,
+- Symbol discovery: `mmcg_search`, `mmcg_concept`, `mmcg_outline`, `mmcg_files`,
   `mmcg_symbols_in_file`.
 - Relationships and architecture: `mmcg_callers`, `mmcg_callees`,
   `mmcg_imports`, `mmcg_imported_by`, `mmcg_impact`, `mmcg_api_surface`,
@@ -89,6 +89,12 @@ logical packet into `content.text` and `structuredContent`; the reported budget
 already counts both copies after JSON escaping. The packet marks repository
 strings as untrusted data and never includes source bodies, declaration
 signatures, literal/default values, or free-form history excerpts.
+
+For natural-language symbol discovery, call `mmcg_concept` with a plain `query`
+and optional `top` (default 10, maximum 50). Terms are normalized, quoted, and
+joined with fixed AND semantics. The tool uses only the local SQLite index and
+returns schema-v1 retrieval candidates, not confidence-ranked answers; it does
+not use embeddings, models, network access, source bodies, or comments.
 
 ## Start the server manually
 

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -8,7 +8,7 @@ the source of truth for the `mmcg` engine. Start with
 `mmcg` is a Rust binary that builds a local structural index for Python,
 TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++.
 It exposes the same indexed state through CLI, Lens, and MCP. The MCP surface
-contains 29 tools: 20 non-destructive queries that may refresh the managed
+contains 30 tools: 21 non-destructive queries that may refresh the managed
 derived index, 8 read-only queries, and one additive local scratchpad write.
 The binary also provides spec gates, client setup, evidence ingestion, review
 export, and style mining.
@@ -30,6 +30,7 @@ export, and style mining.
 | Architecture rules | [Policy as code](#architecture-policy-as-code-mmcg-policy-check) |
 | MCP protocol and tool schemas | [MCP server](#mcp-server-usage), [MCP tools](#mcp-tools) |
 | Bounds and precision caveats | [Work budgets](#work-budgets-timeouts-and-cancellation), [limitations](#limitations) |
+| Local natural-language symbol retrieval | [Local symbol concept search](#local-symbol-concept-search) |
 
 ## What it indexes
 
@@ -100,7 +101,7 @@ bounded query surface instead of repeatedly rescanning source text.
   syntactic graph.
 - External producers submit validated facts; they cannot execute inside the
   process or write SQLite.
-- MCP exposes 29 bounded tools: 20 non-destructive queries that may refresh the
+- MCP exposes 30 bounded tools: 21 non-destructive queries that may refresh the
   managed derived index, 8 read-only queries, and the additive, gitignored
   `mmcg_scratchpad_append` write.
 
@@ -280,7 +281,51 @@ mmcg query outline src/store.rs                    # symbol tree of one file
 mmcg query recent --since 2h                       # files re-indexed in last 2 hours
 mmcg query unreferenced --kind function            # dead-code candidates (review manually)
 mmcg query api-surface src/runtime/                # symbols under prefix used externally
+
+# Deterministic local concept retrieval (no embeddings or model calls)
+mmcg concept "payment retry handler" --top 10
+mmcg concept "payment retry handler" --top 10 --format json
 ```
+
+### Local symbol concept search
+
+`mmcg_concept` and `mastermind concept` use one schema-v1 query builder over a
+private derived corpus. Searchable fields are normalized symbol names,
+repository-relative paths, and bounded declaration shapes; the documentation
+field is reserved and empty. Source bodies and comments are never indexed or
+returned. Quoted, character, raw, template, regex, numeric, and default-value
+content is removed from declaration shapes before persistence.
+
+The query is plain text up to 256 UTF-8 bytes. Shared normalization applies
+Unicode lowercase without claiming canonical equivalence, splits punctuation,
+paths, snake/kebab/camel/acronym transitions and letter/digit boundaries, and
+admits at most 16 terms of 64 bytes each. Every term is escaped, quoted, and
+joined by a fixed `AND`, so callers cannot supply FTS syntax, column selectors,
+boolean operators, or prefix wildcards. `top` is an integer from 1 through 50.
+
+SQLite FTS5 ranks with fixed BM25 weights: name 10, path 4, declaration shape
+2, and the reserved documentation field 1. The total tie order is score,
+lowercase repository path, line, kind, name, then symbol ID. Scores are local
+to one query, lower is better, and they are not confidence values. Each
+candidate contains `name`, `kind`, `language`, `path`, `line`, a declaration
+`signature_shape` capped at 256 bytes, `matched_fields`, `citation`, and
+`score`; the envelope also reports normalized `query_terms`, count, requested
+top, freshness, limits, and precision notes.
+
+The corpus is an additive schema-v7 table plus external-content FTS5 index.
+Symbol mutations dirty its independent normalization contract, including writes
+from older schema-v7 binaries. Managed queries may perform one bounded full
+refresh and retry when the extractor or concept contract drifts. Finalization
+checks symbol/concept parity and FTS integrity before stamping both contracts
+current. Custom external indexes open read-only, are never migrated, and return
+`index_stale` or `schema_incompatible` when the required corpus is unavailable.
+Stable query failures also include `invalid_arguments`, `snapshot_changed`,
+`work_limit_exceeded`, `cancelled`, and `internal_error`.
+
+This is deterministic local retrieval, not semantic inference: no embeddings,
+model calls, network access, broad grep, or canonical-equivalence matching are
+used. Returned repository strings are untrusted data. JSON preserves them as
+JSON strings; human text renders syntax-forming characters as Unicode escapes.
 
 ### Workflow audit
 
@@ -347,7 +392,7 @@ structural rebuild even when file mtimes are unchanged. `status`, `doctor`, and
 Output example:
 
 ```
-indexed 3 (unchanged 124, purged 1, skipped binary 2, skipped large 1, failed 0) / scanned 1247 | 87 symbols | 412 edges | 4 task specs | 84 ms
+indexed 3 (unchanged 124, purged 1, skipped binary 2, skipped large 1, failed 0) / scanned 1247 | 87 symbols | 412 edges | 87 concept rows (orphans purged 0, contract rebuilt false) | 4 task specs | 84 history entries (skipped 0, truncated false) | 84 ms
 ```
 
 When to use `--force`:
@@ -944,6 +989,7 @@ or given WAL/SHM sidecars by the server. Incompatible custom schemas return
 | `mmcg_dependency_cycles` | optional `language`, `min_size` (default 2) | Detect circular imports — strongly-connected components in the file-level import graph (Tarjan's algorithm). Each result is a cycle = a list of files. Pre-merge guard ("does this PR introduce a new cycle?") and architectural-hygiene survey. Resolves edges by leaf-name match — over-approximates (two unrelated `Logger` symbols cross-link) so verify before refactoring. Bump `min_size` to hide trivial A↔B and surface only larger structural problems. Work-capped at 50,000 file-pair edges: above that, `truncated: true` with an empty `cycles` list — incomplete and possibly inaccurate, not "more available"; narrow with `language` and retry. |
 | `mmcg_symbols_changed_since` | `git_ref`, optional `root` | Symbol-level diff between a git ref and the current index. Returns `{added, removed, signature_changed}` symbol sets for files in `git diff --name-only <ref>..HEAD`. Re-parses old blobs from `git show <ref>:<path>` using the same extractor. Different from `mmcg_recent_changes` (watcher mtime) — this is git-ref-based, answering "what symbols did THIS PR/branch touch?". PR-review pre-flight, auditor verification, "what new public API appeared in v2.3?". Git subprocesses are killed after `MMCG_GIT_TIMEOUT_MS`; the per-file loop is capped at 10,000 files with `truncated: true` marking a partial diff. |
 | `mmcg_status` | — | Index path, file/symbol counts, and bounded `stale_files`. A non-zero value means the next structural query will refresh a managed index, or that a custom external index needs an explicit `mmcg index`. |
+| `mmcg_concept` | `query`, optional `top` (default 10, max 50) | Deterministic schema-v1 symbol candidates from normalized names, repository paths, and declaration shapes. Plain terms are escaped and fixed-AND joined; no raw FTS syntax, embeddings, model calls, network, source bodies, comments, literals, or defaults. BM25 score is query-local and lower-is-better, not confidence. Managed drift gets at most one refresh/retry; custom indexes remain read-only and fail closed. |
 
 Tool responses are bounded JSON. Collection responses expose their own count or
 collection metadata; status and workflow responses use named fields.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -7,7 +7,7 @@ Mastermind currently ships one server:
 
 | Server | Transport | Surface |
 |---|---|---|
-| [`mmcg`](servers/mmcg/README.md) | stdio | 29 bounded tools over a local SQLite index: 20 refreshable non-destructive queries, 8 read-only queries, and one additive scratchpad write |
+| [`mmcg`](servers/mmcg/README.md) | stdio | 30 bounded tools over a local SQLite index: 21 refreshable non-destructive queries, 8 read-only queries, and one additive scratchpad write |
 
 The server supports Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#,
 Go, Java, PHP, and C/C++. It exposes structural, semantic, evidence, history,

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -1,6 +1,6 @@
 ---
 name: mmcg
-description: Mastermind Codegraph — local multi-language code indexer for Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Stores symbols, calls, imports, evidence, and project history in SQLite and exposes 29 bounded MCP tools.
+description: Mastermind Codegraph — local multi-language code indexer for Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Stores symbols, calls, imports, evidence, and project history in SQLite and exposes 30 bounded MCP tools.
 metadata:
   version: 2.0.1
   authors:
@@ -72,6 +72,7 @@ mmcg status
 mmcg map .
 mmcg impact --since main
 mmcg brief --role executor --since main --budget-tokens 2000
+mmcg concept "payment retry handler" --top 10
 mmcg temporal --since main
 mmcg ui --since main
 ```
@@ -117,7 +118,7 @@ See the [client integration guides](https://github.com/xcrft/mastermind/tree/mai
 | Workflow gates | `verify-spec`, `audit-spec`, and `run-task` |
 | Local coordination | Bounded additive scratchpad and indexed project history |
 
-The MCP surface contains 20 non-destructive queries that may refresh the managed
+The MCP surface contains 21 non-destructive queries that may refresh the managed
 derived index, 8 read-only tools, and one additive local scratchpad write.
 Results are bounded and return precision or truncation notes when the engine
 cannot prove completeness.
@@ -128,6 +129,14 @@ The 256–8,000 token budget counts the final MCP envelope after JSON escaping
 and `content.text`/`structuredContent` duplication. Typed repository strings
 are marked untrusted; source bodies, declaration signatures, literal/default
 values, and history titles or excerpts are excluded.
+
+Use `mmcg_concept` or `mastermind concept` to retrieve at most 50 local symbol
+candidates from plain concept terms. The schema-v1 result uses fixed quoted-AND
+matching over normalized names, repository paths, and declaration shapes. It
+uses SQLite FTS5 only: no embeddings, model calls, network access, source
+bodies, comments, literals, or default values. Scores are query-local retrieval
+ranks where lower is better, not confidence. Managed indexes refresh once when
+needed; custom external indexes remain read-only and fail closed when stale.
 
 ## Supported languages
 

--- a/mcp/servers/mmcg/src/commands/query.rs
+++ b/mcp/servers/mmcg/src/commands/query.rs
@@ -539,6 +539,67 @@ pub fn render_brief(
     Ok(output)
 }
 
+fn concept_text_field(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    for character in value.chars() {
+        if character.is_alphanumeric() || matches!(character, ' ' | '-') {
+            output.push(character);
+        } else {
+            output.push_str(&format!("\\u{:06x}", character as u32));
+        }
+    }
+    output
+}
+
+pub fn render_concept(
+    response: &queries::ConceptResponse,
+    format: crate::ConceptFormat,
+) -> Result<String, serde_json::Error> {
+    if matches!(format, crate::ConceptFormat::Json) {
+        let mut output = serde_json::to_string_pretty(response)?;
+        output.push('\n');
+        return Ok(output);
+    }
+
+    let mut output = format!(
+        "mastermind concept\nquery terms: {}\ncount: {}\ntop: {}\nfreshness: {}\n\n",
+        response
+            .query_terms
+            .iter()
+            .map(|term| concept_text_field(term))
+            .collect::<Vec<_>>()
+            .join(" "),
+        response.count,
+        response.top,
+        concept_text_field(&response.freshness.status),
+    );
+    output.push_str("candidates\n");
+    for candidate in &response.candidates {
+        output.push_str(&format!(
+            "name={} kind={} language={} line={} score={}\npath={}\nsignature={}\nmatched={}\ncitation={}\n\n",
+            concept_text_field(&candidate.name),
+            concept_text_field(&candidate.kind),
+            concept_text_field(&candidate.language),
+            candidate.line,
+            candidate.score,
+            concept_text_field(&candidate.path),
+            concept_text_field(&candidate.signature_shape),
+            candidate
+                .matched_fields
+                .iter()
+                .map(|field| concept_text_field(field))
+                .collect::<Vec<_>>()
+                .join(" "),
+            concept_text_field(&candidate.citation),
+        ));
+    }
+    output.push_str("precision notes\n");
+    for note in &response.precision_notes {
+        output.push_str(&format!("{}\n", concept_text_field(note)));
+    }
+    Ok(output)
+}
+
 fn execute(store: &Store, q: QueryCmd) -> Result<Value, Box<dyn std::error::Error>> {
     let budget_ms = query_budget_ms_from_env(DEFAULT_CLI_BUDGET_MS);
     store.push_work_budget(WorkBudget::from_millis(budget_ms));
@@ -668,6 +729,63 @@ mod map_tests {
         assert!(!label.contains("%%"));
         assert!(!label.contains('['));
         assert!(!label.contains('"'));
+    }
+
+    #[test]
+    fn concept_text_renderer_has_no_markdown_html_url_or_terminal_syntax() {
+        let hostile = "](https://evil.example)<a>`file://\u{1b}\u{7}\u{202e}\r\n";
+        assert_eq!(
+            concept_text_field(hostile),
+            "\\u00005d\\u000028https\\u00003a\\u00002f\\u00002fevil\\u00002eexample\\u000029\\u00003ca\\u00003e\\u000060file\\u00003a\\u00002f\\u00002f\\u00001b\\u000007\\u00202e\\u00000d\\u00000a"
+        );
+        let response = queries::ConceptResponse {
+            schema_version: 1,
+            repository_content_untrusted: true,
+            query_terms: vec!["handler".to_string()],
+            count: 1,
+            top: 10,
+            freshness: queries::ConceptFreshness {
+                status: "fresh".to_string(),
+                extractor_contract: "extractor".to_string(),
+                normalization_contract: "normalization".to_string(),
+            },
+            limits: queries::ConceptLimits {
+                query_bytes: 256,
+                query_terms: 16,
+                term_bytes: 64,
+                top: 50,
+                signature_shape_bytes: 256,
+            },
+            precision_notes: vec!["retrieval only".to_string()],
+            candidates: vec![queries::ConceptCandidate {
+                name: hostile.to_string(),
+                kind: "function".to_string(),
+                language: "typescript".to_string(),
+                path: hostile.to_string(),
+                line: 7,
+                signature_shape: hostile.to_string(),
+                matched_fields: vec!["path".to_string()],
+                citation: format!("{hostile}:7"),
+                score: -1.0,
+            }],
+        };
+        let text = render_concept(&response, crate::ConceptFormat::Text).unwrap();
+        for forbidden in [
+            "](https://",
+            "file://",
+            "<a>",
+            "`",
+            "\u{1b}",
+            "\u{7}",
+            "\u{202e}",
+            "\r",
+            "\n\n\n",
+        ] {
+            assert!(!text.contains(forbidden), "rendered {forbidden:?}");
+        }
+        let json = render_concept(&response, crate::ConceptFormat::Json).unwrap();
+        assert!(json.contains("https://evil.example"));
+        assert!(json.contains("file://"));
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/indexer.rs
+++ b/mcp/servers/mmcg/src/indexer.rs
@@ -44,7 +44,7 @@ pub use vue::VueExtractor;
 /// Semantic contract for the extractor output stored in SQLite. Bump this when
 /// an extractor or grammar change can alter symbols, edges, ownership, or paths
 /// without requiring a database schema migration.
-pub const EXTRACTOR_CONTRACT_VERSION: &str = "mmcg-extractors-v3";
+pub const EXTRACTOR_CONTRACT_VERSION: &str = "mmcg-extractors-v4";
 pub const EXTRACTOR_CONTRACT_META_KEY: &str = "extractor_contract_version";
 
 /// Bind a persisted codegraph to the repository it was built from.
@@ -187,6 +187,12 @@ pub struct IndexStats {
     pub history_entries_truncated: bool,
     /// True when this run rebuilt an index made by an older extractor contract.
     pub extractor_contract_rebuilt: bool,
+    /// Searchable symbol concepts present after the run; content is never logged.
+    pub concept_rows_indexed: u32,
+    /// Defensive orphan cleanup count. Foreign keys normally keep this at zero.
+    pub concept_orphans_purged: u32,
+    /// True when this run rebuilt an older concept-normalization contract.
+    pub concept_contract_rebuilt: bool,
     pub duration_ms: u128,
 }
 
@@ -199,6 +205,8 @@ pub struct ProjectHistoryIndexStats {
 
 pub struct Indexer {
     root: PathBuf,
+    #[cfg(test)]
+    after_file_commit: Option<Box<dyn Fn() + Send + Sync>>,
 }
 
 struct ProjectHistorySnapshot {
@@ -238,7 +246,17 @@ impl IndexLimits {
 
 impl Indexer {
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        Self {
+            root: root.into(),
+            #[cfg(test)]
+            after_file_commit: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_after_file_commit(mut self, callback: impl Fn() + Send + Sync + 'static) -> Self {
+        self.after_file_commit = Some(Box::new(callback));
+        self
     }
 
     fn bind_or_validate_index_root(&self, store: &Store) -> Result<(), IndexError> {
@@ -303,17 +321,33 @@ impl Indexer {
         let start = SystemTime::now();
         ensure_indexing_active(store)?;
         self.bind_or_validate_index_root(store)?;
+        store
+            .ensure_concept_schema()
+            .map_err(|error| IndexError::Other(error.to_string()))?;
         let stored_extractor_contract = store
             .meta_value(EXTRACTOR_CONTRACT_META_KEY)
             .map_err(|error| IndexError::Other(error.to_string()))?;
         let extractor_contract_current =
             stored_extractor_contract.as_deref() == Some(EXTRACTOR_CONTRACT_VERSION);
-        let extractor_contract_rebuild_required = !extractor_contract_current
-            && store
-                .file_count()
-                .map_err(|error| IndexError::Other(error.to_string()))?
-                > 0;
-        let force_full = force_full || !extractor_contract_current;
+        let concept_contract_current = store
+            .concept_contract_current()
+            .map_err(|error| IndexError::Other(error.to_string()))?;
+        let indexed_file_count = store
+            .file_count()
+            .map_err(|error| IndexError::Other(error.to_string()))?;
+        let extractor_contract_rebuild_required =
+            !extractor_contract_current && indexed_file_count > 0;
+        let concept_contract_rebuild_required = !concept_contract_current && indexed_file_count > 0;
+        let force_full = force_full || !extractor_contract_current || !concept_contract_current;
+        let contracts_need_finalization = force_full;
+        if force_full {
+            // A full rebuild can replace graph rows incrementally. Persist the
+            // derived-corpus dirty marker before the first replacement so an
+            // interruption can never leave a partial corpus stamped current.
+            store
+                .mark_concept_contract_dirty()
+                .map_err(|error| IndexError::Other(error.to_string()))?;
+        }
         let root_capability = if limits == IndexLimits::MANUAL {
             None
         } else {
@@ -486,7 +520,13 @@ impl Indexer {
                             *stats.by_language.entry(lang.to_string()).or_insert(0) += 1;
                         }
                         match store.commit_file(pending) {
-                            Ok(()) => stats.files_indexed += 1,
+                            Ok(()) => {
+                                stats.files_indexed += 1;
+                                #[cfg(test)]
+                                if let Some(callback) = &self.after_file_commit {
+                                    callback();
+                                }
+                            }
                             Err(_) => stats.files_failed += 1,
                         }
                     }
@@ -508,12 +548,16 @@ impl Indexer {
         // Phase 5: purge orphans (in index, no longer on disk). Safe only after a
         // FULL root scan — a partial scan would wrongly purge the unscanned subtree.
         ensure_indexing_active(store)?;
-        if let Ok(indexed) = store.indexed_paths() {
-            for path in indexed {
-                ensure_indexing_active(store)?;
-                if !current_paths.contains(&path) && store.purge_file(&path).is_ok() {
-                    stats.files_purged += 1;
-                }
+        let indexed = store
+            .indexed_paths()
+            .map_err(|error| IndexError::Other(error.to_string()))?;
+        for path in indexed {
+            ensure_indexing_active(store)?;
+            if !current_paths.contains(&path) {
+                store
+                    .purge_file(&path)
+                    .map_err(|error| IndexError::Other(error.to_string()))?;
+                stats.files_purged += 1;
             }
         }
 
@@ -532,13 +576,22 @@ impl Indexer {
         stats.history_entries_indexed = history.indexed;
         stats.history_entries_skipped = history.skipped;
         stats.history_entries_truncated = history.truncated;
-
-        if stats.files_failed == 0 {
+        if stats.files_failed == 0 && contracts_need_finalization {
             ensure_indexing_active(store)?;
-            store
-                .set_meta(EXTRACTOR_CONTRACT_META_KEY, EXTRACTOR_CONTRACT_VERSION)
+            let finalized = store
+                .finalize_index_contracts_current()
                 .map_err(|error| IndexError::Other(error.to_string()))?;
+            stats.concept_orphans_purged = finalized.orphans_purged;
+            stats.concept_rows_indexed = finalized.rows;
             stats.extractor_contract_rebuilt = extractor_contract_rebuild_required;
+            stats.concept_contract_rebuilt = concept_contract_rebuild_required;
+        } else {
+            stats.concept_orphans_purged = store
+                .purge_orphan_concepts()
+                .map_err(|error| IndexError::Other(error.to_string()))?;
+            stats.concept_rows_indexed = store
+                .concept_count()
+                .map_err(|error| IndexError::Other(error.to_string()))?;
         }
 
         stats.duration_ms = start.elapsed().map(|d| d.as_millis()).unwrap_or(0);
@@ -1363,7 +1416,7 @@ fn extract_spec_title(body: &str, filename: &str) -> String {
     filename.trim_end_matches(".md").to_string()
 }
 
-fn guess_language_for(rel_path: &str) -> Option<&'static str> {
+pub(crate) fn guess_language_for(rel_path: &str) -> Option<&'static str> {
     let extension = Path::new(rel_path)
         .extension()
         .and_then(|extension| extension.to_str())?
@@ -1609,7 +1662,11 @@ pub enum IndexError {
 
 fn ensure_indexing_active(store: &Store) -> Result<(), IndexError> {
     if store.work_interrupted() {
-        Err(IndexError::Other("indexing interrupted".to_string()))
+        Err(match store.interrupt_source() {
+            Some(crate::store::InterruptSource::Cancel) => IndexError::Cancelled,
+            Some(crate::store::InterruptSource::Budget) => IndexError::DeadlineExceeded,
+            None => IndexError::Other("indexing interrupted".to_string()),
+        })
     } else {
         Ok(())
     }
@@ -1713,7 +1770,7 @@ mod incremental_tests {
 
         store.cancel_handle().cancel();
         let error = indexer.index_all(&mut store, false).unwrap_err();
-        assert!(error.to_string().contains("indexing interrupted"));
+        assert!(matches!(error, IndexError::Cancelled));
         assert_eq!(
             store.take_interrupt_source(),
             Some(crate::store::InterruptSource::Cancel)
@@ -1735,6 +1792,49 @@ mod incremental_tests {
         let forced = indexer.index_all(&mut store, true).unwrap();
         assert_eq!(forced.files_indexed, 1, "force should re-parse");
         assert_eq!(forced.files_unchanged, 0);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn cancelled_forced_rebuild_leaves_concept_contract_dirty() {
+        let (dir, db) = setup("cancel_forced_concept_rebuild");
+        fs::write(dir.join("a.py"), "def alpha_handler(): pass\n").unwrap();
+        fs::write(dir.join("b.py"), "def beta_handler(): pass\n").unwrap();
+
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(&dir).index_all(&mut store, false).unwrap();
+        assert!(store.concept_contract_current().unwrap());
+        drop(store);
+
+        let connection = rusqlite::Connection::open(&db).unwrap();
+        connection
+            .execute(
+                "UPDATE symbol_concepts SET name_search = 'corrupted'
+                 WHERE symbol_id = (SELECT MIN(symbol_id) FROM symbol_concepts)",
+                [],
+            )
+            .unwrap();
+        drop(connection);
+
+        let mut store = Store::open(&db).unwrap();
+        assert!(store.concept_contract_current().unwrap());
+        let cancel = store.cancel_handle();
+        let indexer = Indexer::new(&dir).with_after_file_commit(move || cancel.cancel());
+        let error = indexer.index_all(&mut store, true).unwrap_err();
+        assert!(matches!(error, IndexError::Cancelled));
+        assert_eq!(
+            store.take_interrupt_source(),
+            Some(crate::store::InterruptSource::Cancel)
+        );
+        assert!(!store.concept_contract_current().unwrap());
+        drop(store);
+
+        let mut custom = Store::open_for_serve(&db, None).unwrap();
+        assert_eq!(
+            crate::mcp::build_concept_current(&mut custom, "handler", 10),
+            Err(crate::queries::ConceptError::IndexStale)
+        );
 
         fs::remove_dir_all(&dir).ok();
     }
@@ -2086,6 +2186,113 @@ mod incremental_tests {
         assert_eq!(stats.files_unchanged, 0);
         assert!(stats.extractor_contract_rebuilt);
         assert!(store.extractor_contract_current().unwrap());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn frozen_v3_partial_and_successful_writes_cannot_leave_concepts_falsely_current() {
+        for old_run_completed in [false, true] {
+            let suffix = if old_run_completed {
+                "complete"
+            } else {
+                "cancelled"
+            };
+            let (dir, db) = setup(&format!("concept_old_writer_{suffix}"));
+            fs::write(dir.join("app.py"), "def current_handler(): pass\n").unwrap();
+            let mut store = Store::open(&db).unwrap();
+            let indexer = Indexer::new(&dir);
+            indexer.index_all(&mut store, false).unwrap();
+            assert!(store.concept_contract_current().unwrap());
+            drop(store);
+
+            // Frozen schema-v7/v3 behavior: replace one file's graph rows but
+            // do not know about symbol_concepts. A cancelled run leaves the
+            // future extractor marker untouched; a successful old run stamps
+            // v3. Persistent schema-v7 triggers must dirty concepts in both.
+            let connection = rusqlite::Connection::open(&db).unwrap();
+            connection
+                .execute_batch("PRAGMA foreign_keys = ON; BEGIN")
+                .unwrap();
+            connection
+                .execute("DELETE FROM symbols WHERE file_path = 'app.py'", [])
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO symbols(name, kind, file_path, line_start, line_end)
+                     VALUES ('legacy_secret', 'function', 'app.py', 1, 1)",
+                    [],
+                )
+                .unwrap();
+            if old_run_completed {
+                connection
+                    .execute(
+                        "INSERT INTO meta(key, value) VALUES (?1, 'mmcg-extractors-v3')
+                         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                        [EXTRACTOR_CONTRACT_META_KEY],
+                    )
+                    .unwrap();
+            }
+            connection.execute_batch("COMMIT").unwrap();
+            drop(connection);
+
+            let mut store = Store::open(&db).unwrap();
+            assert!(!store.concept_contract_current().unwrap());
+            assert_eq!(
+                store.extractor_contract_current().unwrap(),
+                !old_run_completed
+            );
+            let stats = indexer.index_all(&mut store, false).unwrap();
+            assert!(stats.concept_contract_rebuilt);
+            assert_eq!(stats.extractor_contract_rebuilt, old_run_completed);
+            assert!(store.concept_contract_current().unwrap());
+            assert!(store.extractor_contract_current().unwrap());
+            assert_eq!(
+                store.concept_count().unwrap(),
+                store.symbol_count().unwrap()
+            );
+            assert!(store.search_concepts("\"legacy\"", 10).unwrap().is_empty());
+            assert!(!store.search_concepts("\"current\"", 10).unwrap().is_empty());
+
+            fs::remove_dir_all(&dir).ok();
+        }
+    }
+
+    #[test]
+    fn deleted_path_purge_failure_is_fatal_and_cannot_stamp_concepts_current() {
+        let (dir, db) = setup("concept_purge_failure");
+        fs::write(dir.join("keep.py"), "def keep(): pass\n").unwrap();
+        fs::write(dir.join("deleted.py"), "def stale_secret(): pass\n").unwrap();
+        let mut store = Store::open(&db).unwrap();
+        let indexer = Indexer::new(&dir);
+        indexer.index_all(&mut store, false).unwrap();
+        drop(store);
+
+        let connection = rusqlite::Connection::open(&db).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TRIGGER fail_deleted_file_purge
+                 BEFORE DELETE ON files
+                 WHEN old.path = 'deleted.py' BEGIN
+                     INSERT INTO missing_concept_purge_sink(value)
+                     VALUES (old.path);
+                 END;",
+            )
+            .unwrap();
+        drop(connection);
+        fs::remove_file(dir.join("deleted.py")).unwrap();
+
+        let mut store = Store::open(&db).unwrap();
+        assert!(store.concept_schema_objects_current().unwrap());
+        assert!(store.concept_contract_current().unwrap());
+        let error = indexer.index_all(&mut store, false).unwrap_err();
+        assert!(error.to_string().contains("missing_concept_purge_sink"));
+        assert!(!store.concept_contract_current().unwrap());
+        assert!(store
+            .indexed_paths()
+            .unwrap()
+            .contains(&"deleted.py".to_string()));
+        assert!(!store.search_concepts("\"stale\"", 10).unwrap().is_empty());
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -50,6 +50,13 @@ pub enum BriefFormat {
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
 #[clap(rename_all = "kebab-case")]
+pub enum ConceptFormat {
+    Text,
+    Json,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
 pub enum BriefRoleArg {
     Planner,
     Executor,
@@ -234,6 +241,14 @@ enum Cmd {
         format: BriefFormat,
         #[arg(long, default_value = ".")]
         root: PathBuf,
+    },
+    /// Retrieve bounded local symbol candidates by plain concept terms.
+    Concept {
+        query: String,
+        #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u32).range(1..=50))]
+        top: u32,
+        #[arg(long, value_enum, default_value_t = ConceptFormat::Text)]
+        format: ConceptFormat,
     },
     /// Compare bounded architecture snapshots between a Git baseline and the indexed worktree.
     Temporal {
@@ -1130,7 +1145,7 @@ fn run_cli_inner(
             let indexer = mmcg::indexer::Indexer::new(&root);
             let stats = indexer.index_all(&mut store, force)?;
             println!(
-                "indexed {} (unchanged {}, purged {}, skipped binary {}, skipped large {}, failed {}) / scanned {} | {} symbols | {} edges | {} task specs | {} history entries (skipped {}, truncated {}) | {} ms",
+                "indexed {} (unchanged {}, purged {}, skipped binary {}, skipped large {}, failed {}) / scanned {} | {} symbols | {} edges | {} concept rows (orphans purged {}, contract rebuilt {}) | {} task specs | {} history entries (skipped {}, truncated {}) | {} ms",
                 stats.files_indexed,
                 stats.files_unchanged,
                 stats.files_purged,
@@ -1140,6 +1155,9 @@ fn run_cli_inner(
                 stats.files_scanned,
                 stats.symbols_total,
                 stats.edges_total,
+                stats.concept_rows_indexed,
+                stats.concept_orphans_purged,
+                stats.concept_contract_rebuilt,
                 stats.task_specs_indexed,
                 stats.history_entries_indexed,
                 stats.history_entries_skipped,
@@ -1383,6 +1401,31 @@ fn run_cli_inner(
                 Err(error) => return Err(error.into()),
             };
             print!("{}", commands::query::render_brief(&response, format)?);
+        }
+        Cmd::Concept { query, top, format } => {
+            mmcg::queries::validate_concept_request(&query, top)?;
+            let managed_root = if index_override.is_none() {
+                Some(std::env::current_dir()?.canonicalize()?)
+            } else {
+                None
+            };
+            let mut store = Store::open_for_serve(&index_path, managed_root.as_deref())?;
+            store.set_default_work_budget_ms(mmcg::store::query_budget_ms_from_env(
+                mmcg::store::DEFAULT_CLI_BUDGET_MS,
+            ));
+            let budget = store.default_work_budget();
+            let expired = store.push_work_budget(budget);
+            let response = if expired {
+                Err(mmcg::queries::ConceptError::WorkLimitExceeded)
+            } else {
+                mmcg::mcp::build_concept_current(&mut store, &query, top)
+            };
+            let interrupted = store.take_interrupt_source();
+            store.pop_work_budget();
+            if interrupted.is_some() {
+                return Err(mmcg::queries::ConceptError::WorkLimitExceeded.into());
+            }
+            print!("{}", commands::query::render_concept(&response?, format)?);
         }
         Cmd::Temporal {
             since,
@@ -2366,6 +2409,56 @@ mod tests {
             "main",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn concept_is_a_first_class_strict_cli_command() {
+        let concept = Cli::try_parse_from([
+            "mastermind",
+            "concept",
+            "request handler",
+            "--top",
+            "7",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            concept.cmd,
+            Cmd::Concept {
+                query,
+                top: 7,
+                format: ConceptFormat::Json,
+            } if query == "request handler"
+        ));
+        for top in ["0", "51", "1.0", "true"] {
+            assert!(
+                Cli::try_parse_from(["mastermind", "concept", "handler", "--top", top,]).is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_concept_cli_request_does_not_open_or_create_an_index() {
+        let directory = tempfile::tempdir().unwrap();
+        let index = directory.path().join("missing.db");
+        let cli = Cli::try_parse_from([
+            "mastermind",
+            "--index",
+            index.to_str().unwrap(),
+            "concept",
+            "",
+        ])
+        .unwrap();
+
+        let error = run_cli(cli).unwrap_err();
+        assert_eq!(
+            error
+                .downcast_ref::<mmcg::queries::ConceptError>()
+                .map(mmcg::queries::ConceptError::code),
+            Some("invalid_arguments")
+        );
+        assert!(!index.exists());
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/mcp.rs
+++ b/mcp/servers/mmcg/src/mcp.rs
@@ -286,6 +286,7 @@ static TOOLS: &[ToolDef] = &[
         schema_change_class,
         handle_change_class,
     ),
+    refreshable_tool("mmcg_concept", schema_concept, handle_concept),
 ];
 
 pub(crate) fn is_known_tool(name: &str) -> bool {
@@ -1241,7 +1242,9 @@ fn handle_tools_call_inner(
     // A validated stale call gets one refresh outside the narrow query budget,
     // then one retry. The request watchdog and client cancellation still bound
     // both indexing and the retried query.
-    let stale_index = if store.interrupt_source().is_none() && tool_requires_fresh_index(tool_name)
+    let stale_index = if store.interrupt_source().is_none()
+        && tool_requires_fresh_index(tool_name)
+        && tool_name != "mmcg_concept"
     {
         match handled.as_ref() {
             Some(Err(HandlerError::IndexStale {
@@ -2060,6 +2063,32 @@ fn schema_brief() -> Value {
     })
 }
 
+fn schema_concept() -> Value {
+    json!({
+        "name": "mmcg_concept",
+        "description": "Deterministic local concept retrieval over bounded normalized symbol names, repository paths, and declaration shapes. Uses SQLite FTS5 only: no embeddings, model calls, network access, source bodies, comments, literals, or defaults. Results are retrieval candidates, not confidence-ranked answers.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256,
+                    "description": "Plain text only. Terms are normalized, quoted, and joined with fixed AND semantics; raw FTS syntax is never accepted."
+                },
+                "top": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 10
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        }
+    })
+}
+
 fn schema_test_impact() -> Value {
     impact_input_schema(
         "mmcg_test_impact",
@@ -2716,6 +2745,83 @@ pub fn build_brief_current(
     brief_current_attempt(store, &root, since, role, budget_tokens)
 }
 
+fn concept_current_attempt(
+    store: &Store,
+    query: &str,
+    top: u32,
+) -> Result<queries::ConceptResponse, queries::ConceptError> {
+    let expected_data_version = store
+        .data_version()
+        .map_err(|_| queries::ConceptError::SnapshotChanged)?;
+    match store.schema_current() {
+        Ok(true) => {}
+        Ok(false) => return Err(queries::ConceptError::SchemaIncompatible),
+        Err(_) => return Err(queries::ConceptError::IndexStale),
+    }
+    let status = safe_index_status(store).map_err(|error| match error {
+        HandlerError::SnapshotChanged => queries::ConceptError::SnapshotChanged,
+        HandlerError::WorkLimitExceeded | HandlerError::RefreshLimit { .. } => {
+            queries::ConceptError::WorkLimitExceeded
+        }
+        _ => queries::ConceptError::IndexStale,
+    })?;
+    if status.stale_files > 0 || !status.extractor_contract_current {
+        return Err(queries::ConceptError::IndexStale);
+    }
+    if !store
+        .concept_contract_current()
+        .map_err(|_| queries::ConceptError::IndexStale)?
+    {
+        return Err(queries::ConceptError::IndexStale);
+    }
+    queries::concept_verified(
+        store,
+        query,
+        top,
+        expected_data_version,
+        queries::ConceptFreshness {
+            status: "fresh".to_string(),
+            extractor_contract: crate::indexer::EXTRACTOR_CONTRACT_VERSION.to_string(),
+            normalization_contract: crate::store::CONCEPT_NORMALIZATION_VERSION.to_string(),
+        },
+    )
+}
+
+/// Build concept candidates through the same structural/concept freshness and
+/// one-refresh/one-retry boundary for both MCP and the standalone CLI.
+pub fn build_concept_current(
+    store: &mut Store,
+    query: &str,
+    top: u32,
+) -> Result<queries::ConceptResponse, queries::ConceptError> {
+    queries::validate_concept_request(query, top)?;
+    match concept_current_attempt(store, query, top) {
+        Err(queries::ConceptError::IndexStale) => {}
+        result => return result,
+    }
+    let status = safe_index_status(store).map_err(|error| match error {
+        HandlerError::SnapshotChanged => queries::ConceptError::SnapshotChanged,
+        HandlerError::WorkLimitExceeded | HandlerError::RefreshLimit { .. } => {
+            queries::ConceptError::WorkLimitExceeded
+        }
+        _ => queries::ConceptError::IndexStale,
+    })?;
+    refresh_stale_index(store, status.stale_files, status.extractor_contract_current).map_err(
+        |error| match error {
+            HandlerError::SchemaIncompatible => queries::ConceptError::SchemaIncompatible,
+            HandlerError::SnapshotChanged => queries::ConceptError::SnapshotChanged,
+            HandlerError::WorkLimitExceeded | HandlerError::RefreshLimit { .. } => {
+                queries::ConceptError::WorkLimitExceeded
+            }
+            HandlerError::Internal { .. } if store.interrupt_source().is_some() => {
+                queries::ConceptError::WorkLimitExceeded
+            }
+            _ => queries::ConceptError::IndexStale,
+        },
+    )?;
+    concept_current_attempt(store, query, top)
+}
+
 fn map_brief_error(store: &Store, error: queries::BriefError) -> HandlerError {
     match error {
         queries::BriefError::InvalidArguments => HandlerError::StructuredInvalid {
@@ -2837,6 +2943,62 @@ fn handle_brief_for_version(
 
 fn handle_brief(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
     handle_brief_for_version(store, args, ProtocolVersion::Current)
+}
+
+fn map_concept_error(store: &Store, error: queries::ConceptError) -> HandlerError {
+    match error {
+        queries::ConceptError::InvalidArguments => HandlerError::StructuredInvalid {
+            code: "invalid_arguments",
+        },
+        queries::ConceptError::IndexStale => {
+            let status = safe_index_status(store).unwrap_or(queries::StatusResponse {
+                db_path: store.db_path().to_string_lossy().to_string(),
+                symbol_count: 0,
+                file_count: 0,
+                stale_files: 1,
+                extractor_contract_current: true,
+            });
+            let concept_current = store.concept_contract_current().unwrap_or(false);
+            index_stale_error(
+                if concept_current {
+                    status.stale_files
+                } else {
+                    status.stale_files.max(1)
+                },
+                status.extractor_contract_current,
+                store.managed_root().is_some(),
+            )
+        }
+        queries::ConceptError::SchemaIncompatible => HandlerError::SchemaIncompatible,
+        queries::ConceptError::SnapshotChanged => HandlerError::SnapshotChanged,
+        queries::ConceptError::WorkLimitExceeded => HandlerError::WorkLimitExceeded,
+        queries::ConceptError::Internal => HandlerError::Internal {
+            class: "concept_query",
+        },
+    }
+}
+
+fn handle_concept(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
+    let query =
+        args.get("query")
+            .and_then(Value::as_str)
+            .ok_or(HandlerError::StructuredInvalid {
+                code: "invalid_arguments",
+            })?;
+    let top = match args.get("top") {
+        None => queries::CONCEPT_DEFAULT_TOP,
+        Some(value) => value
+            .as_u64()
+            .and_then(|value| u32::try_from(value).ok())
+            .filter(|value| (1..=queries::CONCEPT_MAX_TOP).contains(value))
+            .ok_or(HandlerError::StructuredInvalid {
+                code: "invalid_arguments",
+            })?,
+    };
+    let response = build_concept_current(store, query, top)
+        .map_err(|error| map_concept_error(store, error))?;
+    serde_json::to_value(response)
+        .map_err(|error| HandlerError::internal("serialize_concept", error))
 }
 
 fn handle_change_impact(store: &mut Store, args: &Value) -> Result<Value, HandlerError> {
@@ -3519,7 +3681,7 @@ mod tests {
     #[test]
     fn tool_annotations_match_behavior_table() {
         let legacy = tools_list(ProtocolVersion::Legacy);
-        assert_eq!(legacy["tools"].as_array().unwrap().len(), 29);
+        assert_eq!(legacy["tools"].as_array().unwrap().len(), 30);
         assert!(legacy["tools"]
             .as_array()
             .unwrap()
@@ -3528,7 +3690,7 @@ mod tests {
 
         let current = tools_list(ProtocolVersion::Current);
         let tools = current["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 29);
+        assert_eq!(tools.len(), 30);
         let mut readers = 0;
         let mut refreshers = 0;
         for tool in tools {
@@ -3559,7 +3721,7 @@ mod tests {
             }
         }
         assert_eq!(readers, 8);
-        assert_eq!(refreshers, 20);
+        assert_eq!(refreshers, 21);
     }
 
     #[test]
@@ -3795,6 +3957,315 @@ mod tests {
             .index_all(&mut store, true)
             .unwrap();
         (root, store)
+    }
+
+    #[test]
+    fn concept_cli_builder_and_mcp_share_one_fresh_payload() {
+        let (root, mut store) = impact_fixture("concept-shared");
+        std::fs::write(
+            root.join("src/app.py"),
+            "def value(secret: str = 'TOPSECRET', required: ImportantType = None):\n    return required\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("src/template.js"),
+            r#"export function templateCanary(pattern = `${typeof /[}]`PREFIX,TOPSECRET/}`, required = null) {}
+"#,
+        )
+        .unwrap();
+        crate::indexer::Indexer::new(&root)
+            .index_all(&mut store, true)
+            .unwrap();
+        let expected =
+            serde_json::to_value(build_concept_current(&mut store, "value", 10).unwrap()).unwrap();
+        assert!(!expected.to_string().to_lowercase().contains("topsecret"));
+        assert!(store
+            .search_concepts("\"topsecret\"", 10)
+            .unwrap()
+            .is_empty());
+        let actual = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({ "name": "mmcg_concept", "arguments": { "query": "value", "top": 10 } }),
+        )
+        .unwrap();
+        assert_eq!(actual["isError"], false);
+        assert_eq!(unwrap_content(&actual), expected);
+        assert_eq!(actual["structuredContent"], expected);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn concept_managed_source_staleness_refreshes_once_before_claiming_fresh() {
+        let (root, mut store) = impact_fixture("concept-refresh");
+        std::fs::write(
+            root.join("src/app.py"),
+            "def refreshed_concept_handler():\n    return 3\n",
+        )
+        .unwrap();
+
+        let actual = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({
+                "name": "mmcg_concept",
+                "arguments": { "query": "refreshed concept", "top": 10 }
+            }),
+        )
+        .unwrap();
+        let payload = unwrap_content(&actual);
+        assert_eq!(actual["isError"], false);
+        assert_eq!(payload["freshness"]["status"], "fresh");
+        assert_eq!(
+            payload["freshness"]["extractor_contract"],
+            crate::indexer::EXTRACTOR_CONTRACT_VERSION
+        );
+        assert!(payload["candidates"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty()));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn concept_shadow_table_drift_repairs_managed_indexes_and_blocks_custom_indexes() {
+        let (root, store) = impact_fixture("concept-shadow-drift");
+        let db = store.db_path().to_path_buf();
+        drop(store);
+
+        for shadow in ["config", "data", "docsize", "idx"] {
+            let connection = rusqlite::Connection::open(&db).unwrap();
+            connection
+                .execute_batch(&format!("DROP TABLE symbol_concepts_fts_{shadow}"))
+                .unwrap();
+            drop(connection);
+
+            let mut managed = crate::store::Store::open_for_serve(&db, Some(&root)).unwrap();
+            assert!(managed.concept_schema_objects_current().unwrap());
+            assert!(!managed.concept_contract_current().unwrap());
+            let result = handle_tools_call(
+                ProtocolVersion::Current,
+                &mut managed,
+                &json!({ "name": "mmcg_concept", "arguments": { "query": "value" } }),
+            )
+            .unwrap();
+            assert_eq!(result["isError"], false, "shadow table {shadow}");
+            assert!(managed.concept_contract_current().unwrap());
+            drop(managed);
+        }
+
+        let connection = rusqlite::Connection::open(&db).unwrap();
+        connection
+            .execute_batch("DROP TABLE symbol_concepts_fts_data")
+            .unwrap();
+        drop(connection);
+        let before = std::fs::read(&db).unwrap();
+        let mut custom = crate::store::Store::open_for_serve(&db, None).unwrap();
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut custom,
+            &json!({ "name": "mmcg_concept", "arguments": { "query": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(result["isError"], true);
+        assert_eq!(unwrap_content(&result)["code"], "index_stale");
+        assert_eq!(std::fs::read(&db).unwrap(), before);
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn concept_orphan_shadow_tables_repair_only_for_managed_indexes() {
+        let (root, store) = impact_fixture("concept-orphan-shadows");
+        let db = store.db_path().to_path_buf();
+        drop(store);
+        let remove_virtual_table_record = || {
+            let connection = rusqlite::Connection::open(&db).unwrap();
+            connection
+                .execute_batch(
+                    "PRAGMA writable_schema = ON;
+                     DELETE FROM sqlite_master
+                     WHERE type = 'table' AND name = 'symbol_concepts_fts';
+                     PRAGMA writable_schema = OFF;
+                     PRAGMA schema_version = 99;",
+                )
+                .unwrap();
+        };
+
+        remove_virtual_table_record();
+        let mut managed = crate::store::Store::open_for_serve(&db, Some(&root)).unwrap();
+        assert!(managed.concept_schema_objects_current().unwrap());
+        assert!(!managed.concept_contract_current().unwrap());
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut managed,
+            &json!({ "name": "mmcg_concept", "arguments": { "query": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(result["isError"], false);
+        assert!(managed.concept_contract_current().unwrap());
+        drop(managed);
+
+        remove_virtual_table_record();
+        let source_paths = [
+            db.clone(),
+            db.with_extension("db-wal"),
+            db.with_extension("db-shm"),
+        ];
+        let before = source_paths
+            .iter()
+            .map(|path| std::fs::read(path).ok())
+            .collect::<Vec<_>>();
+        let mut custom = crate::store::Store::open_for_serve(&db, None).unwrap();
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut custom,
+            &json!({ "name": "mmcg_concept", "arguments": { "query": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(result["isError"], true);
+        assert_eq!(unwrap_content(&result)["code"], "index_stale");
+        let after = source_paths
+            .iter()
+            .map(|path| std::fs::read(path).ok())
+            .collect::<Vec<_>>();
+        assert_eq!(after, before);
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn concept_malformed_shadow_view_repairs_only_for_managed_indexes() {
+        let (root, store) = impact_fixture("concept-shadow-view");
+        let db = store.db_path().to_path_buf();
+        drop(store);
+        let replace_shadow_with_view = || {
+            let connection = rusqlite::Connection::open(&db).unwrap();
+            connection
+                .execute_batch(
+                    "DROP TABLE symbol_concepts_fts_data;
+                     CREATE VIEW symbol_concepts_fts_data
+                     AS SELECT 1 AS id, x'' AS block;",
+                )
+                .unwrap();
+        };
+
+        replace_shadow_with_view();
+        let mut managed = crate::store::Store::open_for_serve(&db, Some(&root)).unwrap();
+        assert!(managed.concept_schema_objects_current().unwrap());
+        assert!(!managed.concept_contract_current().unwrap());
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut managed,
+            &json!({ "name": "mmcg_concept", "arguments": { "query": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(result["isError"], false);
+        assert!(managed.concept_contract_current().unwrap());
+        drop(managed);
+
+        replace_shadow_with_view();
+        let source_paths = [
+            db.clone(),
+            db.with_extension("db-wal"),
+            db.with_extension("db-shm"),
+        ];
+        let before = source_paths
+            .iter()
+            .map(|path| std::fs::read(path).ok())
+            .collect::<Vec<_>>();
+        let mut custom = crate::store::Store::open_for_serve(&db, None).unwrap();
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut custom,
+            &json!({ "name": "mmcg_concept", "arguments": { "query": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(result["isError"], true);
+        assert_eq!(unwrap_content(&result)["code"], "index_stale");
+        let after = source_paths
+            .iter()
+            .map(|path| std::fs::read(path).ok())
+            .collect::<Vec<_>>();
+        assert_eq!(after, before);
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn concept_invalid_arguments_do_not_trigger_managed_refresh() {
+        let (root, mut store) = impact_fixture("concept-invalid-before-refresh");
+        std::fs::write(
+            root.join("src/unindexed.py"),
+            "def should_not_be_indexed():\n    return 1\n",
+        )
+        .unwrap();
+
+        let actual = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({
+                "name": "mmcg_concept",
+                "arguments": { "query": "bad\u{0}query", "top": 10 }
+            }),
+        )
+        .unwrap();
+        assert_eq!(actual["isError"], true);
+        assert_eq!(unwrap_content(&actual)["code"], "invalid_arguments");
+        assert!(
+            queries::search(&store, "should_not_be_indexed", None, None, true)
+                .unwrap()
+                .results
+                .is_empty()
+        );
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn missing_custom_concept_corpus_does_not_block_existing_structural_tools() {
+        let (root, store) = impact_fixture("concept-custom-optional");
+        let db = store.db_path().to_path_buf();
+        drop(store);
+        let connection = rusqlite::Connection::open(&db).unwrap();
+        connection
+            .execute_batch(
+                "DROP TRIGGER IF EXISTS symbol_concepts_graph_ai;
+                 DROP TRIGGER IF EXISTS symbol_concepts_graph_ad;
+                 DROP TRIGGER IF EXISTS symbol_concepts_graph_au;
+                 DROP TRIGGER IF EXISTS symbol_concepts_ai;
+                 DROP TRIGGER IF EXISTS symbol_concepts_ad;
+                 DROP TRIGGER IF EXISTS symbol_concepts_au;
+                 DROP TABLE IF EXISTS symbol_concepts_fts;
+                 DROP TABLE IF EXISTS symbol_concepts;
+                 INSERT INTO meta(key, value)
+                 VALUES ('concept_normalization_version', 'dirty')
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value;",
+            )
+            .unwrap();
+        drop(connection);
+        let before = std::fs::read(&db).unwrap();
+        let mut custom = crate::store::Store::open_for_serve(&db, None).unwrap();
+
+        let structural = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut custom,
+            &json!({ "name": "mmcg_search", "arguments": { "name": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(structural["isError"], false);
+        let concept = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut custom,
+            &json!({ "name": "mmcg_concept", "arguments": { "query": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(concept["isError"], true);
+        let payload = unwrap_content(&concept);
+        assert_eq!(payload["code"], "index_stale");
+        assert_eq!(payload["refresh_attempted"], false);
+        assert_eq!(std::fs::read(&db).unwrap(), before);
+        assert!(!db.with_extension("db-wal").exists());
+        assert!(!db.with_extension("db-shm").exists());
+        std::fs::remove_dir_all(root).ok();
     }
 
     #[test]
@@ -4528,7 +4999,7 @@ mod tests {
     #[test]
     fn tools_list_covers_every_handler() {
         let listed: Vec<&str> = TOOLS.iter().map(|t| t.name).collect();
-        assert_eq!(listed.len(), 29, "expected 29 tools, got {}", listed.len());
+        assert_eq!(listed.len(), 30, "expected 30 tools, got {}", listed.len());
         for name in &listed {
             assert!(
                 TOOLS.iter().any(|t| &t.name == name),
@@ -4816,9 +5287,17 @@ mod tests {
                     "root": root.to_string_lossy(),
                     "budget_tokens": 2000
                 }),
+                "mmcg_concept" => json!({ "query": "value" }),
                 name => panic!("missing valid-argument fixture for structural tool {name}"),
             };
-            let error = (tool.handler)(&mut store, &arguments).unwrap_err();
+            let result = (tool.handler)(&mut store, &arguments);
+            if tool.name == "mmcg_concept" {
+                let response = result.expect("concept owns its one managed refresh");
+                assert_eq!(response["freshness"]["status"], "fresh");
+                assert!(store.file_mtime("src/unindexed.py").unwrap().is_some());
+                continue;
+            }
+            let error = result.unwrap_err();
             assert!(
                 matches!(error, HandlerError::IndexStale { .. }),
                 "{} queried without enforcing freshness: {error:?}",

--- a/mcp/servers/mmcg/src/queries.rs
+++ b/mcp/servers/mmcg/src/queries.rs
@@ -801,6 +801,206 @@ const BRIEF_HISTORY_LIMIT: usize = 10;
 const BRIEF_HISTORY_TERM_LIMIT: usize = 8;
 const BRIEF_REPOSITORY_STRING_BYTES: usize = 512;
 
+pub const CONCEPT_DEFAULT_TOP: u32 = 10;
+pub const CONCEPT_MAX_TOP: u32 = 50;
+pub const CONCEPT_QUERY_MAX_BYTES: usize = 256;
+pub const CONCEPT_QUERY_TERM_LIMIT: usize = 16;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConceptError {
+    InvalidArguments,
+    IndexStale,
+    SchemaIncompatible,
+    SnapshotChanged,
+    WorkLimitExceeded,
+    Internal,
+}
+
+impl ConceptError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidArguments => "invalid_arguments",
+            Self::IndexStale => "index_stale",
+            Self::SchemaIncompatible => "schema_incompatible",
+            Self::SnapshotChanged => "snapshot_changed",
+            Self::WorkLimitExceeded => "work_limit_exceeded",
+            Self::Internal => "internal_error",
+        }
+    }
+}
+
+impl std::fmt::Display for ConceptError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for ConceptError {}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ConceptResponse {
+    pub schema_version: u32,
+    pub repository_content_untrusted: bool,
+    pub query_terms: Vec<String>,
+    pub count: u32,
+    pub top: u32,
+    pub freshness: ConceptFreshness,
+    pub limits: ConceptLimits,
+    pub precision_notes: Vec<String>,
+    pub candidates: Vec<ConceptCandidate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConceptFreshness {
+    pub status: String,
+    pub extractor_contract: String,
+    pub normalization_contract: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConceptLimits {
+    pub query_bytes: u32,
+    pub query_terms: u32,
+    pub term_bytes: u32,
+    pub top: u32,
+    pub signature_shape_bytes: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ConceptCandidate {
+    pub name: String,
+    pub kind: String,
+    pub language: String,
+    pub path: String,
+    pub line: u32,
+    pub signature_shape: String,
+    pub matched_fields: Vec<String>,
+    pub citation: String,
+    pub score: f64,
+}
+
+pub fn validate_concept_request(query: &str, top: u32) -> Result<Vec<String>, ConceptError> {
+    if query.is_empty()
+        || query.len() > CONCEPT_QUERY_MAX_BYTES
+        || !(1..=CONCEPT_MAX_TOP).contains(&top)
+    {
+        return Err(ConceptError::InvalidArguments);
+    }
+    let terms = crate::store::concept_terms(query).ok_or(ConceptError::InvalidArguments)?;
+    if terms.is_empty()
+        || terms.len() > CONCEPT_QUERY_TERM_LIMIT
+        || terms
+            .iter()
+            .any(|term| term.is_empty() || term.len() > crate::store::CONCEPT_TERM_MAX_BYTES)
+    {
+        return Err(ConceptError::InvalidArguments);
+    }
+    Ok(terms)
+}
+
+fn concept_match_query(terms: &[String]) -> String {
+    terms
+        .iter()
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" AND ")
+}
+
+pub(crate) fn concept_verified(
+    store: &Store,
+    query: &str,
+    top: u32,
+    expected_data_version: u64,
+    freshness: ConceptFreshness,
+) -> Result<ConceptResponse, ConceptError> {
+    let query_terms = validate_concept_request(query, top)?;
+    let match_query = concept_match_query(&query_terms);
+    store
+        .begin_read_snapshot()
+        .map_err(|_| ConceptError::SnapshotChanged)?;
+    let search = store.search_concepts(&match_query, top);
+    let end = store.end_read_snapshot();
+    let data_version_after = store.data_version().map_err(|_| {
+        if store.interrupt_source().is_some() {
+            ConceptError::WorkLimitExceeded
+        } else {
+            ConceptError::SnapshotChanged
+        }
+    })?;
+    end.map_err(|_| ConceptError::SnapshotChanged)?;
+    if data_version_after != expected_data_version {
+        return Err(ConceptError::SnapshotChanged);
+    }
+    let hits = search.map_err(|_| {
+        if store.interrupt_source().is_some() {
+            ConceptError::WorkLimitExceeded
+        } else {
+            ConceptError::Internal
+        }
+    })?;
+
+    let mut unsafe_omitted = 0u32;
+    let mut candidates = Vec::with_capacity(hits.len());
+    for hit in hits {
+        if !hit.score.is_finite() {
+            unsafe_omitted = unsafe_omitted.saturating_add(1);
+            continue;
+        }
+        let language = hit.language.unwrap_or_else(|| "unknown".to_string());
+        let mut matched_fields = Vec::new();
+        for (matched, field) in [
+            (hit.name_matched, "name"),
+            (hit.path_matched, "path"),
+            (hit.signature_matched, "signature"),
+            (hit.documentation_matched, "documentation"),
+        ] {
+            if matched {
+                matched_fields.push(field.to_string());
+            }
+        }
+        if matched_fields.is_empty() {
+            unsafe_omitted = unsafe_omitted.saturating_add(1);
+            continue;
+        }
+        candidates.push(ConceptCandidate {
+            name: hit.name,
+            kind: hit.kind,
+            language,
+            path: hit.path.clone(),
+            line: hit.line,
+            signature_shape: hit.signature_shape,
+            matched_fields,
+            citation: format!("{}:{}", hit.path, hit.line),
+            score: hit.score,
+        });
+    }
+    let mut precision_notes = vec![
+        "bm25_score_is_query_local_lower_is_better_not_confidence".to_string(),
+        "unicode_lowercase_without_canonical_equivalence".to_string(),
+        "documentation_search_reserved_empty".to_string(),
+    ];
+    if unsafe_omitted > 0 {
+        precision_notes.push(format!("unsafe_candidates_omitted:{unsafe_omitted}"));
+    }
+    Ok(ConceptResponse {
+        schema_version: 1,
+        repository_content_untrusted: true,
+        query_terms,
+        count: brief_u32(candidates.len()),
+        top,
+        freshness,
+        limits: ConceptLimits {
+            query_bytes: CONCEPT_QUERY_MAX_BYTES as u32,
+            query_terms: CONCEPT_QUERY_TERM_LIMIT as u32,
+            term_bytes: crate::store::CONCEPT_TERM_MAX_BYTES as u32,
+            top: CONCEPT_MAX_TOP,
+            signature_shape_bytes: crate::store::CONCEPT_SIGNATURE_MAX_BYTES as u32,
+        },
+        precision_notes,
+        candidates,
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum BriefRole {
@@ -3804,6 +4004,207 @@ mod tests {
         p.push(format!("mmcg-queries-{}-{}.db", std::process::id(), name));
         let _ = std::fs::remove_file(&p);
         p
+    }
+
+    fn verified_concept_freshness() -> ConceptFreshness {
+        ConceptFreshness {
+            status: "fresh".to_string(),
+            extractor_contract: crate::indexer::EXTRACTOR_CONTRACT_VERSION.to_string(),
+            normalization_contract: crate::store::CONCEPT_NORMALIZATION_VERSION.to_string(),
+        }
+    }
+
+    #[test]
+    fn concept_request_validation_never_admits_raw_fts_syntax() {
+        assert_eq!(
+            concept_match_query(&validate_concept_request("foo OR bar", 10).unwrap()),
+            "\"foo\" AND \"or\" AND \"bar\""
+        );
+        for invalid in ["", "---", "foo\0bar", "foo\nbar"] {
+            assert_eq!(
+                validate_concept_request(invalid, 10),
+                Err(ConceptError::InvalidArguments)
+            );
+        }
+        let too_many_terms = (0..17)
+            .map(|index| format!("term{index}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert_eq!(
+            validate_concept_request(&too_many_terms, 10),
+            Err(ConceptError::InvalidArguments)
+        );
+        assert_eq!(
+            validate_concept_request(&"a".repeat(65), 10),
+            Err(ConceptError::InvalidArguments)
+        );
+        for top in [0, 51] {
+            assert_eq!(
+                validate_concept_request("handler", top),
+                Err(ConceptError::InvalidArguments)
+            );
+        }
+    }
+
+    #[test]
+    fn concept_ranking_applies_exact_path_sort_before_limit() {
+        let path = tmp_db("concept_path_sort");
+        let store = Store::open(&path).unwrap();
+        for index in (0..100).rev() {
+            store
+                .insert_symbol(
+                    "handler",
+                    "function",
+                    &format!("src/p{index:03}.rs"),
+                    1,
+                    2,
+                    Some("fn handler()"),
+                    None,
+                )
+                .unwrap();
+        }
+        store.finalize_index_contracts_current().unwrap();
+
+        let response = concept_verified(
+            &store,
+            "handler",
+            10,
+            store.data_version().unwrap(),
+            verified_concept_freshness(),
+        )
+        .unwrap();
+        let expected = (0..10)
+            .map(|index| format!("src/p{index:03}.rs"))
+            .collect::<Vec<_>>();
+        let paths = response
+            .candidates
+            .iter()
+            .map(|candidate| candidate.path.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(paths, expected);
+        store.finalize_index_contracts_current().unwrap();
+        let rebuilt = concept_verified(
+            &store,
+            "handler",
+            10,
+            store.data_version().unwrap(),
+            verified_concept_freshness(),
+        )
+        .unwrap();
+        assert_eq!(rebuilt.candidates, response.candidates);
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn concept_json_fields_preserve_repository_identity_for_serde_escaping() {
+        let path = tmp_db("concept_raw_json_fields");
+        let store = Store::open(&path).unwrap();
+        let hostile_name = "handler](https://evil.example)<a>`\u{1b}\u{7}\u{202e}";
+        let hostile_path = "src/](file://evil)/<b>`handler.rs";
+        store
+            .insert_symbol(
+                hostile_name,
+                "function",
+                hostile_path,
+                7,
+                8,
+                Some("fn handler()"),
+                None,
+            )
+            .unwrap();
+        store.finalize_index_contracts_current().unwrap();
+
+        let response = concept_verified(
+            &store,
+            "handler",
+            10,
+            store.data_version().unwrap(),
+            verified_concept_freshness(),
+        )
+        .unwrap();
+        let candidate = response.candidates.first().unwrap();
+        assert_eq!(candidate.name, hostile_name);
+        assert_eq!(candidate.path, hostile_path);
+        assert_eq!(candidate.citation, format!("{hostile_path}:7"));
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\\u001b"));
+        assert!(json.contains("\\u0007"));
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn concept_snapshot_rejects_a_writer_after_the_freshness_token() {
+        let path = tmp_db("concept_snapshot_race");
+        let store = Store::open(&path).unwrap();
+        store
+            .insert_symbol(
+                "ready_handler",
+                "function",
+                "src/ready.rs",
+                1,
+                2,
+                Some("fn ready_handler()"),
+                None,
+            )
+            .unwrap();
+        store.finalize_index_contracts_current().unwrap();
+        let expected_data_version = store.data_version().unwrap();
+
+        let writer = rusqlite::Connection::open(&path).unwrap();
+        writer
+            .execute(
+                "INSERT INTO symbols(name, kind, file_path, line_start, line_end)
+                 VALUES ('late_handler', 'function', 'src/late.rs', 1, 2)",
+                [],
+            )
+            .unwrap();
+        drop(writer);
+
+        let result = concept_verified(
+            &store,
+            "ready",
+            10,
+            expected_data_version,
+            verified_concept_freshness(),
+        );
+        assert_eq!(result, Err(ConceptError::SnapshotChanged));
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn concept_query_budget_interrupts_without_partial_candidates() {
+        let path = tmp_db("concept_budget");
+        let store = Store::open(&path).unwrap();
+        for index in 0..2_000 {
+            store
+                .insert_symbol(
+                    &format!("common_handler_{index}"),
+                    "function",
+                    &format!("src/handler_{index}.rs"),
+                    1,
+                    2,
+                    Some("fn common_handler()"),
+                    None,
+                )
+                .unwrap();
+        }
+        store.finalize_index_contracts_current().unwrap();
+        assert!(!store.push_work_budget(crate::store::WorkBudget {
+            deadline: None,
+            op_ticks: Some(1),
+        }));
+        let result = concept_verified(
+            &store,
+            "common",
+            50,
+            store.data_version().unwrap(),
+            verified_concept_freshness(),
+        );
+        assert_eq!(result, Err(ConceptError::WorkLimitExceeded));
+        assert!(store.interrupt_source().is_some());
+        store.pop_work_budget();
+        let _ = store.take_interrupt_source();
+        std::fs::remove_file(path).ok();
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/queries.rs
+++ b/mcp/servers/mmcg/src/queries.rs
@@ -5365,6 +5365,11 @@ mod tests {
     }
 
     fn brief_repo(name: &str) -> (PathBuf, Store) {
+        let escaped_source_path = if cfg!(windows) {
+            "src/é quoted.py"
+        } else {
+            "src/é\"quoted.py"
+        };
         let root = impact_repo(
             name,
             &[
@@ -5376,7 +5381,7 @@ mod tests {
                     "src/test_app.py",
                     "from src.app import target\n\ndef test_target():\n    assert target() == 1\n",
                 ),
-                ("src/é\"quoted.py", "def unicode_target():\n    return 1\n"),
+                (escaped_source_path, "def unicode_target():\n    return 1\n"),
                 (
                     "CONTEXT.md",
                     "# Target decision\nDO_NOT_OUTPUT_HISTORY_BODY target caller details.\n",
@@ -5390,7 +5395,7 @@ mod tests {
         );
         write_impact_file(
             &root,
-            "src/é\"quoted.py",
+            escaped_source_path,
             "def unicode_target():\n    return 2\n",
         );
         let store = index_impact(&root, name);

--- a/mcp/servers/mmcg/src/store.rs
+++ b/mcp/servers/mmcg/src/store.rs
@@ -22,10 +22,148 @@ use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 const SCHEMA_VERSION: &str = "7";
+pub const CONCEPT_NORMALIZATION_META_KEY: &str = "concept_normalization_version";
+pub const CONCEPT_NORMALIZATION_VERSION: &str = "mmcg-concepts-v1";
+pub const CONCEPT_TERM_MAX_BYTES: usize = 64;
+pub const CONCEPT_SIGNATURE_MAX_BYTES: usize = 256;
+const CONCEPT_FIELD_MAX_BYTES: usize = 512;
+const CONCEPT_INDEX_TERM_LIMIT: usize = 128;
+const CONCEPT_SIGNATURE_SCAN_MAX_BYTES: usize = 64 * 1024;
+const CONCEPT_CONTRACT_DIRTY: &str = "dirty";
+static INSERT_SYMBOL_SAVEPOINT_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+const CONCEPT_SCHEMA_DROP_SQL: &str = r#"
+    DROP TRIGGER IF EXISTS symbol_concepts_graph_ai;
+    DROP TRIGGER IF EXISTS symbol_concepts_graph_ad;
+    DROP TRIGGER IF EXISTS symbol_concepts_graph_au;
+    DROP TRIGGER IF EXISTS symbol_concepts_ai;
+    DROP TRIGGER IF EXISTS symbol_concepts_ad;
+    DROP TRIGGER IF EXISTS symbol_concepts_au;
+    DROP TABLE IF EXISTS symbol_concepts_fts;
+    DROP TABLE IF EXISTS symbol_concepts;
+"#;
+const CONCEPT_SCHEMA_DDL: &str = r#"
+    CREATE TABLE symbol_concepts (
+        symbol_id             INTEGER PRIMARY KEY
+                              REFERENCES symbols(id) ON DELETE CASCADE,
+        name_search           TEXT NOT NULL,
+        path_search           TEXT NOT NULL,
+        path_sort             TEXT NOT NULL,
+        signature_search      TEXT NOT NULL,
+        documentation_search  TEXT NOT NULL DEFAULT ''
+    );
+    CREATE VIRTUAL TABLE symbol_concepts_fts USING fts5(
+        name_search,
+        path_search,
+        signature_search,
+        documentation_search,
+        content='symbol_concepts',
+        content_rowid='symbol_id',
+        tokenize = "unicode61 remove_diacritics 0 tokenchars '_'"
+    );
+    CREATE TRIGGER symbol_concepts_ai
+    AFTER INSERT ON symbol_concepts BEGIN
+        INSERT INTO symbol_concepts_fts(
+            rowid, name_search, path_search, signature_search,
+            documentation_search
+        ) VALUES (
+            new.symbol_id, new.name_search, new.path_search,
+            new.signature_search, new.documentation_search
+        );
+    END;
+    CREATE TRIGGER symbol_concepts_ad
+    AFTER DELETE ON symbol_concepts BEGIN
+        INSERT INTO symbol_concepts_fts(
+            symbol_concepts_fts, rowid, name_search, path_search,
+            signature_search, documentation_search
+        ) VALUES (
+            'delete', old.symbol_id, old.name_search, old.path_search,
+            old.signature_search, old.documentation_search
+        );
+    END;
+    CREATE TRIGGER symbol_concepts_au
+    AFTER UPDATE ON symbol_concepts BEGIN
+        INSERT INTO symbol_concepts_fts(
+            symbol_concepts_fts, rowid, name_search, path_search,
+            signature_search, documentation_search
+        ) VALUES (
+            'delete', old.symbol_id, old.name_search, old.path_search,
+            old.signature_search, old.documentation_search
+        );
+        INSERT INTO symbol_concepts_fts(
+            rowid, name_search, path_search, signature_search,
+            documentation_search
+        ) VALUES (
+            new.symbol_id, new.name_search, new.path_search,
+            new.signature_search, new.documentation_search
+        );
+    END;
+    CREATE TRIGGER symbol_concepts_graph_ai
+    AFTER INSERT ON symbols BEGIN
+        INSERT INTO meta(key, value)
+        VALUES ('concept_normalization_version', 'dirty')
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        WHERE meta.value <> excluded.value;
+    END;
+    CREATE TRIGGER symbol_concepts_graph_ad
+    AFTER DELETE ON symbols BEGIN
+        INSERT INTO meta(key, value)
+        VALUES ('concept_normalization_version', 'dirty')
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        WHERE meta.value <> excluded.value;
+    END;
+    CREATE TRIGGER symbol_concepts_graph_au
+    AFTER UPDATE ON symbols BEGIN
+        INSERT INTO meta(key, value)
+        VALUES ('concept_normalization_version', 'dirty')
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        WHERE meta.value <> excluded.value;
+    END;
+"#;
+const CONCEPT_SHADOW_REPAIR_SQL: &str = r#"
+    CREATE TABLE IF NOT EXISTS 'symbol_concepts_fts_config'(k PRIMARY KEY, v) WITHOUT ROWID;
+    CREATE TABLE IF NOT EXISTS 'symbol_concepts_fts_data'(id INTEGER PRIMARY KEY, block BLOB);
+    CREATE TABLE IF NOT EXISTS 'symbol_concepts_fts_docsize'(id INTEGER PRIMARY KEY, sz BLOB);
+    CREATE TABLE IF NOT EXISTS 'symbol_concepts_fts_idx'(
+        segid, term, pgno, PRIMARY KEY(segid, term)
+    ) WITHOUT ROWID;
+    INSERT OR IGNORE INTO symbol_concepts_fts_config(k, v) VALUES ('version', 4);
+    INSERT OR IGNORE INTO symbol_concepts_fts_data(id, block) VALUES (1, x'');
+    INSERT OR IGNORE INTO symbol_concepts_fts_data(id, block) VALUES (10, zeroblob(7));
+"#;
+const CONCEPT_SHADOW_NAMES: &[&str] = &[
+    "symbol_concepts_fts_config",
+    "symbol_concepts_fts_data",
+    "symbol_concepts_fts_docsize",
+    "symbol_concepts_fts_idx",
+];
+const CONCEPT_TRIGGER_NAMES: &[&str] = &[
+    "symbol_concepts_graph_ai",
+    "symbol_concepts_graph_ad",
+    "symbol_concepts_graph_au",
+    "symbol_concepts_ai",
+    "symbol_concepts_ad",
+    "symbol_concepts_au",
+];
+const CONCEPT_SCHEMA_OBJECTS: &[(&str, &str)] = &[
+    ("table", "symbol_concepts"),
+    ("table", "symbol_concepts_fts"),
+    ("table", "symbol_concepts_fts_config"),
+    ("table", "symbol_concepts_fts_data"),
+    ("table", "symbol_concepts_fts_docsize"),
+    ("table", "symbol_concepts_fts_idx"),
+    ("trigger", "symbol_concepts_ai"),
+    ("trigger", "symbol_concepts_ad"),
+    ("trigger", "symbol_concepts_au"),
+    ("trigger", "symbol_concepts_graph_ai"),
+    ("trigger", "symbol_concepts_graph_ad"),
+    ("trigger", "symbol_concepts_graph_au"),
+];
+static CONCEPT_SCHEMA_CONTRACT: OnceLock<Vec<(&'static str, &'static str, String)>> =
+    OnceLock::new();
 const READ_ONLY_SNAPSHOT_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const READ_ONLY_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -79,6 +217,7 @@ fn impact_precision_budget() -> WorkBudget {
 #[cfg(test)]
 thread_local! {
     static IMPACT_PRECISION_BUDGET_OVERRIDE: Cell<Option<WorkBudget>> = const { Cell::new(None) };
+    static FAIL_CONCEPT_SCHEMA_AFTER_SHADOW_REPAIR: Cell<bool> = const { Cell::new(false) };
 }
 
 #[cfg(test)]
@@ -516,6 +655,1140 @@ pub struct ProjectHistoryHit {
     pub(crate) matched_terms: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
+struct ConceptDocument {
+    name_search: String,
+    path_search: String,
+    path_sort: String,
+    signature_search: String,
+    documentation_search: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ConceptStoreHit {
+    pub name: String,
+    pub kind: String,
+    pub language: Option<String>,
+    pub path: String,
+    pub line: u32,
+    pub signature_shape: String,
+    pub name_matched: bool,
+    pub path_matched: bool,
+    pub signature_matched: bool,
+    pub documentation_matched: bool,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ConceptFinalizeStats {
+    pub rows: u32,
+    pub orphans_purged: u32,
+}
+
+fn lowercase_concept(value: &str) -> String {
+    value.chars().flat_map(char::to_lowercase).collect()
+}
+
+fn push_concept_term(term: String, seen: &mut HashSet<String>, terms: &mut Vec<String>) {
+    if !term.is_empty() && seen.insert(term.clone()) {
+        terms.push(term);
+    }
+}
+
+fn split_concept_identifier(value: &[char], seen: &mut HashSet<String>, terms: &mut Vec<String>) {
+    if value.is_empty() {
+        return;
+    }
+    let joined = lowercase_concept(
+        &value
+            .iter()
+            .filter(|character| **character != '_' && **character != '-')
+            .collect::<String>(),
+    );
+    push_concept_term(joined, seen, terms);
+
+    for part in value.split(|character| matches!(character, '_' | '-')) {
+        if part.is_empty() {
+            continue;
+        }
+        let mut start = 0usize;
+        for index in 1..part.len() {
+            let previous = part[index - 1];
+            let current = part[index];
+            let next = part.get(index + 1).copied();
+            let lower_to_upper = previous.is_lowercase() && current.is_uppercase();
+            let acronym_to_word = previous.is_uppercase()
+                && current.is_uppercase()
+                && next.is_some_and(char::is_lowercase);
+            let letter_to_digit = previous.is_alphabetic() && current.is_numeric();
+            let digit_to_letter = previous.is_numeric() && current.is_alphabetic();
+            if lower_to_upper || acronym_to_word || letter_to_digit || digit_to_letter {
+                push_concept_term(
+                    lowercase_concept(&part[start..index].iter().collect::<String>()),
+                    seen,
+                    terms,
+                );
+                start = index;
+            }
+        }
+        push_concept_term(
+            lowercase_concept(&part[start..].iter().collect::<String>()),
+            seen,
+            terms,
+        );
+    }
+}
+
+fn normalized_concept_terms(value: &str, formatting_whitespace: bool) -> Option<Vec<String>> {
+    let mut seen = HashSet::new();
+    let mut terms = Vec::new();
+    let mut identifier = Vec::new();
+    for character in value.chars() {
+        if character.is_control() {
+            if formatting_whitespace && matches!(character, '\r' | '\n' | '\t') {
+                split_concept_identifier(&identifier, &mut seen, &mut terms);
+                identifier.clear();
+                continue;
+            }
+            return None;
+        }
+        if character.is_alphanumeric() || matches!(character, '_' | '-') {
+            identifier.push(character);
+        } else {
+            split_concept_identifier(&identifier, &mut seen, &mut terms);
+            identifier.clear();
+        }
+    }
+    split_concept_identifier(&identifier, &mut seen, &mut terms);
+    Some(terms)
+}
+
+/// Query lexical normalization. Index fields use the same splitting and
+/// lowercase rules but additionally admit CR/LF/tab as declaration separators.
+pub(crate) fn concept_terms(value: &str) -> Option<Vec<String>> {
+    normalized_concept_terms(value, false)
+}
+
+fn concept_index_terms(value: &str) -> Option<Vec<String>> {
+    normalized_concept_terms(value, true)
+}
+
+fn concept_path_sort(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\\' => output.push('/'),
+            character if character.is_control() => {
+                output.push_str(&format!("\\u{:06x}", character as u32));
+            }
+            character => output.extend(character.to_lowercase()),
+        }
+    }
+    output
+}
+
+#[derive(Clone, Copy, Default)]
+struct SignatureDialect {
+    hash_line_comments: bool,
+    nested_block_comments: bool,
+    csharp_raw_strings: bool,
+    interpolated_strings: bool,
+    javascript_regex: bool,
+    python_defaults: bool,
+    php_heredoc: bool,
+    cpp_operators: bool,
+}
+
+fn signature_dialect(path: &str) -> SignatureDialect {
+    let language = crate::indexer::guess_language_for(path).unwrap_or_default();
+    SignatureDialect {
+        hash_line_comments: matches!(language, "python" | "php"),
+        nested_block_comments: language == "rust",
+        csharp_raw_strings: language == "csharp",
+        interpolated_strings: matches!(language, "python" | "csharp"),
+        javascript_regex: matches!(language, "javascript" | "typescript" | "tsx" | "vue"),
+        python_defaults: language == "python",
+        php_heredoc: language == "php",
+        cpp_operators: language == "cpp",
+    }
+}
+
+fn php_heredoc_signature_end(characters: &[char], start: usize) -> Option<usize> {
+    if characters.get(start..start + 3) != Some(&['<', '<', '<']) {
+        return None;
+    }
+    let mut cursor = start + 3;
+    while characters
+        .get(cursor)
+        .is_some_and(|character| matches!(character, ' ' | '\t'))
+    {
+        cursor += 1;
+    }
+    let quote = characters
+        .get(cursor)
+        .copied()
+        .filter(|character| matches!(character, '\'' | '"'));
+    if quote.is_some() {
+        cursor += 1;
+    }
+    let label_start = cursor;
+    while characters
+        .get(cursor)
+        .is_some_and(|character| character.is_alphanumeric() || *character == '_')
+    {
+        cursor += 1;
+    }
+    if cursor == label_start {
+        return Some(characters.len());
+    }
+    let label = &characters[label_start..cursor];
+    if let Some(quote) = quote {
+        if characters.get(cursor) != Some(&quote) {
+            return Some(characters.len());
+        }
+        cursor += 1;
+    }
+    while characters
+        .get(cursor)
+        .is_some_and(|character| !matches!(character, '\r' | '\n'))
+    {
+        cursor += 1;
+    }
+    if characters.get(cursor) == Some(&'\r') {
+        cursor += 1;
+    }
+    if characters.get(cursor) == Some(&'\n') {
+        cursor += 1;
+    } else {
+        return Some(characters.len());
+    }
+
+    while cursor < characters.len() {
+        let mut candidate = cursor;
+        while characters
+            .get(candidate)
+            .is_some_and(|character| matches!(character, ' ' | '\t'))
+        {
+            candidate += 1;
+        }
+        if characters.get(candidate..candidate + label.len()) == Some(label) {
+            candidate += label.len();
+            while characters
+                .get(candidate)
+                .is_some_and(|character| matches!(character, ' ' | '\t'))
+            {
+                candidate += 1;
+            }
+            if characters.get(candidate) == Some(&';') {
+                candidate += 1;
+                while characters
+                    .get(candidate)
+                    .is_some_and(|character| matches!(character, ' ' | '\t'))
+                {
+                    candidate += 1;
+                }
+            }
+            if characters.get(candidate) == Some(&',') {
+                return Some(candidate);
+            }
+            if characters
+                .get(candidate)
+                .is_none_or(|character| matches!(character, '\r' | '\n'))
+            {
+                if characters.get(candidate) == Some(&'\r') {
+                    candidate += 1;
+                }
+                if characters.get(candidate) == Some(&'\n') {
+                    candidate += 1;
+                }
+                return Some(candidate);
+            }
+        }
+        while characters
+            .get(cursor)
+            .is_some_and(|character| !matches!(character, '\r' | '\n'))
+        {
+            cursor += 1;
+        }
+        if characters.get(cursor) == Some(&'\r') {
+            cursor += 1;
+        }
+        if characters.get(cursor) == Some(&'\n') {
+            cursor += 1;
+        }
+    }
+    Some(characters.len())
+}
+
+fn quoted_signature_end(characters: &[char], start: usize, dialect: SignatureDialect) -> usize {
+    let quote = characters[start];
+    let quote_run = characters[start..]
+        .iter()
+        .take_while(|character| **character == quote)
+        .count();
+    let csharp_raw = dialect.csharp_raw_strings && quote_run >= 3;
+    let width = if csharp_raw {
+        quote_run
+    } else if quote_run >= 3 {
+        3
+    } else {
+        1
+    };
+    let mut prefix_start = start;
+    while prefix_start > 0
+        && start - prefix_start < 3
+        && matches!(
+            characters[prefix_start - 1],
+            'f' | 'F' | 'r' | 'R' | '$' | '@'
+        )
+    {
+        prefix_start -= 1;
+    }
+    let prefix = characters[prefix_start..start]
+        .iter()
+        .collect::<String>()
+        .to_ascii_lowercase();
+    let prefix_boundary = prefix_start == 0
+        || !characters[prefix_start - 1].is_alphanumeric() && characters[prefix_start - 1] != '_';
+    let interpolated = dialect.interpolated_strings
+        && prefix_boundary
+        && (dialect.python_defaults && matches!(prefix.as_str(), "f" | "fr" | "rf")
+            || dialect.csharp_raw_strings && matches!(prefix.as_str(), "$" | "$@" | "@$"));
+    let doubled_quote_escape = dialect.csharp_raw_strings && prefix.contains('@');
+    let mut interpolation_depth = 0usize;
+    let mut index = start + width;
+    while index < characters.len() {
+        if !csharp_raw && characters[index] == '\\' {
+            index = index.saturating_add(2);
+            continue;
+        }
+        if interpolated && width == 1 {
+            if interpolation_depth > 0 && matches!(characters[index], '\'' | '"') {
+                index = quoted_signature_end(characters, index, SignatureDialect::default());
+                continue;
+            }
+            match characters[index] {
+                '{' if characters.get(index + 1) == Some(&'{') => {
+                    index += 2;
+                    continue;
+                }
+                '{' => {
+                    interpolation_depth += 1;
+                    index += 1;
+                    continue;
+                }
+                '}' if characters.get(index + 1) == Some(&'}') => {
+                    index += 2;
+                    continue;
+                }
+                '}' if interpolation_depth > 0 => {
+                    interpolation_depth -= 1;
+                    index += 1;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        if interpolation_depth == 0
+            && (0..width).all(|offset| characters.get(index + offset) == Some(&quote))
+        {
+            if doubled_quote_escape && characters.get(index + width) == Some(&quote) {
+                index += width + 1;
+                continue;
+            }
+            return index + width;
+        }
+        index += 1;
+    }
+    characters.len()
+}
+
+fn rust_raw_signature_end(characters: &[char], start: usize) -> Option<usize> {
+    let boundary =
+        start == 0 || !characters[start - 1].is_alphanumeric() && characters[start - 1] != '_';
+    if !boundary {
+        return None;
+    }
+    let mut cursor = start;
+    if matches!(characters.get(cursor), Some('b' | 'c')) {
+        cursor += 1;
+    }
+    if characters.get(cursor) != Some(&'r') {
+        return None;
+    }
+    cursor += 1;
+    let hashes_start = cursor;
+    while characters.get(cursor) == Some(&'#') && cursor - hashes_start <= 255 {
+        cursor += 1;
+    }
+    let hashes = cursor - hashes_start;
+    if hashes > 255 || characters.get(cursor) != Some(&'"') {
+        return None;
+    }
+    cursor += 1;
+    while cursor < characters.len() {
+        if characters[cursor] == '"'
+            && (0..hashes).all(|offset| characters.get(cursor + 1 + offset) == Some(&'#'))
+        {
+            return Some(cursor + 1 + hashes);
+        }
+        cursor += 1;
+    }
+    Some(characters.len())
+}
+
+fn cpp_raw_signature_end(characters: &[char], start: usize) -> Option<usize> {
+    let boundary =
+        start == 0 || !characters[start - 1].is_alphanumeric() && characters[start - 1] != '_';
+    if !boundary {
+        return None;
+    }
+    let raw_prefix_end = match characters.get(start..) {
+        Some(['R', '"', ..]) => start + 1,
+        Some(['L' | 'u' | 'U', 'R', '"', ..]) => start + 2,
+        Some(['u', '8', 'R', '"', ..]) => start + 3,
+        _ => return None,
+    };
+    let mut open = raw_prefix_end + 1;
+    while open < characters.len()
+        && open - (raw_prefix_end + 1) <= 16
+        && characters[open] != '('
+        && !characters[open].is_whitespace()
+        && !matches!(characters[open], '\\' | ')')
+    {
+        open += 1;
+    }
+    if open - (raw_prefix_end + 1) > 16 || characters.get(open) != Some(&'(') {
+        return None;
+    }
+    let delimiter = &characters[raw_prefix_end + 1..open];
+    let mut cursor = open + 1;
+    while cursor < characters.len() {
+        if characters[cursor] == ')'
+            && characters.get(cursor + 1..cursor + 1 + delimiter.len()) == Some(delimiter)
+            && characters.get(cursor + 1 + delimiter.len()) == Some(&'"')
+        {
+            return Some(cursor + 2 + delimiter.len());
+        }
+        cursor += 1;
+    }
+    Some(characters.len())
+}
+
+fn raw_signature_end(characters: &[char], start: usize) -> Option<usize> {
+    rust_raw_signature_end(characters, start).or_else(|| cpp_raw_signature_end(characters, start))
+}
+
+fn template_signature_end(characters: &[char], start: usize) -> Option<usize> {
+    if characters.get(start) != Some(&'`') {
+        return None;
+    }
+
+    #[derive(Clone, Copy)]
+    enum Mode {
+        Template,
+        Expression { depth: usize, regex_allowed: bool },
+    }
+
+    let mut modes = vec![Mode::Template];
+    let mut index = start + 1;
+    while index < characters.len() {
+        match modes.last().copied().unwrap_or(Mode::Template) {
+            Mode::Template => match characters[index] {
+                '\\' => index = index.saturating_add(2),
+                '$' if characters.get(index + 1) == Some(&'{') => {
+                    modes.push(Mode::Expression {
+                        depth: 1,
+                        regex_allowed: true,
+                    });
+                    index += 2;
+                }
+                '`' => {
+                    modes.pop();
+                    index += 1;
+                    if modes.is_empty() {
+                        return Some(index);
+                    }
+                }
+                _ => index += 1,
+            },
+            Mode::Expression {
+                depth,
+                regex_allowed,
+            } => {
+                if let Some(end) = comment_signature_end(
+                    characters,
+                    index,
+                    SignatureDialect {
+                        javascript_regex: true,
+                        ..SignatureDialect::default()
+                    },
+                ) {
+                    index = end;
+                    continue;
+                }
+                if matches!(characters[index], '\'' | '"') {
+                    index = quoted_signature_end(characters, index, SignatureDialect::default());
+                    *modes.last_mut().expect("template expression exists") = Mode::Expression {
+                        depth,
+                        regex_allowed: false,
+                    };
+                    continue;
+                }
+                if characters[index].is_alphabetic() || matches!(characters[index], '_' | '$') {
+                    let token_start = index;
+                    index += 1;
+                    while characters.get(index).is_some_and(|character| {
+                        character.is_alphanumeric() || matches!(character, '_' | '$')
+                    }) {
+                        index += 1;
+                    }
+                    let token = characters[token_start..index].iter().collect::<String>();
+                    *modes.last_mut().expect("template expression exists") = Mode::Expression {
+                        depth,
+                        regex_allowed: matches!(
+                            token.as_str(),
+                            "await"
+                                | "case"
+                                | "delete"
+                                | "do"
+                                | "else"
+                                | "in"
+                                | "instanceof"
+                                | "new"
+                                | "of"
+                                | "return"
+                                | "throw"
+                                | "typeof"
+                                | "void"
+                                | "yield"
+                        ),
+                    };
+                    continue;
+                }
+                match characters[index] {
+                    '`' => {
+                        *modes.last_mut().expect("template expression exists") = Mode::Expression {
+                            depth,
+                            regex_allowed: false,
+                        };
+                        modes.push(Mode::Template);
+                        index += 1;
+                    }
+                    '{' => {
+                        *modes.last_mut().expect("template mode exists") = Mode::Expression {
+                            depth: depth + 1,
+                            regex_allowed: true,
+                        };
+                        index += 1;
+                    }
+                    '}' if depth == 1 => {
+                        modes.pop();
+                        index += 1;
+                    }
+                    '}' => {
+                        *modes.last_mut().expect("template mode exists") = Mode::Expression {
+                            depth: depth - 1,
+                            regex_allowed: false,
+                        };
+                        index += 1;
+                    }
+                    '/' => {
+                        if regex_allowed {
+                            if let Some(end) = js_regex_signature_end(characters, index) {
+                                index = end;
+                                *modes.last_mut().expect("template expression exists") =
+                                    Mode::Expression {
+                                        depth,
+                                        regex_allowed: false,
+                                    };
+                                continue;
+                            }
+                        }
+                        index += 1;
+                        *modes.last_mut().expect("template expression exists") = Mode::Expression {
+                            depth,
+                            regex_allowed: true,
+                        };
+                    }
+                    '(' | '[' | ',' | ':' | '?' | '!' | '&' | '|' | '+' | '-' | '*' | '%' | '^'
+                    | '~' | '=' => {
+                        index += 1;
+                        *modes.last_mut().expect("template expression exists") = Mode::Expression {
+                            depth,
+                            regex_allowed: true,
+                        };
+                    }
+                    ')' | ']' => {
+                        index += 1;
+                        *modes.last_mut().expect("template expression exists") = Mode::Expression {
+                            depth,
+                            regex_allowed: false,
+                        };
+                    }
+                    character if character.is_whitespace() => index += 1,
+                    _ => {
+                        index += 1;
+                        *modes.last_mut().expect("template expression exists") = Mode::Expression {
+                            depth,
+                            regex_allowed: false,
+                        };
+                    }
+                }
+            }
+        }
+    }
+    Some(characters.len())
+}
+
+fn comment_signature_end(
+    characters: &[char],
+    start: usize,
+    dialect: SignatureDialect,
+) -> Option<usize> {
+    match (characters.get(start), characters.get(start + 1)) {
+        (Some('#'), _) if dialect.hash_line_comments => {
+            let content_start = start + 1;
+            Some(
+                characters[content_start..]
+                    .iter()
+                    .position(|character| matches!(character, '\r' | '\n'))
+                    .map_or(characters.len(), |offset| content_start + offset),
+            )
+        }
+        (Some('/'), Some('/')) => {
+            let content_start = start + usize::from(characters[start] == '/') + 1;
+            Some(
+                characters[content_start..]
+                    .iter()
+                    .position(|character| matches!(character, '\r' | '\n'))
+                    .map_or(characters.len(), |offset| content_start + offset),
+            )
+        }
+        (Some('/'), Some('*')) => {
+            let mut index = start + 2;
+            let mut depth = 1usize;
+            while index + 1 < characters.len() {
+                if dialect.nested_block_comments
+                    && characters[index] == '/'
+                    && characters[index + 1] == '*'
+                {
+                    depth += 1;
+                    index += 2;
+                    continue;
+                }
+                if characters[index] == '*' && characters[index + 1] == '/' {
+                    depth -= 1;
+                    index += 2;
+                    if depth == 0 {
+                        return Some(index);
+                    }
+                    continue;
+                }
+                index += 1;
+            }
+            Some(characters.len())
+        }
+        _ => None,
+    }
+}
+
+fn rust_lifetime_start(characters: &[char], start: usize) -> bool {
+    if characters.get(start) != Some(&'\'') {
+        return false;
+    }
+    let Some(first) = characters.get(start + 1) else {
+        return false;
+    };
+    if !first.is_alphabetic() && *first != '_' {
+        return false;
+    }
+    let mut end = start + 2;
+    while characters
+        .get(end)
+        .is_some_and(|character| character.is_alphanumeric() || *character == '_')
+    {
+        end += 1;
+    }
+    characters.get(end) != Some(&'\'')
+}
+
+fn js_regex_signature_end(characters: &[char], start: usize) -> Option<usize> {
+    if characters.get(start) != Some(&'/') || matches!(characters.get(start + 1), Some('/' | '*')) {
+        return None;
+    }
+    let mut index = start + 1;
+    let mut in_class = false;
+    while index < characters.len() {
+        match characters[index] {
+            '\\' => index = index.saturating_add(2),
+            '[' => {
+                in_class = true;
+                index += 1;
+            }
+            ']' => {
+                in_class = false;
+                index += 1;
+            }
+            '/' if !in_class => {
+                index += 1;
+                while characters
+                    .get(index)
+                    .is_some_and(|character| character.is_alphabetic())
+                {
+                    index += 1;
+                }
+                return Some(index);
+            }
+            _ => index += 1,
+        }
+    }
+    Some(characters.len())
+}
+
+fn previous_non_whitespace(characters: &[char], index: usize) -> Option<usize> {
+    (0..index)
+        .rev()
+        .find(|candidate| !characters[*candidate].is_whitespace())
+}
+
+fn next_non_whitespace(characters: &[char], index: usize) -> Option<usize> {
+    (index + 1..characters.len()).find(|candidate| !characters[*candidate].is_whitespace())
+}
+
+fn generic_angle_has_close(characters: &[char], start: usize) -> bool {
+    let (mut angles, mut parentheses, mut brackets, mut braces) = (1usize, 0usize, 0usize, 0usize);
+    let mut index = start + 1;
+    while index < characters.len() {
+        if let Some(end) = raw_signature_end(characters, index) {
+            index = end;
+            continue;
+        }
+        if let Some(end) = template_signature_end(characters, index) {
+            index = end;
+            continue;
+        }
+        if let Some(end) = comment_signature_end(characters, index, SignatureDialect::default()) {
+            index = end;
+            continue;
+        }
+        if matches!(characters[index], '\'' | '"') {
+            index = quoted_signature_end(characters, index, SignatureDialect::default());
+            continue;
+        }
+        match characters[index] {
+            '(' => parentheses += 1,
+            ')' if parentheses == 0 && brackets == 0 && braces == 0 => return false,
+            ')' => parentheses = parentheses.saturating_sub(1),
+            '[' => brackets += 1,
+            ']' if brackets == 0 && parentheses == 0 && braces == 0 => return false,
+            ']' => brackets = brackets.saturating_sub(1),
+            '{' => braces += 1,
+            '}' if braces == 0 && parentheses == 0 && brackets == 0 => return false,
+            '}' => braces = braces.saturating_sub(1),
+            '<' if !matches!(characters.get(index + 1), Some('<' | '=')) => angles += 1,
+            '>' if !matches!(characters.get(index + 1), Some('=')) => {
+                angles -= 1;
+                if angles == 0 {
+                    return true;
+                }
+            }
+            ';' if parentheses == 0 && brackets == 0 && braces == 0 => return false,
+            _ => {}
+        }
+        index += 1;
+    }
+    false
+}
+
+fn generic_angle_open(characters: &[char], index: usize) -> bool {
+    if characters.get(index) != Some(&'<') || matches!(characters.get(index + 1), Some('<' | '=')) {
+        return false;
+    }
+    let Some(previous) = previous_non_whitespace(characters, index) else {
+        return false;
+    };
+    let Some(next) = next_non_whitespace(characters, index) else {
+        return false;
+    };
+    if !matches!(characters[previous], '>' | ':' | ')' | ']')
+        && !characters[previous].is_alphanumeric()
+        && characters[previous] != '_'
+    {
+        return false;
+    }
+    !matches!(
+        characters[next],
+        '<' | '=' | '>' | ',' | ';' | ')' | ']' | '}'
+    ) && generic_angle_has_close(characters, index)
+}
+
+fn cpp_operator_equals(characters: &[char], index: usize) -> bool {
+    let mut cursor = index;
+    while cursor > 0 && characters[cursor - 1].is_whitespace() {
+        cursor -= 1;
+    }
+    while cursor > 0
+        && matches!(
+            characters[cursor - 1],
+            '+' | '-' | '*' | '/' | '%' | '&' | '|' | '^' | '!' | '<' | '>' | '~'
+        )
+    {
+        cursor -= 1;
+    }
+    while cursor > 0 && characters[cursor - 1].is_whitespace() {
+        cursor -= 1;
+    }
+    let end = cursor;
+    while cursor > 0 && (characters[cursor - 1].is_alphanumeric() || characters[cursor - 1] == '_')
+    {
+        cursor -= 1;
+    }
+    characters[cursor..end].iter().collect::<String>() == "operator"
+}
+
+fn standalone_default_equals(characters: &[char], index: usize, dialect: SignatureDialect) -> bool {
+    if characters.get(index) != Some(&'=') {
+        return false;
+    }
+    if dialect.cpp_operators && cpp_operator_equals(characters, index) {
+        return false;
+    }
+    let previous =
+        previous_non_whitespace(characters, index).and_then(|value| characters.get(value));
+    let next = characters.get(index + 1);
+    !previous.is_some_and(|value| {
+        matches!(
+            value,
+            '=' | '!' | '<' | '>' | '-' | ':' | '+' | '*' | '/' | '%' | '&' | '|' | '^'
+        )
+    }) && !next.is_some_and(|value| matches!(value, '=' | '>'))
+}
+
+fn skip_signature_default(
+    characters: &[char],
+    start: usize,
+    base_depth: (usize, usize, usize, usize),
+    dialect: SignatureDialect,
+) -> usize {
+    let (mut parentheses, mut brackets, mut braces, mut angles) = base_depth;
+    let mut index = start;
+    let mut regex_allowed = true;
+    let mut python_lambda_parameters = 0usize;
+    while index < characters.len() {
+        if dialect.php_heredoc {
+            if let Some(end) = php_heredoc_signature_end(characters, index) {
+                index = end;
+                regex_allowed = false;
+                continue;
+            }
+        }
+        if let Some(end) = raw_signature_end(characters, index) {
+            index = end;
+            regex_allowed = false;
+            continue;
+        }
+        if let Some(end) = template_signature_end(characters, index) {
+            index = end;
+            regex_allowed = false;
+            continue;
+        }
+        if let Some(end) = comment_signature_end(characters, index, dialect) {
+            index = end;
+            continue;
+        }
+        if characters[index] == '\'' && rust_lifetime_start(characters, index) {
+            index += 1;
+            regex_allowed = false;
+            continue;
+        }
+        if matches!(characters[index], '\'' | '"') {
+            index = quoted_signature_end(characters, index, dialect);
+            regex_allowed = false;
+            continue;
+        }
+        if dialect.javascript_regex && characters[index] == '/' && regex_allowed {
+            if let Some(end) = js_regex_signature_end(characters, index) {
+                index = end;
+                regex_allowed = false;
+                continue;
+            }
+        }
+        if dialect.python_defaults
+            && (parentheses, brackets, braces, angles) == base_depth
+            && characters[index..].starts_with(&['l', 'a', 'm', 'b', 'd', 'a'])
+            && (index == 0
+                || !characters[index - 1].is_alphanumeric() && characters[index - 1] != '_')
+            && characters
+                .get(index + 6)
+                .is_none_or(|character| !character.is_alphanumeric() && *character != '_')
+        {
+            python_lambda_parameters += 1;
+            index += 6;
+            regex_allowed = false;
+            continue;
+        }
+        match characters[index] {
+            '(' => {
+                parentheses += 1;
+                regex_allowed = true;
+            }
+            ')' if parentheses == base_depth.0 => return index,
+            ')' => {
+                parentheses = parentheses.saturating_sub(1);
+                regex_allowed = false;
+            }
+            '[' => {
+                brackets += 1;
+                regex_allowed = true;
+            }
+            ']' if brackets == base_depth.1 => return index,
+            ']' => {
+                brackets = brackets.saturating_sub(1);
+                regex_allowed = false;
+            }
+            '{' => {
+                braces += 1;
+                regex_allowed = true;
+            }
+            '}' if braces == base_depth.2 => return index,
+            '}' => {
+                braces = braces.saturating_sub(1);
+                regex_allowed = false;
+            }
+            '<' if generic_angle_open(characters, index) => {
+                angles += 1;
+                regex_allowed = true;
+            }
+            '>' if angles > base_depth.3 => {
+                angles -= 1;
+                regex_allowed = false;
+            }
+            ':' if dialect.python_defaults
+                && python_lambda_parameters > 0
+                && (parentheses, brackets, braces, angles) == base_depth =>
+            {
+                python_lambda_parameters -= 1;
+                regex_allowed = true;
+            }
+            ',' if dialect.python_defaults
+                && python_lambda_parameters > 0
+                && (parentheses, brackets, braces, angles) == base_depth =>
+            {
+                regex_allowed = true;
+            }
+            ',' | ';' if (parentheses, brackets, braces, angles) == base_depth => {
+                return index + usize::from(characters[index] == ',');
+            }
+            character if character.is_whitespace() => {}
+            '=' | ':' | '?' | '!' | '&' | '|' | '+' | '-' | '*' | '/' | '%' | '^' | '~' => {
+                regex_allowed = true;
+            }
+            _ => regex_allowed = false,
+        }
+        index += 1;
+    }
+    index
+}
+
+fn redact_signature(value: &str, dialect: SignatureDialect) -> Option<String> {
+    if value.len() > CONCEPT_SIGNATURE_SCAN_MAX_BYTES {
+        return None;
+    }
+    let characters = value.chars().collect::<Vec<_>>();
+    let mut output = String::with_capacity(value.len().min(CONCEPT_SIGNATURE_MAX_BYTES));
+    let (mut parentheses, mut brackets, mut braces, mut angles) = (0, 0, 0, 0);
+    let mut index = 0usize;
+    let mut regex_allowed = true;
+    while index < characters.len() {
+        if characters[index].is_control() {
+            if matches!(characters[index], '\r' | '\n' | '\t') {
+                output.push(' ');
+                index += 1;
+                continue;
+            }
+            return None;
+        }
+        if dialect.php_heredoc {
+            if let Some(end) = php_heredoc_signature_end(&characters, index) {
+                output.push(' ');
+                index = end;
+                regex_allowed = false;
+                continue;
+            }
+        }
+        if let Some(end) = raw_signature_end(&characters, index) {
+            output.push(' ');
+            index = end;
+            regex_allowed = false;
+            continue;
+        }
+        if let Some(end) = template_signature_end(&characters, index) {
+            output.push(' ');
+            index = end;
+            regex_allowed = false;
+            continue;
+        }
+        if let Some(end) = comment_signature_end(&characters, index, dialect) {
+            output.push(' ');
+            index = end;
+            continue;
+        }
+        if characters[index] == '\'' && rust_lifetime_start(&characters, index) {
+            output.push(characters[index]);
+            index += 1;
+            regex_allowed = false;
+            continue;
+        }
+        if matches!(characters[index], '\'' | '"') {
+            output.push(' ');
+            index = quoted_signature_end(&characters, index, dialect);
+            regex_allowed = false;
+            continue;
+        }
+        if dialect.javascript_regex && characters[index] == '/' && regex_allowed {
+            if let Some(end) = js_regex_signature_end(&characters, index) {
+                output.push(' ');
+                index = end;
+                regex_allowed = false;
+                continue;
+            }
+        }
+        if standalone_default_equals(&characters, index, dialect) {
+            output.push(' ');
+            index = skip_signature_default(
+                &characters,
+                index + 1,
+                (parentheses, brackets, braces, angles),
+                dialect,
+            );
+            regex_allowed = true;
+            continue;
+        }
+        let numeric_boundary =
+            index == 0 || !characters[index - 1].is_alphanumeric() && characters[index - 1] != '_';
+        if characters[index].is_ascii_digit() && numeric_boundary {
+            output.push(' ');
+            index += 1;
+            while index < characters.len()
+                && (characters[index].is_alphanumeric()
+                    || matches!(characters[index], '_' | '.' | '+' | '-'))
+            {
+                index += 1;
+            }
+            regex_allowed = false;
+            continue;
+        }
+        match characters[index] {
+            '(' => {
+                parentheses += 1;
+                regex_allowed = true;
+            }
+            ')' => {
+                parentheses = parentheses.saturating_sub(1);
+                regex_allowed = false;
+            }
+            '[' => {
+                brackets += 1;
+                regex_allowed = true;
+            }
+            ']' => {
+                brackets = brackets.saturating_sub(1);
+                regex_allowed = false;
+            }
+            '{' => {
+                braces += 1;
+                regex_allowed = true;
+            }
+            '}' => {
+                braces = braces.saturating_sub(1);
+                regex_allowed = false;
+            }
+            '<' if generic_angle_open(&characters, index) => {
+                angles += 1;
+                regex_allowed = true;
+            }
+            '>' => {
+                angles = angles.saturating_sub(1);
+                regex_allowed = false;
+            }
+            character if character.is_whitespace() => {}
+            '=' | ':' | '?' | '!' | '&' | '|' | '+' | '-' | '*' | '/' | '%' | '^' | '~' | ',' => {
+                regex_allowed = true;
+            }
+            _ => regex_allowed = false,
+        }
+        output.push(characters[index]);
+        index += 1;
+    }
+    Some(output)
+}
+
+fn bounded_concept_field(value: &str, byte_limit: usize) -> Option<String> {
+    let terms = concept_index_terms(value)?;
+    let mut output = String::new();
+    for term in terms.into_iter().take(CONCEPT_INDEX_TERM_LIMIT) {
+        if term.len() > CONCEPT_TERM_MAX_BYTES {
+            continue;
+        }
+        let separator = usize::from(!output.is_empty());
+        if output
+            .len()
+            .saturating_add(separator)
+            .saturating_add(term.len())
+            > byte_limit
+        {
+            break;
+        }
+        if separator == 1 {
+            output.push(' ');
+        }
+        output.push_str(&term);
+    }
+    Some(output)
+}
+
+fn concept_document(name: &str, path: &str, signature: Option<&str>) -> ConceptDocument {
+    let name_search = bounded_concept_field(name, CONCEPT_FIELD_MAX_BYTES).unwrap_or_default();
+    let path_search = bounded_concept_field(path, CONCEPT_FIELD_MAX_BYTES).unwrap_or_default();
+    let signature_search = signature
+        .and_then(|value| redact_signature(value, signature_dialect(path)))
+        .and_then(|value| bounded_concept_field(&value, CONCEPT_SIGNATURE_MAX_BYTES))
+        .unwrap_or_default();
+    ConceptDocument {
+        name_search,
+        path_search,
+        path_sort: concept_path_sort(path),
+        signature_search,
+        documentation_search: String::new(),
+    }
+}
+
+fn insert_concept_document(
+    connection: &Connection,
+    symbol_id: i64,
+    name: &str,
+    path: &str,
+    signature: Option<&str>,
+) -> SqlResult<()> {
+    let document = concept_document(name, path, signature);
+    connection.execute(
+        "INSERT INTO symbol_concepts(
+             symbol_id, name_search, path_search, path_sort, signature_search,
+             documentation_search
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            symbol_id,
+            document.name_search,
+            document.path_search,
+            document.path_sort,
+            document.signature_search,
+            document.documentation_search
+        ],
+    )?;
+    Ok(())
+}
+
 fn highlighted_fts_terms(values: [&str; 2]) -> Vec<String> {
     const START: char = '\u{001e}';
     const END: char = '\u{001f}';
@@ -668,6 +1941,148 @@ fn sqlite_sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
     let mut value = db_path.as_os_str().to_os_string();
     value.push(suffix);
     PathBuf::from(value)
+}
+
+fn normalized_schema_sql(value: &str) -> String {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Quote {
+        Single,
+        Double,
+        Backtick,
+        Bracket,
+    }
+
+    let characters = value.chars().collect::<Vec<_>>();
+    let mut output = String::with_capacity(value.len());
+    let mut quote = None;
+    let mut index = 0usize;
+    while index < characters.len() {
+        let character = characters[index];
+        if let Some(active) = quote {
+            output.push(character);
+            let closing = match active {
+                Quote::Single => '\'',
+                Quote::Double => '"',
+                Quote::Backtick => '`',
+                Quote::Bracket => ']',
+            };
+            if character == closing {
+                if characters.get(index + 1) == Some(&closing) {
+                    output.push(closing);
+                    index += 2;
+                    continue;
+                }
+                quote = None;
+            }
+            index += 1;
+            continue;
+        }
+        quote = match character {
+            '\'' => Some(Quote::Single),
+            '"' => Some(Quote::Double),
+            '`' => Some(Quote::Backtick),
+            '[' => Some(Quote::Bracket),
+            _ => None,
+        };
+        if quote.is_some() {
+            output.push(character);
+        } else if !character.is_whitespace() {
+            output.extend(character.to_lowercase());
+        }
+        index += 1;
+    }
+    output
+}
+
+fn concept_schema_contract() -> &'static [(&'static str, &'static str, String)] {
+    CONCEPT_SCHEMA_CONTRACT.get_or_init(|| {
+        let connection = Connection::open_in_memory()
+            .expect("constant concept schema contract must open an in-memory database");
+        connection
+            .execute_batch(
+                "CREATE TABLE symbols(id INTEGER PRIMARY KEY);
+                 CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+            )
+            .expect("constant concept schema prerequisites must be valid");
+        connection
+            .execute_batch(CONCEPT_SCHEMA_DDL)
+            .expect("constant concept schema DDL must be valid");
+        CONCEPT_SCHEMA_OBJECTS
+            .iter()
+            .map(|&(object_type, name)| {
+                let sql: String = connection
+                    .query_row(
+                        "SELECT sql FROM sqlite_master WHERE type = ?1 AND name = ?2",
+                        params![object_type, name],
+                        |row| row.get(0),
+                    )
+                    .expect("constant concept schema object must exist");
+                (object_type, name, normalized_schema_sql(&sql))
+            })
+            .collect()
+    })
+}
+
+fn schema_object_sql(
+    connection: &Connection,
+    object_type: &str,
+    name: &str,
+) -> SqlResult<Option<String>> {
+    connection
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = ?1 AND name = ?2",
+            params![object_type, name],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .map(Option::flatten)
+}
+
+fn concept_schema_object_current_on(
+    connection: &Connection,
+    object_type: &str,
+    name: &str,
+) -> SqlResult<bool> {
+    let Some((_, _, expected_sql)) =
+        concept_schema_contract()
+            .iter()
+            .find(|(expected_type, expected_name, _)| {
+                *expected_type == object_type && *expected_name == name
+            })
+    else {
+        return Ok(false);
+    };
+    Ok(schema_object_sql(connection, object_type, name)?
+        .is_some_and(|sql| normalized_schema_sql(&sql) == *expected_sql))
+}
+
+fn retire_schema_object_name(connection: &Connection, name: &str) -> SqlResult<()> {
+    let mut statement = connection.prepare(
+        "SELECT type FROM sqlite_master
+         WHERE name = ?1 AND type IN ('trigger', 'index', 'view', 'table')
+         ORDER BY CASE type
+             WHEN 'trigger' THEN 1
+             WHEN 'index' THEN 2
+             WHEN 'view' THEN 3
+             ELSE 4
+         END",
+    )?;
+    let object_types = statement
+        .query_map([name], |row| row.get::<_, String>(0))?
+        .collect::<SqlResult<Vec<_>>>()?;
+    drop(statement);
+    let quoted_name = name.replace('"', "\"\"");
+    for object_type in object_types {
+        let keyword = match object_type.as_str() {
+            "trigger" => "TRIGGER",
+            "index" => "INDEX",
+            "view" => "VIEW",
+            "table" => "TABLE",
+            _ => continue,
+        };
+        connection.execute_batch(&format!("DROP {keyword} IF EXISTS \"{quoted_name}\";"))?;
+    }
+    Ok(())
 }
 
 fn sqlite_bounded_error(
@@ -1165,6 +2580,7 @@ impl Store {
         if !snapshot.schema_current()? {
             return Err(rusqlite::Error::InvalidQuery);
         }
+        snapshot.init_schema()?;
         Ok(snapshot)
     }
 
@@ -1527,6 +2943,7 @@ impl Store {
                     "[mmcg] schema version mismatch (have {:?}, need {}). Rebuilding — re-run `mastermind index <root>` to repopulate.",
                     stored, SCHEMA_VERSION
                 );
+                self.conn.execute_batch(CONCEPT_SCHEMA_DROP_SQL)?;
                 self.conn.execute_batch(
                     r#"
                     DROP TABLE IF EXISTS edges;
@@ -1536,6 +2953,12 @@ impl Store {
                     DROP TABLE IF EXISTS task_specs_fts;
                     "#,
                 )?;
+            } else {
+                // Repair a partially missing FTS5 corpus before the general
+                // CREATE TABLE batch asks SQLite to initialize its broken
+                // virtual-table module. The rebuilt corpus remains dirty until
+                // a successful full index finalizes it.
+                self.ensure_concept_schema()?;
             }
         }
 
@@ -1854,6 +3277,76 @@ impl Store {
              ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             params![SCHEMA_VERSION],
         )?;
+        self.ensure_concept_schema()?;
+        Ok(())
+    }
+
+    fn concept_schema_objects_current_on(connection: &Connection) -> SqlResult<bool> {
+        for (object_type, name, _) in concept_schema_contract() {
+            if !concept_schema_object_current_on(connection, object_type, name)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    pub(crate) fn concept_schema_objects_current(&self) -> SqlResult<bool> {
+        Self::concept_schema_objects_current_on(&self.conn)
+    }
+
+    pub(crate) fn ensure_concept_schema(&self) -> SqlResult<()> {
+        if self.concept_schema_objects_current()? {
+            return Ok(());
+        }
+        let virtual_table_sql = schema_object_sql(&self.conn, "table", "symbol_concepts_fts")?;
+        let virtual_table_uses_fts5 = virtual_table_sql.as_deref().is_some_and(|sql| {
+            let normalized = normalized_schema_sql(sql);
+            normalized.starts_with("createvirtualtable") && normalized.contains("usingfts5(")
+        });
+        let tx = self.conn.unchecked_transaction()?;
+        if virtual_table_uses_fts5 {
+            // SQLite cannot drop an FTS5 virtual table from a newly opened
+            // connection when a generated shadow table is absent or malformed.
+            // Retire wrong-type/wrong-DDL collisions, then recreate only the
+            // disposable minimum needed for the constructor. This same
+            // transaction drops and rebuilds the complete corpus.
+            for shadow in CONCEPT_SHADOW_NAMES {
+                if !concept_schema_object_current_on(&tx, "table", shadow)? {
+                    retire_schema_object_name(&tx, shadow)?;
+                }
+            }
+            tx.execute_batch(CONCEPT_SHADOW_REPAIR_SQL)?;
+            #[cfg(test)]
+            if FAIL_CONCEPT_SCHEMA_AFTER_SHADOW_REPAIR.with(Cell::get) {
+                return Err(rusqlite::Error::InvalidQuery);
+            }
+        } else {
+            // A damaged schema can lose or replace only the virtual-table row
+            // while generated shadows remain. Every name is private derived
+            // state, so retire any table/view/index collision before rebuild.
+            retire_schema_object_name(&tx, "symbol_concepts_fts")?;
+            for shadow in CONCEPT_SHADOW_NAMES {
+                retire_schema_object_name(&tx, shadow)?;
+            }
+        }
+        for trigger in CONCEPT_TRIGGER_NAMES {
+            retire_schema_object_name(&tx, trigger)?;
+        }
+        retire_schema_object_name(&tx, "symbol_concepts_fts")?;
+        for shadow in CONCEPT_SHADOW_NAMES {
+            retire_schema_object_name(&tx, shadow)?;
+        }
+        retire_schema_object_name(&tx, "symbol_concepts")?;
+        tx.execute_batch(CONCEPT_SCHEMA_DDL)?;
+        tx.execute(
+            "INSERT INTO meta(key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![CONCEPT_NORMALIZATION_META_KEY, CONCEPT_CONTRACT_DIRTY],
+        )?;
+        tx.commit()?;
+        if !self.concept_schema_objects_current()? {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
         Ok(())
     }
 
@@ -2632,20 +4125,33 @@ impl Store {
     /// Wipe everything related to a single file before re-indexing it.
     /// Foreign keys CASCADE delete edges + child symbols.
     pub fn purge_file(&self, file_path: &str) -> SqlResult<()> {
-        let tx = self.conn.unchecked_transaction()?;
-        tx.execute(
-            "DELETE FROM symbols WHERE file_path = ?1",
-            params![file_path],
-        )?;
-        tx.execute("DELETE FROM files WHERE path = ?1", params![file_path])?;
-        tx.commit()?;
-        Ok(())
+        let result = (|| {
+            let tx = self.conn.unchecked_transaction()?;
+            let restore_contract = Self::incremental_concept_contract_current_on(&tx)?;
+            tx.execute(
+                "DELETE FROM symbols WHERE file_path = ?1",
+                params![file_path],
+            )?;
+            tx.execute("DELETE FROM files WHERE path = ?1", params![file_path])?;
+            if restore_contract {
+                Self::set_concept_contract_current(&tx)?;
+            }
+            tx.commit()
+        })();
+        if result.is_err() {
+            // A failing delete trigger rolls its dirty-marker write back with the
+            // file transaction. Persist the marker separately so a later file
+            // commit cannot make an unpurged path queryable as current.
+            let _ = self.mark_concept_contract_dirty();
+        }
+        result
     }
 
     /// Commit a parsed file's symbols and edges in a single transaction.
     /// Hot path during indexing — keep it batched.
     pub fn commit_file(&mut self, pending: PendingFile) -> SqlResult<()> {
         let tx = self.conn.transaction()?;
+        let restore_contract = Self::incremental_concept_contract_current_on(&tx)?;
 
         // Purge any existing data for this file.
         tx.execute(
@@ -2681,7 +4187,15 @@ impl Store {
                     s.decorators,
                     production
                 ])?;
-                symbol_ids.push(tx.last_insert_rowid());
+                let symbol_id = tx.last_insert_rowid();
+                insert_concept_document(
+                    &tx,
+                    symbol_id,
+                    &s.name,
+                    &pending.path,
+                    s.signature.as_deref(),
+                )?;
+                symbol_ids.push(symbol_id);
             }
         }
 
@@ -2714,6 +4228,9 @@ impl Store {
             ],
         )?;
 
+        if restore_contract {
+            Self::set_concept_contract_current(&tx)?;
+        }
         tx.commit()?;
         Ok(())
     }
@@ -2729,21 +4246,49 @@ impl Store {
         signature: Option<&str>,
         parent_id: Option<i64>,
     ) -> SqlResult<i64> {
-        self.conn.execute(
-            "INSERT INTO symbols(name, kind, file_path, line_start, line_end, signature, parent_id, production)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            params![
-                name,
-                kind,
-                file_path,
-                line_start,
-                line_end,
-                signature,
-                parent_id,
-                is_production_path(file_path)
-            ],
-        )?;
-        Ok(self.conn.last_insert_rowid())
+        let sequence = INSERT_SYMBOL_SAVEPOINT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let savepoint = format!("mmcg_insert_symbol_{sequence}");
+        self.conn.execute_batch(&format!("SAVEPOINT {savepoint}"))?;
+        let result = (|| {
+            let restore_contract = Self::incremental_concept_contract_current_on(&self.conn)?;
+            self.conn.execute(
+                "INSERT INTO symbols(name, kind, file_path, line_start, line_end, signature, parent_id, production)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    name,
+                    kind,
+                    file_path,
+                    line_start,
+                    line_end,
+                    signature,
+                    parent_id,
+                    is_production_path(file_path)
+                ],
+            )?;
+            let symbol_id = self.conn.last_insert_rowid();
+            insert_concept_document(&self.conn, symbol_id, name, file_path, signature)?;
+            if restore_contract {
+                Self::set_concept_contract_current(&self.conn)?;
+            }
+            Ok(symbol_id)
+        })();
+        match result {
+            Ok(symbol_id) => {
+                if let Err(error) = self.conn.execute_batch(&format!("RELEASE {savepoint}")) {
+                    let _ = self
+                        .conn
+                        .execute_batch(&format!("ROLLBACK TO {savepoint}; RELEASE {savepoint}"));
+                    return Err(error);
+                }
+                Ok(symbol_id)
+            }
+            Err(error) => {
+                let _ = self
+                    .conn
+                    .execute_batch(&format!("ROLLBACK TO {savepoint}; RELEASE {savepoint}"));
+                Err(error)
+            }
+        }
     }
 
     pub fn insert_edge(
@@ -2859,6 +4404,133 @@ impl Store {
             .meta_value(crate::indexer::EXTRACTOR_CONTRACT_META_KEY)?
             .as_deref()
             == Some(crate::indexer::EXTRACTOR_CONTRACT_VERSION))
+    }
+
+    pub fn concept_contract_current(&self) -> SqlResult<bool> {
+        Ok(self.concept_schema_objects_current()?
+            && self.meta_value(CONCEPT_NORMALIZATION_META_KEY)?.as_deref()
+                == Some(CONCEPT_NORMALIZATION_VERSION))
+    }
+
+    fn incremental_concept_contract_current_on(connection: &Connection) -> SqlResult<bool> {
+        if !Self::concept_schema_objects_current_on(connection)? {
+            return Ok(false);
+        }
+        let extractor_contract = connection
+            .query_row(
+                "SELECT value FROM meta WHERE key = ?1",
+                [crate::indexer::EXTRACTOR_CONTRACT_META_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        let concept_contract = connection
+            .query_row(
+                "SELECT value FROM meta WHERE key = ?1",
+                [CONCEPT_NORMALIZATION_META_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(
+            extractor_contract.as_deref() == Some(crate::indexer::EXTRACTOR_CONTRACT_VERSION)
+                && concept_contract.as_deref() == Some(CONCEPT_NORMALIZATION_VERSION),
+        )
+    }
+
+    pub(crate) fn mark_concept_contract_dirty(&self) -> SqlResult<()> {
+        self.conn.execute(
+            "INSERT INTO meta(key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![CONCEPT_NORMALIZATION_META_KEY, CONCEPT_CONTRACT_DIRTY],
+        )?;
+        Ok(())
+    }
+
+    fn set_concept_contract_current(connection: &Connection) -> SqlResult<()> {
+        connection.execute(
+            "INSERT INTO meta(key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![
+                CONCEPT_NORMALIZATION_META_KEY,
+                CONCEPT_NORMALIZATION_VERSION
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn finalize_index_contracts_current(&self) -> SqlResult<ConceptFinalizeStats> {
+        self.ensure_concept_schema()?;
+        let tx = self.conn.unchecked_transaction()?;
+        let orphans_purged = tx.execute(
+            "DELETE FROM symbol_concepts
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM symbols WHERE symbols.id = symbol_concepts.symbol_id
+             )",
+            [],
+        )?;
+        let missing: i64 = tx.query_row(
+            "SELECT COUNT(*)
+             FROM symbols s
+             LEFT JOIN symbol_concepts c ON c.symbol_id = s.id
+             WHERE c.symbol_id IS NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        if missing != 0 {
+            return Err(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+                Some(format!(
+                    "concept finalization found {missing} symbols without concept rows"
+                )),
+            ));
+        }
+        tx.execute(
+            "INSERT INTO symbol_concepts_fts(symbol_concepts_fts) VALUES ('rebuild')",
+            [],
+        )?;
+        tx.execute(
+            "INSERT INTO symbol_concepts_fts(symbol_concepts_fts, rank)
+             VALUES ('integrity-check', 1)",
+            [],
+        )?;
+        tx.execute(
+            "INSERT INTO meta(key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            params![
+                crate::indexer::EXTRACTOR_CONTRACT_META_KEY,
+                crate::indexer::EXTRACTOR_CONTRACT_VERSION
+            ],
+        )?;
+        tx.execute(
+            "INSERT INTO meta(key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![
+                CONCEPT_NORMALIZATION_META_KEY,
+                CONCEPT_NORMALIZATION_VERSION
+            ],
+        )?;
+        let rows: u32 =
+            tx.query_row("SELECT COUNT(*) FROM symbol_concepts", [], |row| row.get(0))?;
+        tx.commit()?;
+        Ok(ConceptFinalizeStats {
+            rows,
+            orphans_purged: u32::try_from(orphans_purged).unwrap_or(u32::MAX),
+        })
+    }
+
+    pub fn concept_count(&self) -> SqlResult<u32> {
+        self.conn
+            .query_row("SELECT COUNT(*) FROM symbol_concepts", [], |row| row.get(0))
+    }
+
+    pub(crate) fn purge_orphan_concepts(&self) -> SqlResult<u32> {
+        let changed = self.conn.execute(
+            "DELETE FROM symbol_concepts
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM symbols WHERE symbols.id = symbol_concepts.symbol_id
+             )",
+            [],
+        )?;
+        Ok(u32::try_from(changed).unwrap_or(u32::MAX))
     }
 
     pub fn data_version(&self) -> SqlResult<u64> {
@@ -4376,6 +6048,65 @@ impl Store {
         rows.collect()
     }
 
+    pub(crate) fn search_concepts(
+        &self,
+        match_query: &str,
+        top: u32,
+    ) -> SqlResult<Vec<ConceptStoreHit>> {
+        let mut statement = self.conn.prepare(
+            "SELECT s.name,
+                    s.kind,
+                    s.language,
+                    s.file_path,
+                    s.line_start,
+                    c.signature_search,
+                    instr(
+                        highlight(symbol_concepts_fts, 0, char(30), char(31)),
+                        char(30)
+                    ) > 0 AS name_matched,
+                    instr(
+                        highlight(symbol_concepts_fts, 1, char(30), char(31)),
+                        char(30)
+                    ) > 0 AS path_matched,
+                    instr(
+                        highlight(symbol_concepts_fts, 2, char(30), char(31)),
+                        char(30)
+                    ) > 0 AS signature_matched,
+                    instr(
+                        highlight(symbol_concepts_fts, 3, char(30), char(31)),
+                        char(30)
+                    ) > 0 AS documentation_matched,
+                    bm25(symbol_concepts_fts, 10.0, 4.0, 2.0, 1.0) AS score
+             FROM symbol_concepts_fts
+             JOIN symbol_concepts c ON c.symbol_id = symbol_concepts_fts.rowid
+             JOIN symbols s ON s.id = c.symbol_id
+             WHERE symbol_concepts_fts MATCH ?1
+             ORDER BY score ASC,
+                      c.path_sort COLLATE BINARY ASC,
+                      s.line_start ASC,
+                      s.kind COLLATE BINARY ASC,
+                      s.name COLLATE BINARY ASC,
+                      s.id ASC
+            LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![match_query, top], |row| {
+            Ok(ConceptStoreHit {
+                name: row.get(0)?,
+                kind: row.get(1)?,
+                language: row.get(2)?,
+                path: row.get(3)?,
+                line: row.get(4)?,
+                signature_shape: row.get(5)?,
+                name_matched: row.get(6)?,
+                path_matched: row.get(7)?,
+                signature_matched: row.get(8)?,
+                documentation_matched: row.get(9)?,
+                score: row.get(10)?,
+            })
+        })?;
+        rows.collect()
+    }
+
     /// Deterministic bounded read of the derived project-history corpus for
     /// local evidence correlation. Markdown remains authoritative.
     pub fn project_history_entries_bounded(
@@ -4976,6 +6707,40 @@ mod tests {
             Some("snapshot")
         );
         assert!(!snapshot.db_path().starts_with(directory.path()));
+        assert_eq!(directory_bytes(directory.path()), before);
+    }
+
+    #[test]
+    fn private_temporal_snapshot_adds_concepts_only_to_old_v7_clone_and_stays_dirty() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("old-v7.db");
+        {
+            let source = Store::open(&path).unwrap();
+            source
+                .insert_symbol("legacy", "function", "src/lib.rs", 1, 2, None, None)
+                .unwrap();
+            source.upsert_file("src/lib.rs", 1, 1).unwrap();
+            source.conn.execute_batch(CONCEPT_SCHEMA_DROP_SQL).unwrap();
+            source
+                .conn
+                .execute(
+                    "DELETE FROM meta WHERE key = ?1",
+                    [CONCEPT_NORMALIZATION_META_KEY],
+                )
+                .unwrap();
+            assert!(!source.concept_schema_objects_current().unwrap());
+        }
+        let before = directory_bytes(directory.path());
+        let source = Store::open_read_only(&path).unwrap();
+        let snapshot = source.private_writable_snapshot().unwrap();
+
+        assert!(snapshot.concept_schema_objects_current().unwrap());
+        assert!(!snapshot.concept_contract_current().unwrap());
+        snapshot.purge_file("src/lib.rs").unwrap();
+        assert_eq!(snapshot.symbol_count().unwrap(), 0);
+        assert!(!snapshot.concept_contract_current().unwrap());
+        assert_eq!(source.symbol_count().unwrap(), 1);
+        assert!(!source.concept_schema_objects_current().unwrap());
         assert_eq!(directory_bytes(directory.path()), before);
     }
 
@@ -7406,5 +9171,593 @@ mod tests {
         assert!(truncated);
         assert!(cycles.is_empty());
         std::fs::remove_file(&path).ok();
+    }
+
+    fn concept_signature_terms_for(path: &str, signature: &str) -> Vec<String> {
+        concept_document("fixture", path, Some(signature))
+            .signature_search
+            .split_whitespace()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn concept_signature_terms(signature: &str) -> Vec<String> {
+        concept_signature_terms_for("src/fixture.rs", signature)
+    }
+
+    #[test]
+    fn concept_normalization_splits_digits_identifiers_and_unicode_lowercase() {
+        let terms =
+            concept_terms("sha256Digest HTTP2Server OAuth2Client path/to_file-name").unwrap();
+        for expected in [
+            "sha256digest",
+            "sha",
+            "256",
+            "digest",
+            "http2server",
+            "http",
+            "2",
+            "server",
+            "oauth2client",
+            "auth",
+            "client",
+            "tofilename",
+            "to",
+            "file",
+            "name",
+        ] {
+            assert!(
+                terms.iter().any(|term| term == expected),
+                "missing {expected:?}"
+            );
+        }
+
+        let expanded = concept_terms("İValue").unwrap();
+        assert!(expanded.iter().any(|term| term == "i\u{307}value"));
+        assert!(expanded.iter().any(|term| term == "i\u{307}"));
+        assert!(expanded.iter().any(|term| term == "value"));
+    }
+
+    #[test]
+    fn concept_signature_redaction_omits_comments_literals_templates_and_regexes() {
+        let multiline = concept_signature_terms(
+            "fn borrow<'a>(\n\t/* TOPSECRET */ x: &'a str,\n y: ImportantType, c: char = 'X'\n) -> &'a str",
+        );
+        for expected in ["borrow", "a", "str", "importanttype"] {
+            assert!(
+                multiline.iter().any(|term| term == expected),
+                "missing {expected:?}"
+            );
+        }
+        assert!(!multiline.iter().any(|term| term.contains("topsecret")));
+
+        let python_comment = concept_signature_terms_for(
+            "src/fixture.py",
+            "def borrow(x: str, # OTHERSECRET\n y: ImportantType): ...",
+        );
+        assert!(python_comment.iter().any(|term| term == "importanttype"));
+        assert!(!python_comment
+            .iter()
+            .any(|term| term.contains("othersecret")));
+
+        let rust_attributes = concept_signature_terms_for(
+            "src/fixture.rs",
+            "#[inline] pub fn r#match<'a>(x: &'a str) -> &'a str",
+        );
+        for expected in ["inline", "match", "a", "str"] {
+            assert!(
+                rust_attributes.iter().any(|term| term == expected),
+                "missing {expected:?}: {rust_attributes:?}"
+            );
+        }
+
+        for signature in [
+            "function f(x = `prefix,TOPSECRET`, y: ImportantType) {}",
+            "function f(x = /a,b/, y: ImportantType) {}",
+            "function f(x = /[/,]TOPSECRET/u, y: ImportantType) {}",
+            r"function f(x = /a\/,TOPSECRET/u, y: ImportantType) {}",
+            "function f(x = a < b, y: ImportantType) {}",
+            "function f(x = value < limit, y: ImportantType) {}",
+            "function f(x = value <= limit, y: ImportantType) {}",
+            "function f(x = low < value && value < high, y: ImportantType) {}",
+            "void f(int x = 1 << 2, ImportantType y={})",
+            "function f(x = new Map<Key,Value>(), y: ImportantType) {}",
+            "function f(x = amount / /prefix,TOPSECRET/.test(v), y: ImportantType) {}",
+            "function f(x = `value ${a / b}`, y: ImportantType) {}",
+            "function f(x = `value ${/TOPSECRET/.test(v)}`, y: ImportantType) {}",
+            "function f(x = `${typeof /[}]`PREFIX,TOPSECRET/}`, y: ImportantType) {}",
+        ] {
+            let terms = concept_signature_terms_for("src/fixture.ts", signature);
+            assert!(
+                terms.iter().any(|term| term == "importanttype"),
+                "following declaration token lost for {signature:?}: {terms:?}"
+            );
+            assert!(
+                !terms.iter().any(|term| term.contains("topsecret")),
+                "literal leaked for {signature:?}: {terms:?}"
+            );
+        }
+
+        for hash_count in [0usize, 1, 16, 17, 255] {
+            let hashes = "#".repeat(hash_count);
+            let content = if hash_count == 0 {
+                "TOPSECRET"
+            } else {
+                "inside \",TOPSECRET"
+            };
+            let signature = format!(
+                "fn borrow<'a>(x: &'a str = r{hashes}\"{content}\"{hashes}, y: ImportantType)"
+            );
+            let terms = concept_signature_terms(&signature);
+            assert!(terms.iter().any(|term| term == "importanttype"));
+            assert!(!terms.iter().any(|term| term.contains("topsecret")));
+            assert!(terms.iter().any(|term| term == "a"));
+        }
+        let c_raw =
+            concept_signature_terms("fn f(x: str = cr#\"inside \",TOPSECRET\"#, y: ImportantType)");
+        assert!(c_raw.iter().any(|term| term == "importanttype"));
+        assert!(!c_raw.iter().any(|term| term.contains("topsecret")));
+
+        for prefix in ["R", "u8R", "uR", "UR", "LR"] {
+            let signature = format!(
+                "void f(const char* x = {prefix}\"tag(before\",TOPSECRET)tag\", ImportantType y={{}})"
+            );
+            let terms = concept_signature_terms_for("src/fixture.cpp", &signature);
+            assert!(
+                terms.iter().any(|term| term == "importanttype"),
+                "following declaration token lost for {signature:?}: {terms:?}"
+            );
+            assert!(
+                !terms.iter().any(|term| term.contains("topsecret")),
+                "raw literal leaked for {signature:?}: {terms:?}"
+            );
+        }
+
+        for (path, signature, retained) in [
+            (
+                "src/fixture.ts",
+                "function f(x = `outer ${`inner,TOPSECRET`}`, y: ImportantType) {}",
+                "importanttype",
+            ),
+            (
+                "src/fixture.cs",
+                r#"[Label(""""prefix """ TOPSECRET"""")] public void F()"#,
+                "void",
+            ),
+            (
+                "src/fixture.ts",
+                "@Matches(/TOPSECRET/) class Candidate {}",
+                "candidate",
+            ),
+            (
+                "src/fixture.py",
+                "def f(cb=lambda a, TOPSECRET: a, y: ImportantType): ...",
+                "importanttype",
+            ),
+            (
+                "src/fixture.cs",
+                r#"[Label($"{ "TOPSECRET" }")] public void Interpolated()"#,
+                "interpolated",
+            ),
+            (
+                "src/fixture.cs",
+                r#"[Label($@"{ "TOPSECRET" }")] public void VerbatimInterpolated()"#,
+                "verbatiminterpolated",
+            ),
+            (
+                "src/fixture.py",
+                "@label(f\"{ \"TOPSECRET\" }\")\ndef decorated() -> ImportantType: ...",
+                "importanttype",
+            ),
+            (
+                "src/fixture.rs",
+                "fn f(/* outer /* inner */ TOPSECRET */ x: ImportantType)",
+                "importanttype",
+            ),
+            (
+                "src/fixture.cpp",
+                "void f(auto x = Foo<1, TOPSECRET>{}, ImportantType y={})",
+                "importanttype",
+            ),
+            (
+                "src/fixture.ts",
+                "function f(x = Foo<\"x\", TOPSECRET>(), y: ImportantType) {}",
+                "importanttype",
+            ),
+        ] {
+            let terms = concept_signature_terms_for(path, signature);
+            assert!(
+                terms.iter().any(|term| term == retained),
+                "following declaration token lost for {signature:?}: {terms:?}"
+            );
+            assert!(
+                !terms.iter().any(|term| term.contains("topsecret")),
+                "literal/default leaked for {signature:?}: {terms:?}"
+            );
+        }
+
+        for signature in [
+            "Widget& operator=(const Widget& other)",
+            "Widget& operator+=(const Widget& other)",
+        ] {
+            let terms = concept_signature_terms_for("src/fixture.cpp", signature);
+            assert!(terms.iter().any(|term| term == "operator"));
+            assert!(terms.iter().any(|term| term == "widget"));
+            assert!(terms.iter().any(|term| term == "other"));
+        }
+
+        for path in ["src/fixture.mjs", "src/fixture.cjs"] {
+            let terms = concept_signature_terms_for(
+                path,
+                "function f(x = /prefix,TOPSECRET/, y: ImportantType) {}",
+            );
+            assert!(terms.iter().any(|term| term == "importanttype"));
+            assert!(!terms.iter().any(|term| term.contains("topsecret")));
+        }
+        let phtml = concept_signature_terms_for(
+            "src/fixture.phtml",
+            "function f($x, # TOPSECRET\n ImportantType $y)",
+        );
+        assert!(phtml.iter().any(|term| term == "importanttype"));
+        assert!(!phtml.iter().any(|term| term.contains("topsecret")));
+        for path in ["src/fixture.ipp", "src/fixture.tpp"] {
+            let terms =
+                concept_signature_terms_for(path, "Widget& operator+=(const Widget& other)");
+            assert!(terms.iter().any(|term| term == "operator"));
+            assert!(terms.iter().any(|term| term == "other"));
+        }
+
+        for signature in [
+            "function f($x = <<<LABEL\nprefix,TOPSECRET\n    LABEL,\n ImportantType $y = null) {}",
+            "function f($x = <<<'LABEL'\nprefix,TOPSECRET\nLABEL;\n, ImportantType $y = null) {}",
+        ] {
+            let terms = concept_signature_terms_for("src/fixture.php", signature);
+            assert!(
+                terms.iter().any(|term| term == "importanttype"),
+                "following declaration token lost for heredoc {terms:?}"
+            );
+            assert!(
+                !terms.iter().any(|term| term.contains("topsecret")),
+                "heredoc leaked into corpus: {terms:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn concept_persisted_corpus_never_contains_signature_canaries() {
+        let path = tmp_db("concept_signature_canaries");
+        let store = Store::open(&path).unwrap();
+        for (index, (source_path, signature)) in [
+            (
+                "src/template.ts",
+                "function template(x = `outer ${`inner,TOPSECRET`}`, y: ImportantType) {}",
+            ),
+            (
+                "src/raw.cs",
+                r#"[Label(""""prefix """ TOPSECRET"""")] public void RawCandidate()"#,
+            ),
+            (
+                "src/decorator.ts",
+                "@Matches(/TOPSECRET/) class RegexCandidate {}",
+            ),
+            (
+                "src/lambda.py",
+                "def lambda_candidate(cb=lambda a, TOPSECRET: a, y: ImportantType): ...",
+            ),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            store
+                .insert_symbol(
+                    &format!("candidate_{index}"),
+                    "function",
+                    source_path,
+                    1,
+                    1,
+                    Some(signature),
+                    None,
+                )
+                .unwrap();
+        }
+        store.finalize_index_contracts_current().unwrap();
+
+        assert!(store
+            .search_concepts("\"topsecret\"", 50)
+            .unwrap()
+            .is_empty());
+        let documents = store
+            .conn
+            .prepare("SELECT signature_search FROM symbol_concepts ORDER BY symbol_id")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<SqlResult<Vec<_>>>()
+            .unwrap();
+        assert_eq!(documents.len(), 4);
+        assert!(documents
+            .iter()
+            .all(|document| !document.to_ascii_lowercase().contains("topsecret")));
+        assert!(!store
+            .search_concepts("\"importanttype\"", 50)
+            .unwrap()
+            .is_empty());
+        assert!(!store
+            .search_concepts("\"candidate\"", 50)
+            .unwrap()
+            .is_empty());
+
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn concept_insert_symbol_savepoint_nests_and_rolls_back_both_rows() {
+        let path = tmp_db("concept_nested_savepoint");
+        let store = Store::open(&path).unwrap();
+        store
+            .insert_symbol(
+                "firstHandler",
+                "function",
+                "src/first.rs",
+                1,
+                2,
+                Some("fn first_handler()"),
+                None,
+            )
+            .unwrap();
+        store.finalize_index_contracts_current().unwrap();
+        assert!(store.concept_contract_current().unwrap());
+        assert_eq!(store.symbol_count().unwrap(), 1);
+        assert_eq!(store.concept_count().unwrap(), 1);
+
+        store.conn.execute_batch("BEGIN").unwrap();
+        store
+            .insert_symbol(
+                "secondHandler",
+                "function",
+                "src/second.rs",
+                1,
+                2,
+                Some("fn second_handler()"),
+                None,
+            )
+            .unwrap();
+        assert_eq!(store.symbol_count().unwrap(), 2);
+        assert_eq!(store.concept_count().unwrap(), 2);
+        store.conn.execute_batch("ROLLBACK").unwrap();
+
+        assert_eq!(store.symbol_count().unwrap(), 1);
+        assert_eq!(store.concept_count().unwrap(), 1);
+        assert!(store.concept_contract_current().unwrap());
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn concept_old_writer_dirty_marker_blocks_incomplete_finalization() {
+        let path = tmp_db("concept_old_writer_dirty");
+        let store = Store::open(&path).unwrap();
+        store
+            .insert_symbol("ready", "function", "src/ready.rs", 1, 2, None, None)
+            .unwrap();
+        store.finalize_index_contracts_current().unwrap();
+        assert!(store.concept_contract_current().unwrap());
+
+        store
+            .conn
+            .execute(
+                "INSERT INTO symbols(name, kind, file_path, line_start, line_end)
+                 VALUES ('legacy_only', 'function', 'src/legacy.rs', 1, 2)",
+                [],
+            )
+            .unwrap();
+        assert!(!store.concept_contract_current().unwrap());
+        assert!(store.finalize_index_contracts_current().is_err());
+        assert!(!store.concept_contract_current().unwrap());
+
+        store
+            .conn
+            .execute("DELETE FROM symbols WHERE name = 'legacy_only'", [])
+            .unwrap();
+        store.finalize_index_contracts_current().unwrap();
+        assert!(store.concept_contract_current().unwrap());
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn concept_schema_object_drift_repairs_additively_and_stays_dirty() {
+        let path = tmp_db("concept_schema_object_drift");
+        let store = Store::open(&path).unwrap();
+        store.finalize_index_contracts_current().unwrap();
+        assert!(store.concept_contract_current().unwrap());
+        store
+            .conn
+            .execute_batch("DROP TRIGGER symbol_concepts_ai")
+            .unwrap();
+        assert!(!store.concept_contract_current().unwrap());
+
+        store.ensure_concept_schema().unwrap();
+        assert!(store.concept_schema_objects_current().unwrap());
+        assert!(!store.concept_contract_current().unwrap());
+        store.finalize_index_contracts_current().unwrap();
+        assert!(store.concept_contract_current().unwrap());
+
+        store
+            .conn
+            .execute_batch(
+                "DROP TRIGGER symbol_concepts_ai;
+                 CREATE TRIGGER symbol_concepts_ai
+                 AFTER INSERT ON symbol_concepts BEGIN
+                     INSERT INTO symbol_concepts_fts(
+                         rowid, name_search, path_search, signature_search,
+                         documentation_search
+                     ) VALUES (
+                         new.symbol_id, new.name_search, new.path_search,
+                         new.signature_search, new.documentation_search
+                     );
+                     INSERT INTO meta(key, value) VALUES ('unexpected', 'extra');
+                 END;",
+            )
+            .unwrap();
+        assert!(!store.concept_schema_objects_current().unwrap());
+        store.ensure_concept_schema().unwrap();
+        assert!(store.concept_schema_objects_current().unwrap());
+        assert!(!store.concept_contract_current().unwrap());
+
+        store
+            .conn
+            .execute_batch(
+                "DROP TRIGGER symbol_concepts_graph_ai;
+                 CREATE TRIGGER symbol_concepts_graph_ai
+                 AFTER INSERT ON symbols BEGIN
+                     INSERT INTO meta(key, value)
+                     VALUES ('CONCEPT_NORMALIZATION_VERSION', 'dirty')
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                     WHERE meta.value <> excluded.value;
+                 END;",
+            )
+            .unwrap();
+        assert!(!store.concept_schema_objects_current().unwrap());
+        store.ensure_concept_schema().unwrap();
+        assert!(store.concept_schema_objects_current().unwrap());
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn concept_schema_contract_checks_and_repairs_every_fts_shadow_table() {
+        for shadow in ["config", "data", "docsize", "idx"] {
+            let path = tmp_db(&format!("concept_shadow_{shadow}"));
+            let store = Store::open(&path).unwrap();
+            store.finalize_index_contracts_current().unwrap();
+            assert!(store.concept_contract_current().unwrap());
+
+            store
+                .conn
+                .execute_batch(&format!("DROP TABLE symbol_concepts_fts_{shadow}"))
+                .unwrap();
+            assert!(!store.concept_schema_objects_current().unwrap());
+            assert!(!store.concept_contract_current().unwrap());
+
+            store.ensure_concept_schema().unwrap();
+            assert!(store.concept_schema_objects_current().unwrap());
+            assert!(!store.concept_contract_current().unwrap());
+            store.finalize_index_contracts_current().unwrap();
+            assert!(store.concept_contract_current().unwrap());
+            std::fs::remove_file(path).ok();
+        }
+    }
+
+    #[test]
+    fn concept_shadow_repair_and_dirty_rebuild_are_one_transaction() {
+        let path = tmp_db("concept_shadow_repair_atomic");
+        let store = Store::open(&path).unwrap();
+        store.finalize_index_contracts_current().unwrap();
+        store
+            .conn
+            .execute_batch("DROP TABLE symbol_concepts_fts_data")
+            .unwrap();
+        assert!(!store.concept_schema_objects_current().unwrap());
+        assert_eq!(
+            store
+                .meta_value(CONCEPT_NORMALIZATION_META_KEY)
+                .unwrap()
+                .as_deref(),
+            Some(CONCEPT_NORMALIZATION_VERSION)
+        );
+
+        FAIL_CONCEPT_SCHEMA_AFTER_SHADOW_REPAIR.set(true);
+        let result = store.ensure_concept_schema();
+        FAIL_CONCEPT_SCHEMA_AFTER_SHADOW_REPAIR.set(false);
+        assert!(result.is_err());
+        assert!(!store.concept_schema_objects_current().unwrap());
+        assert!(!store.concept_contract_current().unwrap());
+
+        store.ensure_concept_schema().unwrap();
+        assert!(store.concept_schema_objects_current().unwrap());
+        assert!(!store.concept_contract_current().unwrap());
+        store.finalize_index_contracts_current().unwrap();
+        assert!(store.concept_contract_current().unwrap());
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn concept_schema_repair_retires_orphaned_fts_shadow_tables() {
+        let path = tmp_db("concept_orphan_shadows");
+        let store = Store::open(&path).unwrap();
+        store.finalize_index_contracts_current().unwrap();
+        store
+            .conn
+            .execute_batch(
+                "PRAGMA writable_schema = ON;
+                 DELETE FROM sqlite_master
+                 WHERE type = 'table' AND name = 'symbol_concepts_fts';
+                 PRAGMA writable_schema = OFF;
+                 PRAGMA schema_version = 99;",
+            )
+            .unwrap();
+        assert!(!store.concept_schema_objects_current().unwrap());
+        let orphan_count: u32 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type = 'table' AND name GLOB 'symbol_concepts_fts_*'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphan_count, 4);
+
+        store.ensure_concept_schema().unwrap();
+        assert!(store.concept_schema_objects_current().unwrap());
+        assert!(!store.concept_contract_current().unwrap());
+        store.finalize_index_contracts_current().unwrap();
+        assert!(store.concept_contract_current().unwrap());
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn concept_schema_repair_retires_wrong_type_owned_objects() {
+        for (name, corruption) in [
+            (
+                "shadow_view",
+                "DROP TABLE symbol_concepts_fts_data;
+                 CREATE VIEW symbol_concepts_fts_data AS SELECT 1 AS id, x'' AS block;",
+            ),
+            (
+                "shadow_table",
+                "DROP TABLE symbol_concepts_fts_data;
+                 CREATE TABLE symbol_concepts_fts_data(
+                     id INTEGER PRIMARY KEY, wrong_column TEXT
+                 );",
+            ),
+            (
+                "virtual_view",
+                "DROP TABLE symbol_concepts_fts;
+                 CREATE VIEW symbol_concepts_fts AS SELECT 1 AS rowid;",
+            ),
+            (
+                "content_view",
+                "DROP TABLE symbol_concepts_fts;
+                 DROP TABLE symbol_concepts;
+                 CREATE VIEW symbol_concepts AS SELECT 1 AS symbol_id;",
+            ),
+            (
+                "trigger_view",
+                "DROP TRIGGER symbol_concepts_ai;
+                 CREATE VIEW symbol_concepts_ai AS SELECT 1 AS value;",
+            ),
+        ] {
+            let path = tmp_db(&format!("concept_wrong_type_{name}"));
+            let store = Store::open(&path).unwrap();
+            store.finalize_index_contracts_current().unwrap();
+            store.conn.execute_batch(corruption).unwrap();
+            assert!(!store.concept_schema_objects_current().unwrap());
+
+            store.ensure_concept_schema().unwrap();
+            assert!(store.concept_schema_objects_current().unwrap());
+            assert!(!store.concept_contract_current().unwrap());
+            store.finalize_index_contracts_current().unwrap();
+            assert!(store.concept_contract_current().unwrap());
+            std::fs::remove_file(path).ok();
+        }
     }
 }

--- a/mcp/servers/mmcg/src/watcher.rs
+++ b/mcp/servers/mmcg/src/watcher.rs
@@ -10,6 +10,7 @@
 
 use crate::indexer::{extractor_for_path, IndexError, Indexer, SourceMatcher};
 use crate::store::Store;
+use notify::event::{ModifyKind, RenameMode};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -100,6 +101,82 @@ fn handle_event(
     }
 
     match event.kind {
+        EventKind::Modify(ModifyKind::Name(rename_mode)) => {
+            let paths = event.paths;
+            let indexed_paths = match store.indexed_paths() {
+                Ok(paths) => paths,
+                Err(error) => {
+                    eprintln!("[mastermind watch] rename inventory failed: {error}");
+                    Vec::new()
+                }
+            };
+            let mut purge_paths = Vec::new();
+            let mut full_refresh = indexed_paths.is_empty()
+                || matches!(
+                    rename_mode,
+                    RenameMode::To | RenameMode::Any | RenameMode::Other
+                );
+
+            for (position, path) in paths.iter().enumerate() {
+                pending.remove(path);
+                if path.is_dir() {
+                    full_refresh = true;
+                }
+                if path.exists() && !rename_event_path_is_old(&rename_mode, position) {
+                    continue;
+                }
+                if let Some(rel) = relative_path(path, root) {
+                    let descendant_prefix = format!("{rel}/");
+                    let mut matched = false;
+                    for indexed in &indexed_paths {
+                        if indexed == &rel || indexed.starts_with(&descendant_prefix) {
+                            if indexed.starts_with(&descendant_prefix) {
+                                full_refresh = true;
+                            }
+                            purge_paths.push(indexed.clone());
+                            matched = true;
+                        }
+                    }
+                    if !matched {
+                        purge_paths.push(rel);
+                    }
+                }
+            }
+            purge_paths.sort();
+            purge_paths.dedup();
+            for rel in purge_paths {
+                if let Err(error) = store.purge_file(&rel) {
+                    eprintln!("[mastermind watch] rename purge failed {rel}: {error}");
+                    full_refresh = true;
+                } else {
+                    eprintln!("[mastermind watch] rename purged {rel}");
+                }
+            }
+
+            if full_refresh {
+                pending.clear();
+                match indexer.index_all(store, false) {
+                    Ok(stats) => eprintln!(
+                        "[mastermind watch] rename refresh: indexed {} (unchanged {}, purged {})",
+                        stats.files_indexed, stats.files_unchanged, stats.files_purged
+                    ),
+                    Err(error) => eprintln!("[mastermind watch] rename refresh failed: {error}"),
+                }
+                return;
+            }
+
+            for (position, path) in paths.into_iter().enumerate() {
+                if rename_event_path_is_old(&rename_mode, position) {
+                    continue;
+                }
+                if path.is_file()
+                    && extractor_for_path(&path).is_some()
+                    && !source_matcher.is_ignored(&path, false)
+                {
+                    pending.insert(path, Instant::now());
+                }
+            }
+        }
         EventKind::Modify(_) | EventKind::Create(_) => {
             for path in event.paths {
                 if path.is_file()
@@ -111,15 +188,45 @@ fn handle_event(
             }
         }
         EventKind::Remove(_) => {
-            for path in event.paths {
-                if let Some(rel) = relative_path(&path, root) {
-                    // Drop from pending — a quick rm + write would otherwise re-add it.
-                    pending.remove(&path);
-                    if let Err(e) = store.purge_file(&rel) {
-                        eprintln!("[mastermind watch] purge failed {rel}: {e}");
-                    } else {
-                        eprintln!("[mastermind watch] purged {rel}");
+            let indexed_paths = match store.indexed_paths() {
+                Ok(paths) => paths,
+                Err(error) => {
+                    eprintln!("[mastermind watch] removal inventory failed: {error}");
+                    match indexer.index_all(store, false) {
+                        Ok(_) => {}
+                        Err(refresh_error) => {
+                            eprintln!("[mastermind watch] removal refresh failed: {refresh_error}");
+                        }
                     }
+                    return;
+                }
+            };
+            let mut purge_paths = Vec::new();
+            for path in event.paths {
+                // Drop descendants too — a directory remove otherwise leaves
+                // debounced child paths able to re-enter the index.
+                pending.retain(|candidate, _| !candidate.starts_with(&path));
+                if let Some(rel) = relative_path(&path, root) {
+                    let descendant_prefix = format!("{rel}/");
+                    let mut matched = false;
+                    for indexed in &indexed_paths {
+                        if indexed == &rel || indexed.starts_with(&descendant_prefix) {
+                            purge_paths.push(indexed.clone());
+                            matched = true;
+                        }
+                    }
+                    if !matched {
+                        purge_paths.push(rel);
+                    }
+                }
+            }
+            purge_paths.sort();
+            purge_paths.dedup();
+            for rel in purge_paths {
+                if let Err(error) = store.purge_file(&rel) {
+                    eprintln!("[mastermind watch] purge failed {rel}: {error}");
+                } else {
+                    eprintln!("[mastermind watch] purged {rel}");
                 }
             }
         }
@@ -157,6 +264,10 @@ fn relative_path(absolute: &Path, root: &Path) -> Option<String> {
         .map(|p| p.to_string_lossy().replace('\\', "/"))
 }
 
+fn rename_event_path_is_old(mode: &RenameMode, position: usize) -> bool {
+    matches!(mode, &RenameMode::From) || matches!(mode, &RenameMode::Both) && position == 0
+}
+
 fn is_ignore_config(path: &Path, root: &Path) -> bool {
     if path
         .file_name()
@@ -182,7 +293,6 @@ fn is_project_history_path(path: &Path, root: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use notify::event::ModifyKind;
 
     #[test]
     fn changing_ignore_rules_rebuilds_matcher_and_purges_newly_ignored_files() {
@@ -247,6 +357,214 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[test]
+    fn rename_event_purges_old_graph_and_concept_path_before_reindexing_new_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join(".mastermind")).unwrap();
+        let old_path = root.join("old_handler.rs");
+        let new_path = root.join("new_handler.rs");
+        std::fs::write(&old_path, "pub fn renamed_handler() {}\n").unwrap();
+        let mut store = Store::open(root.join(".mastermind/mmcg.db")).unwrap();
+        let indexer = Indexer::new(&root);
+        indexer.index_all(&mut store, false).unwrap();
+        assert_eq!(store.search_concepts("\"old\"", 10).unwrap().len(), 2);
+
+        std::fs::rename(&old_path, &new_path).unwrap();
+        let event = notify::Event::new(EventKind::Modify(ModifyKind::Name(
+            notify::event::RenameMode::Both,
+        )))
+        .add_path(old_path.clone())
+        .add_path(new_path.clone());
+        let mut matcher = SourceMatcher::new(&root);
+        let mut pending = HashMap::new();
+        handle_event(
+            event,
+            &root,
+            &indexer,
+            &mut matcher,
+            &mut pending,
+            &mut store,
+        );
+
+        assert!(store.symbols_in_file("old_handler.rs").unwrap().is_empty());
+        assert!(store.search_concepts("\"old\"", 10).unwrap().is_empty());
+        assert!(pending.contains_key(&new_path));
+        pending.insert(new_path, Instant::now() - DEBOUNCE);
+        flush_settled(&indexer, &mut store, &mut pending);
+
+        assert_eq!(store.symbols_in_file("new_handler.rs").unwrap().len(), 2);
+        assert_eq!(store.search_concepts("\"new\"", 10).unwrap().len(), 2);
+        assert!(store.concept_contract_current().unwrap());
+    }
+
+    #[test]
+    fn directory_rename_purges_all_old_paths_and_indexes_the_new_tree() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join("old/nested")).unwrap();
+        std::fs::create_dir_all(root.join(".mastermind")).unwrap();
+        std::fs::write(root.join("old/first.rs"), "pub fn first_handler() {}\n").unwrap();
+        std::fs::write(
+            root.join("old/nested/second.py"),
+            "def second_handler(): pass\n",
+        )
+        .unwrap();
+        let mut store = Store::open(root.join(".mastermind/mmcg.db")).unwrap();
+        let indexer = Indexer::new(&root);
+        indexer.index_all(&mut store, false).unwrap();
+
+        let old_path = root.join("old");
+        let new_path = root.join("new");
+        std::fs::rename(&old_path, &new_path).unwrap();
+        let event = notify::Event::new(EventKind::Modify(ModifyKind::Name(
+            notify::event::RenameMode::Both,
+        )))
+        .add_path(old_path)
+        .add_path(new_path);
+        let mut matcher = SourceMatcher::new(&root);
+        let mut pending = HashMap::new();
+        handle_event(
+            event,
+            &root,
+            &indexer,
+            &mut matcher,
+            &mut pending,
+            &mut store,
+        );
+
+        assert!(store.symbols_in_file("old/first.rs").unwrap().is_empty());
+        assert!(store
+            .symbols_in_file("old/nested/second.py")
+            .unwrap()
+            .is_empty());
+        assert_eq!(store.symbols_in_file("new/first.rs").unwrap().len(), 2);
+        assert_eq!(
+            store.symbols_in_file("new/nested/second.py").unwrap().len(),
+            2
+        );
+        assert!(pending.is_empty());
+        assert!(store.concept_contract_current().unwrap());
+    }
+
+    #[test]
+    fn rename_to_event_runs_inventory_refresh_when_the_old_path_is_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join(".mastermind")).unwrap();
+        let old_path = root.join("old.rs");
+        let new_path = root.join("new.rs");
+        std::fs::write(&old_path, "pub fn moved_handler() {}\n").unwrap();
+        let mut store = Store::open(root.join(".mastermind/mmcg.db")).unwrap();
+        let indexer = Indexer::new(&root);
+        indexer.index_all(&mut store, false).unwrap();
+
+        std::fs::rename(&old_path, &new_path).unwrap();
+        let event = notify::Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::To)))
+            .add_path(new_path);
+        let mut matcher = SourceMatcher::new(&root);
+        let mut pending = HashMap::new();
+        handle_event(
+            event,
+            &root,
+            &indexer,
+            &mut matcher,
+            &mut pending,
+            &mut store,
+        );
+
+        assert!(store.symbols_in_file("old.rs").unwrap().is_empty());
+        assert_eq!(store.symbols_in_file("new.rs").unwrap().len(), 2);
+        assert!(pending.is_empty());
+        assert!(store.concept_contract_current().unwrap());
+    }
+
+    #[test]
+    fn rename_mode_positions_identify_case_only_old_paths_without_stat() {
+        assert!(rename_event_path_is_old(&RenameMode::From, 0));
+        assert!(rename_event_path_is_old(&RenameMode::Both, 0));
+        assert!(!rename_event_path_is_old(&RenameMode::Both, 1));
+        assert!(!rename_event_path_is_old(&RenameMode::To, 0));
+    }
+
+    #[test]
+    fn case_only_rename_never_requeues_the_old_spelling_when_it_still_stats() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join(".mastermind")).unwrap();
+        let old_path = root.join("Handler.rs");
+        let new_path = root.join("handler.rs");
+        std::fs::write(&old_path, "pub fn renamed_handler() {}\n").unwrap();
+        let mut store = Store::open(root.join(".mastermind/mmcg.db")).unwrap();
+        let indexer = Indexer::new(&root);
+        indexer.index_all(&mut store, false).unwrap();
+
+        // Keep both spellings present to reproduce the observable stat result
+        // of a case-insensitive filesystem without making the test platform-specific.
+        std::fs::write(&new_path, "pub fn renamed_handler() {}\n").unwrap();
+        let event = notify::Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)))
+            .add_path(old_path.clone())
+            .add_path(new_path.clone());
+        let mut matcher = SourceMatcher::new(&root);
+        let mut pending = HashMap::new();
+        handle_event(
+            event,
+            &root,
+            &indexer,
+            &mut matcher,
+            &mut pending,
+            &mut store,
+        );
+
+        assert!(old_path.is_file());
+        assert!(!pending.contains_key(&old_path));
+        assert!(pending.contains_key(&new_path));
+        pending.insert(new_path, Instant::now() - DEBOUNCE);
+        flush_settled(&indexer, &mut store, &mut pending);
+        assert!(store.symbols_in_file("Handler.rs").unwrap().is_empty());
+        assert_eq!(store.symbols_in_file("handler.rs").unwrap().len(), 2);
+        assert!(store.concept_contract_current().unwrap());
+    }
+
+    #[test]
+    fn directory_remove_event_purges_descendant_graph_and_concept_rows() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let removed = root.join("removed");
+        std::fs::create_dir_all(removed.join("nested")).unwrap();
+        std::fs::create_dir_all(root.join(".mastermind")).unwrap();
+        std::fs::write(removed.join("first.rs"), "pub fn first_handler() {}\n").unwrap();
+        std::fs::write(
+            removed.join("nested/second.py"),
+            "def second_handler(): pass\n",
+        )
+        .unwrap();
+        let mut store = Store::open(root.join(".mastermind/mmcg.db")).unwrap();
+        let indexer = Indexer::new(&root);
+        indexer.index_all(&mut store, false).unwrap();
+        assert_eq!(store.concept_count().unwrap(), 4);
+
+        std::fs::remove_dir_all(&removed).unwrap();
+        let event = notify::Event::new(EventKind::Remove(notify::event::RemoveKind::Folder))
+            .add_path(removed.clone());
+        let mut matcher = SourceMatcher::new(&root);
+        let mut pending =
+            HashMap::from([(removed.join("nested/second.py"), Instant::now() - DEBOUNCE)]);
+        handle_event(
+            event,
+            &root,
+            &indexer,
+            &mut matcher,
+            &mut pending,
+            &mut store,
+        );
+
+        assert!(store.indexed_paths().unwrap().is_empty());
+        assert_eq!(store.concept_count().unwrap(), 0);
+        assert!(pending.is_empty());
+        assert!(store.concept_contract_current().unwrap());
     }
 
     #[test]

--- a/npm/mastermind/README.md
+++ b/npm/mastermind/README.md
@@ -28,7 +28,7 @@ A diff tells you what changed. Mastermind shows what the change reaches:
 downstream callers, architecture boundaries, candidate tests, ownership,
 security findings, runtime evidence, and repository policy.
 
-One local snapshot powers the CLI, 29 bounded MCP tools, the read-only Lens UI,
+One local snapshot powers the CLI, 30 bounded MCP tools, the read-only Lens UI,
 SARIF output, and a standalone review package.
 
 ## Your first review in three commands
@@ -43,6 +43,7 @@ cd your-repository
 mastermind index .
 mastermind impact --since main
 mastermind brief --role executor --since main --budget-tokens 2000
+mastermind concept "payment retry handler" --top 10
 mastermind ui --since main
 ```
 
@@ -52,6 +53,10 @@ reads the index without mutating it, and loads no remote frontend resources.
 budget includes the final MCP transport envelope; repository source bodies,
 declaration signatures, literal/default values, and history excerpts are never
 included.
+
+`concept` retrieves a small deterministic candidate set from normalized symbol
+names, repository paths, and declaration shapes. It uses local SQLite FTS5,
+with no embeddings, model calls, network access, source bodies, or comments.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/xcrft/mastermind/main/docs/images/lens/mastermind-lens-live-desktop.png" alt="Mastermind Lens showing changed symbols, downstream impact, boundary crossings, test candidates, and explicit partial evidence" width="900">
@@ -122,7 +127,7 @@ writer conflicts, unreachable tools, and componentized context estimates.
 
 Mastermind supports Claude Code, Codex, Cursor, Continue, and generic MCP stdio
 clients. Setup previews changes unless `--write` is present. The MCP server
-exposes 20 non-destructive queries that may refresh the managed derived index,
+exposes 21 non-destructive queries that may refresh the managed derived index,
 8 read-only tools, and one additive write to the local gitignored scratchpad.
 
 ## Supported stack

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -477,6 +477,12 @@ MMCG_TEMPLATE_MIRRORS: list[tuple[str, str]] = [
 # without forcing the same long inventory into every user-facing README.
 
 MMCG_MCP_SRC = "mcp/servers/mmcg/src/mcp.rs"
+MMCG_EXPECTED_LAST_TOOL = "mmcg_concept"
+MMCG_EXPECTED_BEHAVIOR_COUNTS = {
+    "refreshable_tool": 21,
+    "read_only_tool": 8,
+    "additive_tool": 1,
+}
 
 # Files that must reference every mmcg_* tool name. (Each may have one
 # canonical mention line; we only require *presence* of each tool name in the
@@ -972,6 +978,29 @@ def validate_mmcg_tool_drift() -> list[Issue]:
         )
         return issues
     canonical_count = len(tools)
+    if tools[-1] != MMCG_EXPECTED_LAST_TOOL:
+        issues.append(
+            Issue(
+                src_path,
+                "error",
+                f"authoritative tool order drift — expected final tool "
+                f"`{MMCG_EXPECTED_LAST_TOOL}`, got `{tools[-1]}`",
+            )
+        )
+    source = src_path.read_text()
+    start = source.find("static TOOLS:")
+    end = source.find("];", start) + 2 if start != -1 else -1
+    registry = source[start:end] if start != -1 and end != -1 else ""
+    for constructor, expected in MMCG_EXPECTED_BEHAVIOR_COUNTS.items():
+        actual = len(re.findall(rf"\b{constructor}\s*\(", registry))
+        if actual != expected:
+            issues.append(
+                Issue(
+                    src_path,
+                    "error",
+                    f"tool behavior drift — expected {expected} `{constructor}` entries, got {actual}",
+                )
+            )
 
     # 1. Presence check — every tool name must appear in each docfile.
     for rel in MMCG_TOOL_LIST_DOCS:


### PR DESCRIPTION
## Summary

- Add mmcg_concept and mastermind concept as one deterministic local search over symbol names, paths, and normalized declaration signatures.
- Keep the private FTS5 concept corpus transactionally aligned with symbol insert, replace, purge, rename, watcher, temporal, and rebuild paths.
- Preserve schema version 7 while using independent extractor and concept-normalization freshness contracts.
- Repair malformed managed concept schemas atomically, while custom indexes stay byte-preserving and return structured stale errors.
- Enforce bounded plain-text queries, fixed ranking, sanitized results, and CLI/MCP payload parity.
- Register the 30th MCP tool and update the exact inventory, validator, docs, READMEs, and unreleased changelog.
- Keep the existing brief hostile-path fixture valid on Windows after MSVC CI exposed a test-only invalid filename.

## Verification

- Concept focused suite: 31 passed.
- Brief focused suite: 18 passed.
- Schema rebuild focused suite: 2 passed.
- Source validator: 39 artifacts, 0 errors, 0 warnings.
- Full just check: 720 Rust tests, 26 npm tests, 1 Lens test, 38 security workflow tests, and 37 eval tests passed.
- Formatting, clippy, dependency policy, and diff checks passed.
- Independent correctness review: SHIP IT.
- Independent bounded-search review: no material blockers.
- Final comment audit: clean.

## Delivery

- Based directly on main.
- Intentionally left open. Do not merge, release, tag, publish, or deploy.