### PR TITLE
Index bounded documentation concepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `mmcg_concept` and `mastermind concept` now return a bounded schema-v1 set of
   local symbol candidates from normalized names, repository paths, and
-  declaration shapes. Fixed quoted-AND FTS5 retrieval uses no embeddings,
-  model calls, network access, source bodies, comments, literals, or defaults;
-  managed indexes refresh once on extractor or normalization drift, while
-  custom external indexes remain read-only and fail closed.
+  declaration shapes. Rust outer docs, Python owned docstrings, and
+  JavaScript/TypeScript JSDoc now contribute bounded normalized search tokens
+  without persisting or returning raw text. Credential-shaped candidates and
+  per-symbol/per-file overflow are omitted and counted. Fixed quoted-AND FTS5
+  retrieval uses no embeddings, model calls, network access, source bodies,
+  literals, or defaults; managed indexes refresh once on extractor or
+  normalization drift, while custom external indexes remain read-only and fail
+  closed.
 - `mmcg_brief` and `mastermind brief` now build one deterministic,
   revision-bound planner/executor/auditor context packet. Role-specific prefix
   admission is capped and reports source, unsafe-content, and budget omissions;

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,6 +82,21 @@ automatic writable refresh. A custom `--index` is served through a read-only
 snapshot and is never created, migrated, truncated, or given source-side
 SQLite sidecars; an incompatible schema fails as `schema_incompatible`.
 
+Concept documentation is derived from untrusted repository text. Rust outer
+docs, Python owned docstrings, and JavaScript/TypeScript JSDoc are inspected
+while their declaration AST is available, but raw text is never written to the
+index or returned by a tool. Only bounded normalized search tokens are stored:
+2 KiB raw inspection per candidate, 512 UTF-8 bytes per symbol, and 64 KiB per
+file. Candidates matching a private-key header, AWS access-key shape, bearer
+authorization value, or non-placeholder api-key/secret/token/password
+assignment are omitted whole before normalization.
+
+These checks reduce accidental credential persistence; they are not a general
+secret scanner or a confidentiality boundary for a hostile local machine. The
+SQLite index remains local derived data and should receive the same filesystem
+protection as the repository. Count-only omission metadata and query precision
+notes never include documentation excerpts.
+
 ## Response and disclosure
 
 This is a small-maintainer open-source project. Targets are best effort:

--- a/docs/reference/mmcg.md
+++ b/docs/reference/mmcg.md
@@ -291,10 +291,33 @@ mmcg concept "payment retry handler" --top 10 --format json
 
 `mmcg_concept` and `mastermind concept` use one schema-v1 query builder over a
 private derived corpus. Searchable fields are normalized symbol names,
-repository-relative paths, and bounded declaration shapes; the documentation
-field is reserved and empty. Source bodies and comments are never indexed or
-returned. Quoted, character, raw, template, regex, numeric, and default-value
-content is removed from declaration shapes before persistence.
+repository-relative paths, bounded declaration shapes, and owned documentation
+for an explicit first language set. Source bodies and raw comments/docstrings
+are never persisted or returned. Quoted, character, raw, template, regex,
+numeric, and default-value content is removed from declaration shapes before
+persistence.
+
+| Language | Documentation ownership |
+|---|---|
+| Rust | Consecutive outer `///` or `/** */` docs on the immediately owned item; attributes may sit between the docs and item. Inner `//!` docs belong only to their module. |
+| Python | The first plain string-expression statement in a module, class, sync function, or async function body. |
+| TypeScript / TSX / JavaScript | One immediately preceding `/** ... */` JSDoc block, including through an export wrapper. |
+
+Blank-line gaps, ordinary/trailing comments, file/license headers, Python
+f-strings, later or assigned strings, and JSDoc before another statement are
+not attached. C, C++, C#, Go, Java, PHP, and Vue remain name/path/declaration-
+shape only; precision notes report this supported matrix rather than implying
+documentation coverage for every extractor.
+
+Each admitted documentation candidate is stripped without rendering Markdown
+or HTML and bounded to 2 KiB of raw UTF-8. The shared concept tokenizer then
+persists at most 512 bytes of normalized search tokens per symbol and 64 KiB
+per file, in stable symbol order. Private-key headers, AWS access-key shapes,
+bearer authorization values, and non-placeholder api-key/secret/token/password
+assignments omit the whole candidate before persistence. Index stats and meta
+report supported languages, indexed-document count, credential omissions,
+size truncations/omissions, and unsupported-language file count only. They do
+not contain matched text.
 
 The query is plain text up to 256 UTF-8 bytes. Shared normalization applies
 Unicode lowercase without claiming canonical equivalence, splits punctuation,
@@ -304,7 +327,7 @@ joined by a fixed `AND`, so callers cannot supply FTS syntax, column selectors,
 boolean operators, or prefix wildcards. `top` is an integer from 1 through 50.
 
 SQLite FTS5 ranks with fixed BM25 weights: name 10, path 4, declaration shape
-2, and the reserved documentation field 1. The total tie order is score,
+2, and documentation 1. The total tie order is score,
 lowercase repository path, line, kind, name, then symbol ID. Scores are local
 to one query, lower is better, and they are not confidence values. Each
 candidate contains `name`, `kind`, `language`, `path`, `line`, a declaration
@@ -312,14 +335,17 @@ candidate contains `name`, `kind`, `language`, `path`, `line`, a declaration
 `score`; the envelope also reports normalized `query_terms`, count, requested
 top, freshness, limits, and precision notes.
 
-The corpus is an additive schema-v7 table plus external-content FTS5 index.
-Symbol mutations dirty its independent normalization contract, including writes
-from older schema-v7 binaries. Managed queries may perform one bounded full
-refresh and retry when the extractor or concept contract drifts. Finalization
-checks symbol/concept parity and FTS integrity before stamping both contracts
-current. Custom external indexes open read-only, are never migrated, and return
-`index_stale` or `schema_incompatible` when the required corpus is unavailable.
-Stable query failures also include `invalid_arguments`, `snapshot_changed`,
+The corpus is an additive schema-v7 concept table, per-file count table, and
+external-content FTS5 index. Documentation rows and their count-only metadata
+are replaced or removed in the same file transaction as symbols and edges.
+Symbol mutations dirty the independent normalization contract, including
+writes from older schema-v7 binaries. Managed queries may perform one bounded
+full refresh and retry when the extractor or concept contract drifts.
+Finalization checks symbol/concept parity and FTS integrity before stamping the
+extractor and normalization contracts current. Custom external indexes open
+read-only, are never migrated, and return `index_stale` or
+`schema_incompatible` when the required corpus is unavailable. Stable query
+failures also include `invalid_arguments`, `snapshot_changed`,
 `work_limit_exceeded`, `cancelled`, and `internal_error`.
 
 This is deterministic local retrieval, not semantic inference: no embeddings,
@@ -989,7 +1015,7 @@ or given WAL/SHM sidecars by the server. Incompatible custom schemas return
 | `mmcg_dependency_cycles` | optional `language`, `min_size` (default 2) | Detect circular imports — strongly-connected components in the file-level import graph (Tarjan's algorithm). Each result is a cycle = a list of files. Pre-merge guard ("does this PR introduce a new cycle?") and architectural-hygiene survey. Resolves edges by leaf-name match — over-approximates (two unrelated `Logger` symbols cross-link) so verify before refactoring. Bump `min_size` to hide trivial A↔B and surface only larger structural problems. Work-capped at 50,000 file-pair edges: above that, `truncated: true` with an empty `cycles` list — incomplete and possibly inaccurate, not "more available"; narrow with `language` and retry. |
 | `mmcg_symbols_changed_since` | `git_ref`, optional `root` | Symbol-level diff between a git ref and the current index. Returns `{added, removed, signature_changed}` symbol sets for files in `git diff --name-only <ref>..HEAD`. Re-parses old blobs from `git show <ref>:<path>` using the same extractor. Different from `mmcg_recent_changes` (watcher mtime) — this is git-ref-based, answering "what symbols did THIS PR/branch touch?". PR-review pre-flight, auditor verification, "what new public API appeared in v2.3?". Git subprocesses are killed after `MMCG_GIT_TIMEOUT_MS`; the per-file loop is capped at 10,000 files with `truncated: true` marking a partial diff. |
 | `mmcg_status` | — | Index path, file/symbol counts, and bounded `stale_files`. A non-zero value means the next structural query will refresh a managed index, or that a custom external index needs an explicit `mmcg index`. |
-| `mmcg_concept` | `query`, optional `top` (default 10, max 50) | Deterministic schema-v1 symbol candidates from normalized names, repository paths, and declaration shapes. Plain terms are escaped and fixed-AND joined; no raw FTS syntax, embeddings, model calls, network, source bodies, comments, literals, or defaults. BM25 score is query-local and lower-is-better, not confidence. Managed drift gets at most one refresh/retry; custom indexes remain read-only and fail closed. |
+| `mmcg_concept` | `query`, optional `top` (default 10, max 50) | Deterministic schema-v1 symbol candidates from normalized names, repository paths, declaration shapes, and owned Rust/Python/JavaScript/TypeScript documentation tokens. Plain terms are escaped and fixed-AND joined; no raw FTS syntax, embeddings, model calls, network, source bodies, raw comments/docstrings, literals, or defaults. BM25 score is query-local and lower-is-better, not confidence. Managed drift gets at most one refresh/retry; custom indexes remain read-only and fail closed. |
 
 Tool responses are bounded JSON. Collection responses expose their own count or
 collection metadata; status and workflow responses use named fields.

--- a/mcp/servers/mmcg/src/indexer.rs
+++ b/mcp/servers/mmcg/src/indexer.rs
@@ -9,12 +9,15 @@ use crate::bounded_fs::{
     read_regular_file, read_regular_file_expected, read_regular_file_with_capability,
     BoundedPathKind, BoundedReadError, ReadControl, RootCapability, StableFileIdentity,
 };
-use crate::store::{PendingFile, PendingSymbol, Store};
+use crate::store::{
+    normalize_concept_documentation, PendingConceptCorpus, PendingConceptDocumentation,
+    PendingFile, PendingSymbol, Store,
+};
 use ignore::{IncrementalIgnore, WalkBuilder};
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use std::borrow::Cow;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use tree_sitter::{Parser, Tree};
@@ -44,7 +47,7 @@ pub use vue::VueExtractor;
 /// Semantic contract for the extractor output stored in SQLite. Bump this when
 /// an extractor or grammar change can alter symbols, edges, ownership, or paths
 /// without requiring a database schema migration.
-pub const EXTRACTOR_CONTRACT_VERSION: &str = "mmcg-extractors-v4";
+pub const EXTRACTOR_CONTRACT_VERSION: &str = "mmcg-extractors-v5";
 pub const EXTRACTOR_CONTRACT_META_KEY: &str = "extractor_contract_version";
 
 /// Bind a persisted codegraph to the repository it was built from.
@@ -91,6 +94,59 @@ pub const AUTO_REFRESH_SOURCE_AGGREGATE_BYTES: u64 = 512 * 1024 * 1024;
 /// memory without changing the existing parallel-parse/single-writer model.
 pub const PARSE_BATCH_SIZE: usize = 64;
 
+const CONCEPT_DOCUMENTATION_RAW_MAX_BYTES: usize = 2 * 1024;
+const CONCEPT_DOCUMENTATION_FILE_MAX_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RawConceptDocumentation {
+    pub symbol_index: usize,
+    pub text: String,
+    pub size_limited: bool,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct DocumentationTextBuilder {
+    text: String,
+    size_limited: bool,
+}
+
+impl DocumentationTextBuilder {
+    pub fn push_line(&mut self, line: &str) {
+        if !self.text.is_empty() {
+            self.push_fragment("\n");
+        }
+        self.push_fragment(line);
+    }
+
+    pub fn push_fragment(&mut self, fragment: &str) {
+        let remaining = CONCEPT_DOCUMENTATION_RAW_MAX_BYTES.saturating_sub(self.text.len());
+        if fragment.len() <= remaining {
+            self.text.push_str(fragment);
+            return;
+        }
+        let mut end = remaining;
+        while end > 0 && !fragment.is_char_boundary(end) {
+            end -= 1;
+        }
+        self.text.push_str(&fragment[..end]);
+        self.size_limited = true;
+    }
+
+    pub fn finish(self, symbol_index: usize) -> Option<RawConceptDocumentation> {
+        (!self.text.trim().is_empty()).then_some(RawConceptDocumentation {
+            symbol_index,
+            text: self.text,
+            size_limited: self.size_limited,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct IndexedPendingFile {
+    pending: PendingFile,
+    documentation: PendingConceptCorpus,
+}
+
 /// Per-language symbol/edge extractor.
 ///
 /// Implementors receive a parsed tree plus source bytes and append symbols/edges
@@ -101,6 +157,261 @@ pub trait LanguageExtractor: Send + Sync {
     fn language(&self) -> tree_sitter::Language;
     fn name(&self) -> &'static str;
     fn extract(&self, tree: &Tree, source: &[u8], pending: &mut PendingFile, module_index: usize);
+}
+
+fn placeholder_documentation_value(value: &str) -> bool {
+    let trimmed = value
+        .trim()
+        .trim_matches(|character: char| {
+            matches!(character, '"' | '\'' | '`' | ',' | ';' | ')' | ']' | '}')
+        })
+        .to_ascii_lowercase();
+    if trimmed.is_empty()
+        || trimmed.starts_with("${")
+        || trimmed.starts_with("{{")
+        || trimmed.starts_with('<')
+        || trimmed == "example"
+        || trimmed.starts_with("example_")
+        || trimmed.starts_with("example-")
+        || trimmed.starts_with("your_")
+        || trimmed.starts_with("your-")
+    {
+        return true;
+    }
+    if matches!(
+        trimmed.as_str(),
+        "placeholder"
+            | "redacted"
+            | "changeme"
+            | "change_me"
+            | "change-me"
+            | "dummy"
+            | "fake"
+            | "test"
+            | "none"
+            | "null"
+            | "value"
+            | "todo"
+            | "secret_here"
+            | "token_here"
+            | "password_here"
+            | "api_key_here"
+    ) {
+        return true;
+    }
+    trimmed
+        .chars()
+        .all(|character| matches!(character, 'x' | '*' | '-' | '_' | '.'))
+}
+
+fn assignment_key_like_secret(value: &str) -> bool {
+    let trimmed = value
+        .trim()
+        .trim_start_matches(['-', '*', '+', '>', '`'])
+        .trim()
+        .trim_matches(|character: char| matches!(character, '"' | '\'' | '`'));
+    if trimmed.is_empty() {
+        return false;
+    }
+    let compact = trimmed
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    let has_internal_space = trimmed.chars().any(char::is_whitespace);
+    !has_internal_space
+        && (compact.ends_with("apikey")
+            || compact.ends_with("secret")
+            || compact.ends_with("token")
+            || compact.ends_with("password"))
+}
+
+fn assigned_secret_like(line: &str) -> bool {
+    for (index, separator) in line.char_indices() {
+        if !matches!(separator, '=' | ':') {
+            continue;
+        }
+        let left = &line[..index];
+        let left = if separator == '=' {
+            let trimmed = left.trim_end();
+            let start = trimmed
+                .rfind(|character: char| {
+                    character.is_whitespace() || matches!(character, ',' | ';' | '(' | '{')
+                })
+                .map_or(0, |position| position + 1);
+            &trimmed[start..]
+        } else {
+            left
+        };
+        let mut right = line[index + separator.len_utf8()..].trim_start();
+        if !assignment_key_like_secret(left) {
+            continue;
+        }
+        right = right.trim_start_matches(['"', '\'', '`']);
+        let end = right
+            .find(|character: char| {
+                character.is_whitespace()
+                    || matches!(character, '"' | '\'' | '`' | ',' | ';' | ')' | ']' | '}')
+            })
+            .unwrap_or(right.len());
+        if !placeholder_documentation_value(&right[..end]) {
+            return true;
+        }
+    }
+    false
+}
+
+fn bearer_authorization_like(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    let mut search_start = 0usize;
+    while let Some(relative) = lower[search_start..].find("authorization") {
+        let authorization = search_start + relative;
+        let before_ok = authorization == 0
+            || !matches!(
+                lower.as_bytes()[authorization - 1],
+                b'a'..=b'z' | b'0'..=b'9' | b'_'
+            );
+        let mut rest = lower[authorization + "authorization".len()..].trim_start();
+        if matches!(rest.as_bytes().first(), Some(b'"' | b'\'' | b'`')) {
+            rest = rest[1..].trim_start();
+        }
+        if before_ok && (rest.starts_with(':') || rest.starts_with('=')) {
+            rest = rest[1..].trim_start().trim_start_matches(['"', '\'', '`']);
+            if let Some(value) = rest.strip_prefix("bearer") {
+                if value.chars().next().is_some_and(char::is_whitespace) {
+                    let value = value.trim_start();
+                    let end = value
+                        .find(|character: char| {
+                            character.is_whitespace()
+                                || matches!(
+                                    character,
+                                    '"' | '\'' | '`' | ',' | ';' | ')' | ']' | '}'
+                                )
+                        })
+                        .unwrap_or(value.len());
+                    if !placeholder_documentation_value(&value[..end]) {
+                        return true;
+                    }
+                }
+            }
+        }
+        search_start = authorization + "authorization".len();
+    }
+    false
+}
+
+fn aws_access_key_like(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() < 20 {
+        return false;
+    }
+    for start in 0..=bytes.len() - 20 {
+        if !matches!(&bytes[start..start + 4], b"AKIA" | b"ASIA") {
+            continue;
+        }
+        let before_ok = start == 0 || !bytes[start - 1].is_ascii_alphanumeric();
+        let end = start + 20;
+        let after_ok = end == bytes.len() || !bytes[end].is_ascii_alphanumeric();
+        if before_ok
+            && after_ok
+            && bytes[start + 4..end]
+                .iter()
+                .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn secret_like_documentation(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    (lower.contains("-----begin ") && lower.contains("private key-----"))
+        || aws_access_key_like(value)
+        || value
+            .lines()
+            .any(|line| bearer_authorization_like(line) || assigned_secret_like(line))
+}
+
+fn build_concept_documentation_corpus(
+    language: &str,
+    mut candidates: Vec<RawConceptDocumentation>,
+) -> PendingConceptCorpus {
+    let language_supported = crate::store::concept_documentation_language_supported(language);
+    let mut corpus = PendingConceptCorpus {
+        language_supported,
+        ..PendingConceptCorpus::default()
+    };
+    if !language_supported {
+        return corpus;
+    }
+
+    candidates.sort_by_key(|candidate| candidate.symbol_index);
+    let mut documents = BTreeMap::<usize, String>::new();
+    for candidate in candidates {
+        if secret_like_documentation(&candidate.text) {
+            corpus.secret_omitted = corpus.secret_omitted.saturating_add(1);
+            continue;
+        }
+        let Some(normalized) = normalize_concept_documentation(&candidate.text) else {
+            corpus.size_omitted = corpus.size_omitted.saturating_add(1);
+            continue;
+        };
+        let mut size_limited = candidate.size_limited || normalized.truncated;
+        if normalized.value.is_empty() {
+            if size_limited {
+                corpus.size_omitted = corpus.size_omitted.saturating_add(1);
+            }
+            continue;
+        }
+        let document = documents.entry(candidate.symbol_index).or_default();
+        let mut seen_terms = document
+            .split(' ')
+            .filter(|term| !term.is_empty())
+            .map(str::to_string)
+            .collect::<HashSet<_>>();
+        for term in normalized.value.split(' ') {
+            if !seen_terms.insert(term.to_string()) {
+                continue;
+            }
+            let separator = usize::from(!document.is_empty());
+            if document
+                .len()
+                .saturating_add(separator)
+                .saturating_add(term.len())
+                > crate::store::CONCEPT_DOCUMENTATION_MAX_BYTES
+            {
+                size_limited = true;
+                break;
+            }
+            if separator == 1 {
+                document.push(' ');
+            }
+            document.push_str(term);
+        }
+        if size_limited {
+            corpus.size_omitted = corpus.size_omitted.saturating_add(1);
+        }
+    }
+
+    let mut aggregate_bytes = 0usize;
+    for (symbol_index, documentation_search) in documents {
+        if documentation_search.is_empty() {
+            continue;
+        }
+        if aggregate_bytes.saturating_add(documentation_search.len())
+            > CONCEPT_DOCUMENTATION_FILE_MAX_BYTES
+        {
+            corpus.size_omitted = corpus.size_omitted.saturating_add(1);
+            continue;
+        }
+        aggregate_bytes += documentation_search.len();
+        corpus.documents.push(PendingConceptDocumentation {
+            symbol_index,
+            documentation_search,
+        });
+    }
+    corpus
 }
 
 /// Map a file extension to a language extractor.
@@ -193,6 +504,16 @@ pub struct IndexStats {
     pub concept_orphans_purged: u32,
     /// True when this run rebuilt an older concept-normalization contract.
     pub concept_contract_rebuilt: bool,
+    /// Languages whose owned documentation contributes normalized concept terms.
+    pub concept_documentation_supported_languages: String,
+    /// Searchable documentation documents present after the run.
+    pub concept_documentation_indexed: u32,
+    /// Candidates omitted because they matched a credential pattern.
+    pub concept_documentation_secret_omitted: u32,
+    /// Candidates truncated or omitted by per-symbol/per-file size limits.
+    pub concept_documentation_size_omitted: u32,
+    /// Indexed source files whose language has no documentation collector.
+    pub concept_documentation_unsupported_language_files: u32,
     pub duration_ms: u128,
 }
 
@@ -462,7 +783,7 @@ impl Indexer {
         // collection retained every PendingFile until parsing the whole repository.
         for batch in to_parse.chunks(PARSE_BATCH_SIZE) {
             ensure_indexing_active(store)?;
-            let parsed: Vec<(PathBuf, Result<PendingFile, IndexError>)> = if limits
+            let parsed: Vec<(PathBuf, Result<IndexedPendingFile, IndexError>)> = if limits
                 == IndexLimits::MANUAL
             {
                 batch
@@ -471,7 +792,7 @@ impl Indexer {
                         let extractor = extractor_for_path(path)?;
                         Some((
                             path.clone(),
-                            parse_one(path, &self.root, extractor.as_ref()),
+                            parse_one_with_concepts(path, &self.root, extractor.as_ref()),
                         ))
                     })
                     .collect()
@@ -486,7 +807,7 @@ impl Indexer {
                         };
                         Some((
                             path.clone(),
-                            parse_one_controlled(
+                            parse_one_with_concepts_controlled(
                                 path,
                                 &self.root,
                                 root_capability
@@ -513,13 +834,15 @@ impl Indexer {
                     .to_string_lossy()
                     .replace('\\', "/");
                 match outcome {
-                    Ok(pending) => {
-                        stats.symbols_total += pending.symbols.len() as u32;
-                        stats.edges_total += pending.edges.len() as u32;
-                        if let Some(lang) = guess_language_for(&pending.path) {
+                    Ok(indexed) => {
+                        stats.symbols_total += indexed.pending.symbols.len() as u32;
+                        stats.edges_total += indexed.pending.edges.len() as u32;
+                        if let Some(lang) = guess_language_for(&indexed.pending.path) {
                             *stats.by_language.entry(lang.to_string()).or_insert(0) += 1;
                         }
-                        match store.commit_file(pending) {
+                        match store
+                            .commit_file_with_concepts(indexed.pending, indexed.documentation)
+                        {
                             Ok(()) => {
                                 stats.files_indexed += 1;
                                 #[cfg(test)]
@@ -593,6 +916,16 @@ impl Indexer {
                 .concept_count()
                 .map_err(|error| IndexError::Other(error.to_string()))?;
         }
+        let documentation = store
+            .concept_documentation_stats()
+            .map_err(|error| IndexError::Other(error.to_string()))?;
+        stats.concept_documentation_supported_languages =
+            crate::store::CONCEPT_DOCUMENTATION_SUPPORTED_LANGUAGES.to_string();
+        stats.concept_documentation_indexed = documentation.indexed_documents;
+        stats.concept_documentation_secret_omitted = documentation.secret_omitted;
+        stats.concept_documentation_size_omitted = documentation.size_omitted;
+        stats.concept_documentation_unsupported_language_files =
+            documentation.unsupported_language_files;
 
         stats.duration_ms = start.elapsed().map(|d| d.as_millis()).unwrap_or(0);
         Ok(stats)
@@ -886,10 +1219,10 @@ impl Indexer {
         ensure_indexing_active(store)?;
         let extractor = extractor_for_path(path)
             .ok_or_else(|| IndexError::Parse(format!("no extractor for {path:?}")))?;
-        let pending = parse_one(path, &self.root, extractor.as_ref())?;
+        let indexed = parse_one_with_concepts(path, &self.root, extractor.as_ref())?;
         ensure_indexing_active(store)?;
         store
-            .commit_file(pending)
+            .commit_file_with_concepts(indexed.pending, indexed.documentation)
             .map_err(|e| IndexError::Other(e.to_string()))
     }
 }
@@ -1469,6 +1802,21 @@ pub(crate) fn parse_one(
     parse_blob(&rel, &source.bytes, source.modified_millis, extractor)
 }
 
+fn parse_one_with_concepts(
+    path: &Path,
+    root: &Path,
+    extractor: &dyn LanguageExtractor,
+) -> Result<IndexedPendingFile, IndexError> {
+    let source = read_source_bounded(path, root, ReadControl::default())?;
+    let rel = path
+        .strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    parse_blob_with_concepts(&rel, &source.bytes, source.modified_millis, extractor)
+}
+
+#[cfg(test)]
 fn parse_one_controlled(
     path: &Path,
     root: &Path,
@@ -1497,6 +1845,34 @@ fn parse_one_controlled(
         .replace('\\', "/");
 
     parse_blob(&rel, &source.bytes, source.modified_millis, extractor)
+}
+
+fn parse_one_with_concepts_controlled(
+    path: &Path,
+    root: &Path,
+    root_capability: &RootCapability,
+    expected_identity: StableFileIdentity,
+    extractor: &dyn LanguageExtractor,
+    control: ReadControl<'_>,
+) -> Result<IndexedPendingFile, IndexError> {
+    let source = read_regular_file_expected(
+        root_capability,
+        path,
+        MAX_INDEXABLE_FILE_SIZE,
+        MAX_INDEXABLE_FILE_SIZE,
+        control,
+        Some(expected_identity),
+    )
+    .map_err(index_error_from_read)?;
+    if is_binary_content(&source.bytes[..source.bytes.len().min(BINARY_SNIFF_BYTES as usize)]) {
+        return Err(IndexError::Skipped(IndexSkipReason::Binary));
+    }
+    let rel = path
+        .strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    parse_blob_with_concepts(&rel, &source.bytes, source.modified_millis, extractor)
 }
 
 pub(crate) fn source_admission_mtime(root: &Path, path: &Path) -> Result<i64, IndexError> {
@@ -1611,6 +1987,25 @@ pub(crate) fn parse_blob(
     mtime: i64,
     extractor: &dyn LanguageExtractor,
 ) -> Result<PendingFile, IndexError> {
+    parse_blob_internal(rel_path, source, mtime, extractor, false).map(|parsed| parsed.pending)
+}
+
+fn parse_blob_with_concepts(
+    rel_path: &str,
+    source: &[u8],
+    mtime: i64,
+    extractor: &dyn LanguageExtractor,
+) -> Result<IndexedPendingFile, IndexError> {
+    parse_blob_internal(rel_path, source, mtime, extractor, true)
+}
+
+fn parse_blob_internal(
+    rel_path: &str,
+    source: &[u8],
+    mtime: i64,
+    extractor: &dyn LanguageExtractor,
+    collect_documentation: bool,
+) -> Result<IndexedPendingFile, IndexError> {
     let parser_source = source_for_parser(source)?;
     let mut parser = Parser::new();
     let language = extractor.language();
@@ -1645,7 +2040,36 @@ pub(crate) fn parse_blob(
     let module_index = pending.symbols.len() - 1;
 
     extractor.extract(&tree, parser_source.as_ref(), &mut pending, module_index);
-    Ok(pending)
+    let candidates = if collect_documentation {
+        match pending.language.as_str() {
+            "rust" => rust_lang::collect_concept_documentation(
+                &tree,
+                parser_source.as_ref(),
+                &pending,
+                module_index,
+            ),
+            "python" => python::collect_concept_documentation(
+                &tree,
+                parser_source.as_ref(),
+                &pending,
+                module_index,
+            ),
+            "typescript" | "tsx" => {
+                typescript::collect_concept_documentation(&tree, parser_source.as_ref(), &pending)
+            }
+            "javascript" => {
+                javascript::collect_concept_documentation(&tree, parser_source.as_ref(), &pending)
+            }
+            _ => Vec::new(),
+        }
+    } else {
+        Vec::new()
+    };
+    let documentation = build_concept_documentation_corpus(&pending.language, candidates);
+    Ok(IndexedPendingFile {
+        pending,
+        documentation,
+    })
 }
 
 #[derive(Debug)]
@@ -1732,6 +2156,410 @@ mod incremental_tests {
             "git {args:?}: {}",
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    fn documentation_matches(store: &Store, term: &str) -> Vec<String> {
+        store
+            .search_concepts(&format!("\"{term}\""), 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hit| hit.documentation_matched)
+            .map(|hit| hit.name)
+            .collect()
+    }
+
+    #[test]
+    fn rust_concept_documentation_attaches_outer_and_module_docs_only() {
+        let (dir, db) = setup("rust_concept_documentation");
+        fs::write(
+            dir.join("owned.rs"),
+            "//! crate atlasquartz routing\n\
+             // license ordinaryquartz\n\
+             /// retryquartz handler\n\
+             #[inline]\n\
+             fn accepted() {}\n\
+             /** ledgerquartz model */\n\
+             struct Ledger;\n\
+             /// outermodulequartz docs\n\
+             mod nested {\n\
+                 //! innermodulequartz docs\n\
+             }\n\
+             /// blankgapquartz ignored\n\
+             \n\
+             fn blank_gap() {}\n\
+             // linecommentquartz ignored\n\
+             fn ordinary() {}\n\
+             fn trailing() {} /// trailingquartz ignored\n",
+        )
+        .unwrap();
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(&dir).index_all(&mut store, true).unwrap();
+
+        assert_eq!(documentation_matches(&store, "atlasquartz"), ["<module>"]);
+        assert_eq!(documentation_matches(&store, "retryquartz"), ["accepted"]);
+        assert_eq!(documentation_matches(&store, "ledgerquartz"), ["Ledger"]);
+        assert_eq!(
+            documentation_matches(&store, "outermodulequartz"),
+            ["nested"]
+        );
+        assert_eq!(
+            documentation_matches(&store, "innermodulequartz"),
+            ["nested"]
+        );
+        for rejected in [
+            "ordinaryquartz",
+            "blankgapquartz",
+            "linecommentquartz",
+            "trailingquartz",
+        ] {
+            assert!(
+                documentation_matches(&store, rejected).is_empty(),
+                "unexpected Rust documentation match for {rejected}"
+            );
+        }
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn python_concept_documentation_attaches_only_owned_plain_docstrings() {
+        let (dir, db) = setup("python_concept_documentation");
+        fs::write(
+            dir.join("owned.py"),
+            r#"# comment before module docs
+"""modulequartz compass"""
+
+def marker(fn):
+    return fn
+
+@marker
+async def accepted():
+    """asyncquartz orbit"""
+    return 1
+
+class Owned:
+    """classquartz prism"""
+    def method(self):
+        """methodquartz amber"""
+        return 1
+
+def fstring():
+    f"""fstringquartz {1}"""
+
+def later():
+    value = 1
+    """laterquartz"""
+
+def assigned():
+    value = """assignedquartz"""
+
+def concatenated(value):
+    "concatquartz" + value
+"#,
+        )
+        .unwrap();
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(&dir).index_all(&mut store, true).unwrap();
+
+        assert_eq!(documentation_matches(&store, "modulequartz"), ["<module>"]);
+        assert_eq!(documentation_matches(&store, "asyncquartz"), ["accepted"]);
+        assert_eq!(documentation_matches(&store, "classquartz"), ["Owned"]);
+        assert_eq!(documentation_matches(&store, "methodquartz"), ["method"]);
+        for rejected in [
+            "fstringquartz",
+            "laterquartz",
+            "assignedquartz",
+            "concatquartz",
+        ] {
+            assert!(
+                documentation_matches(&store, rejected).is_empty(),
+                "unexpected Python documentation match for {rejected}"
+            );
+        }
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn js_ts_concept_documentation_attaches_immediate_jsdoc_through_export() {
+        let (dir, db) = setup("js_ts_concept_documentation");
+        fs::write(
+            dir.join("owned.ts"),
+            "/** @file headerquartz */\n\
+             function headerTarget() {}\n\
+             /** Copyright licensequartz */\n\
+             function licenseTarget() {}\n\
+             /** exportquartz handler */\n\
+             export function accepted() {}\n\
+             /** classquartz service */\n\
+             export class Service {\n\
+                 /** methodquartz action */\n\
+                 run() {}\n\
+             }\n\
+             /** variablequartz callback */\n\
+             export const Handler = () => 1;\n\
+             /** blankgapquartz ignored */\n\
+             \n\
+             function blankGap() {}\n\
+             /* ordinaryquartz ignored */\n\
+             function ordinary() {}\n\
+             function trailing() {} /** trailingquartz ignored */\n\
+             /** stalequartz ignored */\n\
+             const value = 1;\n\
+             function afterValue() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("owned.js"),
+            "/** javascriptquartz export */\nexport function jsAccepted() {}\n",
+        )
+        .unwrap();
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(&dir).index_all(&mut store, true).unwrap();
+
+        assert_eq!(documentation_matches(&store, "exportquartz"), ["accepted"]);
+        assert_eq!(documentation_matches(&store, "classquartz"), ["Service"]);
+        assert_eq!(documentation_matches(&store, "methodquartz"), ["run"]);
+        assert_eq!(documentation_matches(&store, "variablequartz"), ["Handler"]);
+        assert_eq!(
+            documentation_matches(&store, "javascriptquartz"),
+            ["jsAccepted"]
+        );
+        for rejected in [
+            "blankgapquartz",
+            "ordinaryquartz",
+            "trailingquartz",
+            "stalequartz",
+            "headerquartz",
+            "licensequartz",
+        ] {
+            assert!(
+                documentation_matches(&store, rejected).is_empty(),
+                "unexpected JS/TS documentation match for {rejected}"
+            );
+        }
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn concept_documentation_secret_patterns_omit_whole_candidates() {
+        let (dir, db) = setup("concept_documentation_secrets");
+        fs::write(
+            dir.join("secrets.py"),
+            r#"def private_material():
+    """privatecanary -----BEGIN PRIVATE KEY----- material"""
+
+def aws_material():
+    """awscanary AKIAIOSFODNN7EXAMPLE"""
+
+def bearer_material():
+    """bearercanary Authorization: Bearer livecredential123"""
+
+def json_bearer_material():
+    """jsonbearercanary {"Authorization": "Bearer jsoncredential789"}"""
+
+def password_material():
+    """passwordcanary password = livecredential456"""
+
+def api_key_material():
+    """apiassignmentcanary stripe_api_key = liveexamplecredential"""
+
+def prose():
+    """rotationquartz explains token buckets and password rotation"""
+
+def bearer_prose():
+    """bearerwordquartz Authorization: Bearerish explanation"""
+
+def placeholder():
+    """placeholderquartz token = placeholder"""
+"#,
+        )
+        .unwrap();
+        let mut store = Store::open(&db).unwrap();
+        Indexer::new(&dir).index_all(&mut store, true).unwrap();
+
+        for omitted in [
+            "privatecanary",
+            "awscanary",
+            "bearercanary",
+            "jsonbearercanary",
+            "passwordcanary",
+            "apiassignmentcanary",
+            "livecredential123",
+            "livecredential456",
+            "liveexamplecredential",
+            "jsoncredential789",
+        ] {
+            assert!(
+                documentation_matches(&store, omitted).is_empty(),
+                "secret-like candidate leaked {omitted}"
+            );
+        }
+        assert_eq!(documentation_matches(&store, "rotationquartz"), ["prose"]);
+        assert_eq!(
+            documentation_matches(&store, "bearerwordquartz"),
+            ["bearer_prose"]
+        );
+        assert_eq!(
+            documentation_matches(&store, "placeholderquartz"),
+            ["placeholder"]
+        );
+        let stats = store.concept_documentation_stats().unwrap();
+        assert_eq!(stats.indexed_documents, 3);
+        assert_eq!(stats.secret_omitted, 6);
+        assert_eq!(
+            store
+                .meta_value(crate::store::CONCEPT_DOCUMENTATION_SECRET_OMITTED_META_KEY)
+                .unwrap()
+                .as_deref(),
+            Some("6")
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn concept_documentation_utf8_and_file_caps_are_stable() {
+        let (utf8_dir, utf8_db) = setup("concept_documentation_utf8");
+        let long_doc = format!(
+            "def bounded():\n    \"\"\"utf8quartz {}\"\"\"\n",
+            "界".repeat(900)
+        );
+        fs::write(utf8_dir.join("bounded.py"), long_doc).unwrap();
+        let mut utf8_store = Store::open(&utf8_db).unwrap();
+        Indexer::new(&utf8_dir)
+            .index_all(&mut utf8_store, true)
+            .unwrap();
+        assert_eq!(
+            documentation_matches(&utf8_store, "utf8quartz"),
+            ["bounded"]
+        );
+        assert_eq!(
+            utf8_store
+                .concept_documentation_stats()
+                .unwrap()
+                .size_omitted,
+            1
+        );
+        let utf8_connection = rusqlite::Connection::open(&utf8_db).unwrap();
+        let document_bytes: i64 = utf8_connection
+            .query_row(
+                "SELECT length(CAST(documentation_search AS BLOB))
+                 FROM symbol_concepts WHERE documentation_search <> ''",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(document_bytes <= 512);
+        drop(utf8_connection);
+        fs::remove_dir_all(&utf8_dir).ok();
+
+        let (aggregate_dir, aggregate_db) = setup("concept_documentation_aggregate");
+        let alpha_word = |mut value: usize| {
+            let mut word = String::from("w");
+            for _ in 0..7 {
+                word.push((b'a' + (value % 26) as u8) as char);
+                value /= 26;
+            }
+            word
+        };
+        let mut source = String::new();
+        for symbol in 0..150usize {
+            source.push_str(&format!("/** aggregatequartz{symbol} "));
+            for term in 0..48usize {
+                source.push_str(&alpha_word(symbol * 64 + term));
+                source.push(' ');
+            }
+            source.push_str(&format!("*/\nfunction item_{symbol}() {{}}\n"));
+        }
+        fs::write(aggregate_dir.join("aggregate.js"), source).unwrap();
+        let mut aggregate_store = Store::open(&aggregate_db).unwrap();
+        Indexer::new(&aggregate_dir)
+            .index_all(&mut aggregate_store, true)
+            .unwrap();
+        let stats = aggregate_store.concept_documentation_stats().unwrap();
+        assert!(stats.indexed_documents > 0 && stats.indexed_documents < 150);
+        assert_eq!(
+            stats.size_omitted,
+            150u32.saturating_sub(stats.indexed_documents)
+        );
+        assert_eq!(
+            documentation_matches(&aggregate_store, "aggregatequartz0"),
+            ["item_0"]
+        );
+        assert!(documentation_matches(&aggregate_store, "aggregatequartz149").is_empty());
+        fs::remove_dir_all(&aggregate_dir).ok();
+    }
+
+    #[test]
+    fn concept_documentation_comment_edit_rename_delete_and_failed_commit_are_atomic() {
+        let (dir, db) = setup("concept_documentation_lifecycle");
+        let original = dir.join("original.py");
+        fs::write(
+            &original,
+            "def handler():\n    \"\"\"oldquartz behavior\"\"\"\n",
+        )
+        .unwrap();
+        let mut store = Store::open(&db).unwrap();
+        let indexer = Indexer::new(&dir);
+        indexer.index_all(&mut store, true).unwrap();
+        assert_eq!(documentation_matches(&store, "oldquartz"), ["handler"]);
+
+        fs::write(
+            &original,
+            "def handler():\n    \"\"\"watchquartz behavior\"\"\"\n",
+        )
+        .unwrap();
+        indexer.index_one(&mut store, &original).unwrap();
+        assert!(documentation_matches(&store, "oldquartz").is_empty());
+        assert_eq!(documentation_matches(&store, "watchquartz"), ["handler"]);
+
+        let renamed = dir.join("renamed.py");
+        fs::rename(&original, &renamed).unwrap();
+        indexer.index_all(&mut store, false).unwrap();
+        let renamed_hits = store.search_concepts("\"watchquartz\"", 10).unwrap();
+        assert_eq!(renamed_hits.len(), 1);
+        assert_eq!(renamed_hits[0].path, "renamed.py");
+
+        fs::remove_file(&renamed).unwrap();
+        indexer.index_all(&mut store, false).unwrap();
+        assert!(documentation_matches(&store, "watchquartz").is_empty());
+
+        let failed = dir.join("failed.py");
+        fs::write(
+            &failed,
+            "def failed():\n    \"\"\"stablequartz behavior\"\"\"\n",
+        )
+        .unwrap();
+        indexer.index_all(&mut store, true).unwrap();
+        fs::write(
+            &failed,
+            "def failed():\n    \"\"\"unstablequartz behavior\"\"\"\n",
+        )
+        .unwrap();
+        let connection = rusqlite::Connection::open(&db).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TRIGGER fail_concept_documentation_commit
+                 BEFORE INSERT ON symbols
+                 WHEN new.file_path = 'failed.py' BEGIN
+                     SELECT RAISE(ABORT, 'forced documentation commit failure');
+                 END;",
+            )
+            .unwrap();
+        drop(connection);
+        assert!(indexer.index_one(&mut store, &failed).is_err());
+        assert!(!store.concept_contract_current().unwrap());
+        assert_eq!(
+            crate::mcp::build_concept_current(&mut store, "stablequartz", 10),
+            Err(crate::queries::ConceptError::IndexStale)
+        );
+        let connection = rusqlite::Connection::open(&db).unwrap();
+        connection
+            .execute_batch("DROP TRIGGER fail_concept_documentation_commit")
+            .unwrap();
+        drop(connection);
+        indexer.index_all(&mut store, true).unwrap();
+        assert!(documentation_matches(&store, "stablequartz").is_empty());
+        assert_eq!(documentation_matches(&store, "unstablequartz"), ["failed"]);
+        fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/mcp/servers/mmcg/src/indexer/javascript.rs
+++ b/mcp/servers/mmcg/src/indexer/javascript.rs
@@ -3,7 +3,7 @@
 //! calls, imports). TS-only node kinds don't appear in JS files.
 
 use super::typescript;
-use super::LanguageExtractor;
+use super::{LanguageExtractor, RawConceptDocumentation};
 use crate::store::PendingFile;
 use tree_sitter::Tree;
 
@@ -28,6 +28,14 @@ impl LanguageExtractor for JavascriptExtractor {
             module_index,
         );
     }
+}
+
+pub(super) fn collect_concept_documentation(
+    tree: &Tree,
+    source: &[u8],
+    pending: &PendingFile,
+) -> Vec<RawConceptDocumentation> {
+    typescript::collect_concept_documentation(tree, source, pending)
 }
 
 #[cfg(test)]

--- a/mcp/servers/mmcg/src/indexer/python.rs
+++ b/mcp/servers/mmcg/src/indexer/python.rs
@@ -3,8 +3,9 @@
 use super::common::{
     line_of, node_text, push_call_with_type, push_def, push_def_with_decorators, push_import,
 };
-use super::LanguageExtractor;
+use super::{DocumentationTextBuilder, LanguageExtractor, RawConceptDocumentation};
 use crate::store::PendingFile;
+use std::collections::HashMap;
 use tree_sitter::{Node, Tree};
 
 pub struct PythonExtractor;
@@ -455,6 +456,122 @@ fn extract_signature(node: &Node, source: &[u8]) -> Option<String> {
     } else {
         Some(trimmed)
     }
+}
+
+fn plain_docstring_body<'a>(node: &Node, source: &'a [u8]) -> Option<&'a str> {
+    if node.kind() != "string" {
+        return None;
+    }
+    let mut cursor = node.walk();
+    if node
+        .named_children(&mut cursor)
+        .any(|child| child.kind() == "interpolation")
+    {
+        return None;
+    }
+    let text = node_text(node, source)?;
+    let quote_index = text.find(['\'', '"'])?;
+    let prefix = text[..quote_index].to_ascii_lowercase();
+    if prefix
+        .chars()
+        .any(|character| matches!(character, 'b' | 'f'))
+        || !prefix
+            .chars()
+            .all(|character| matches!(character, 'r' | 'u'))
+    {
+        return None;
+    }
+    let quoted = &text[quote_index..];
+    let quote = quoted.as_bytes().first().copied()?;
+    let triple = quoted.as_bytes().get(..3) == Some([quote, quote, quote].as_slice());
+    let delimiter_len = if triple { 3 } else { 1 };
+    if quoted.len() < delimiter_len * 2
+        || !quoted.as_bytes()[quoted.len() - delimiter_len..]
+            .iter()
+            .all(|byte| *byte == quote)
+    {
+        return None;
+    }
+    Some(&quoted[delimiter_len..quoted.len() - delimiter_len])
+}
+
+fn first_owned_docstring<'source>(body: Node<'_>, source: &'source [u8]) -> Option<&'source str> {
+    let mut cursor = body.walk();
+    let statement = body
+        .named_children(&mut cursor)
+        .find(|child| child.kind() != "comment")?;
+    if statement.kind() != "expression_statement" {
+        return None;
+    }
+    let expression = statement.named_child(0)?;
+    plain_docstring_body(&expression, source)
+}
+
+fn definition_symbol_index(
+    node: &Node,
+    source: &[u8],
+    symbols: &HashMap<(u32, &str), usize>,
+) -> Option<usize> {
+    let name = node
+        .child_by_field_name("name")
+        .and_then(|name| node_text(&name, source))?;
+    let line = node.start_position().row as u32 + 1;
+    symbols.get(&(line, name)).copied()
+}
+
+fn collect_owned_docstrings(
+    node: Node,
+    source: &[u8],
+    symbols: &HashMap<(u32, &str), usize>,
+    module_index: usize,
+    output: &mut Vec<RawConceptDocumentation>,
+) {
+    let owner = match node.kind() {
+        "module" => Some((module_index, node)),
+        "class_definition" | "function_definition" | "async_function_definition" => {
+            definition_symbol_index(&node, source, symbols).zip(node.child_by_field_name("body"))
+        }
+        _ => None,
+    };
+    if let Some((symbol_index, body)) = owner {
+        if let Some(docstring) = first_owned_docstring(body, source) {
+            let mut builder = DocumentationTextBuilder::default();
+            builder.push_fragment(docstring);
+            if let Some(candidate) = builder.finish(symbol_index) {
+                output.push(candidate);
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_owned_docstrings(child, source, symbols, module_index, output);
+    }
+}
+
+pub(super) fn collect_concept_documentation(
+    tree: &Tree,
+    source: &[u8],
+    pending: &PendingFile,
+    module_index: usize,
+) -> Vec<RawConceptDocumentation> {
+    let mut output = Vec::new();
+    let mut symbols = HashMap::with_capacity(pending.symbols.len());
+    for (index, symbol) in pending.symbols.iter().enumerate() {
+        if symbol.kind != "module" {
+            symbols
+                .entry((symbol.line_start, symbol.name.as_str()))
+                .or_insert(index);
+        }
+    }
+    collect_owned_docstrings(
+        tree.root_node(),
+        source,
+        &symbols,
+        module_index,
+        &mut output,
+    );
+    output
 }
 
 #[cfg(test)]

--- a/mcp/servers/mmcg/src/indexer/rust_lang.rs
+++ b/mcp/servers/mmcg/src/indexer/rust_lang.rs
@@ -5,8 +5,9 @@ use super::common::{
     line_of, node_text, push_call, push_call_with_type, push_def, push_def_with_decorators,
     push_import,
 };
-use super::LanguageExtractor;
+use super::{DocumentationTextBuilder, LanguageExtractor, RawConceptDocumentation};
 use crate::store::PendingFile;
+use std::collections::HashMap;
 use tree_sitter::{Node, Tree};
 
 pub struct RustExtractor;
@@ -431,6 +432,211 @@ fn signature_until_body_or_semi(node: &Node, source: &[u8]) -> Option<String> {
     } else {
         Some(trimmed)
     }
+}
+
+fn documentation_nodes_adjacent(source: &[u8], left: &Node, right: &Node) -> bool {
+    if left.end_byte() > right.start_byte()
+        || right.start_position().row > left.end_position().row.saturating_add(1)
+    {
+        return false;
+    }
+    let gap = &source[left.end_byte()..right.start_byte()];
+    if !gap.iter().all(u8::is_ascii_whitespace) {
+        return false;
+    }
+    let mut newlines = 0usize;
+    let mut index = 0usize;
+    while index < gap.len() {
+        if gap[index] == b'\r' {
+            newlines += 1;
+            index += usize::from(gap.get(index + 1) == Some(&b'\n'));
+        } else if gap[index] == b'\n' {
+            newlines += 1;
+        }
+        index += 1;
+    }
+    let consumed_line_ending = usize::from(
+        left.kind() == "line_comment"
+            && left.end_position().column == 0
+            && left.end_position().row > left.start_position().row,
+    );
+    newlines.saturating_add(consumed_line_ending) <= 1
+}
+
+fn documentation_comment_starts_line(source: &[u8], node: &Node) -> bool {
+    let line_start = source[..node.start_byte()]
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |index| index + 1);
+    source[line_start..node.start_byte()]
+        .iter()
+        .all(u8::is_ascii_whitespace)
+}
+
+fn is_outer_doc_comment(node: &Node) -> bool {
+    matches!(node.kind(), "line_comment" | "block_comment")
+        && node.child_by_field_name("outer").is_some()
+}
+
+fn is_inner_doc_comment(node: &Node) -> bool {
+    matches!(node.kind(), "line_comment" | "block_comment")
+        && node.child_by_field_name("inner").is_some()
+}
+
+fn push_rust_doc_comment(builder: &mut DocumentationTextBuilder, node: &Node, source: &[u8]) {
+    let Some(text) = node_text(node, source) else {
+        return;
+    };
+    if node.kind() == "line_comment" {
+        let body = text.get(3..).unwrap_or_default();
+        builder.push_line(body.strip_prefix(' ').unwrap_or(body));
+        return;
+    }
+    let body = text
+        .strip_prefix("/**")
+        .or_else(|| text.strip_prefix("/*!"))
+        .unwrap_or_default()
+        .strip_suffix("*/")
+        .unwrap_or_default();
+    for line in body.lines() {
+        let line = line.trim_start();
+        let line = line.strip_prefix('*').unwrap_or(line);
+        builder.push_line(line.strip_prefix(' ').unwrap_or(line).trim_end());
+    }
+}
+
+fn symbol_index_for_declaration(
+    node: &Node,
+    source: &[u8],
+    symbols: &HashMap<(u32, &str), usize>,
+) -> Option<usize> {
+    let name = match node.kind() {
+        "impl_item" => impl_target_name(node, source)?,
+        _ => name_field(node, source)?.to_string(),
+    };
+    let line = node.start_position().row as u32 + 1;
+    symbols.get(&(line, name.as_str())).copied()
+}
+
+fn declaration_owns_outer_docs(kind: &str) -> bool {
+    matches!(
+        kind,
+        "function_item" | "struct_item" | "enum_item" | "trait_item" | "impl_item" | "mod_item"
+    )
+}
+
+fn collect_outer_docs_in(
+    node: Node,
+    source: &[u8],
+    symbols: &HashMap<(u32, &str), usize>,
+    output: &mut Vec<RawConceptDocumentation>,
+) {
+    let mut cursor = node.walk();
+    let children = node.named_children(&mut cursor).collect::<Vec<_>>();
+    for (declaration_index, declaration) in children.iter().enumerate() {
+        if !declaration_owns_outer_docs(declaration.kind()) {
+            continue;
+        }
+        let Some(symbol_index) = symbol_index_for_declaration(declaration, source, symbols) else {
+            continue;
+        };
+        let mut preceding_index = declaration_index;
+        let mut next = *declaration;
+        while preceding_index > 0 {
+            let candidate = children[preceding_index - 1];
+            if candidate.kind() != "attribute_item"
+                || !documentation_nodes_adjacent(source, &candidate, &next)
+            {
+                break;
+            }
+            preceding_index -= 1;
+            next = candidate;
+        }
+
+        let mut docs = Vec::new();
+        while preceding_index > 0 {
+            let candidate = children[preceding_index - 1];
+            if !is_outer_doc_comment(&candidate)
+                || !documentation_comment_starts_line(source, &candidate)
+                || !documentation_nodes_adjacent(source, &candidate, &next)
+            {
+                break;
+            }
+            docs.push(candidate);
+            preceding_index -= 1;
+            next = candidate;
+        }
+        if docs.is_empty() {
+            continue;
+        }
+        let mut builder = DocumentationTextBuilder::default();
+        for doc in docs.into_iter().rev() {
+            push_rust_doc_comment(&mut builder, &doc, source);
+        }
+        if let Some(candidate) = builder.finish(symbol_index) {
+            output.push(candidate);
+        }
+    }
+}
+
+fn collect_inner_module_docs(
+    node: Node,
+    module_index: usize,
+    source: &[u8],
+    output: &mut Vec<RawConceptDocumentation>,
+) {
+    let mut cursor = node.walk();
+    let mut builder = DocumentationTextBuilder::default();
+    for child in node.named_children(&mut cursor) {
+        if is_inner_doc_comment(&child) && documentation_comment_starts_line(source, &child) {
+            push_rust_doc_comment(&mut builder, &child, source);
+        }
+    }
+    if let Some(candidate) = builder.finish(module_index) {
+        output.push(candidate);
+    }
+}
+
+fn walk_concept_documentation(
+    node: Node,
+    source: &[u8],
+    symbols: &HashMap<(u32, &str), usize>,
+    output: &mut Vec<RawConceptDocumentation>,
+) {
+    collect_outer_docs_in(node, source, symbols, output);
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.kind() == "mod_item" {
+            if let (Some(module_index), Some(body)) = (
+                symbol_index_for_declaration(&child, source, symbols),
+                child.child_by_field_name("body"),
+            ) {
+                collect_inner_module_docs(body, module_index, source, output);
+            }
+        }
+        walk_concept_documentation(child, source, symbols, output);
+    }
+}
+
+pub(super) fn collect_concept_documentation(
+    tree: &Tree,
+    source: &[u8],
+    pending: &PendingFile,
+    module_index: usize,
+) -> Vec<RawConceptDocumentation> {
+    let root = tree.root_node();
+    let mut output = Vec::new();
+    let mut symbols = HashMap::with_capacity(pending.symbols.len());
+    for (index, symbol) in pending.symbols.iter().enumerate() {
+        if symbol.kind != "module" {
+            symbols
+                .entry((symbol.line_start, symbol.name.as_str()))
+                .or_insert(index);
+        }
+    }
+    collect_inner_module_docs(root, module_index, source, &mut output);
+    walk_concept_documentation(root, source, &symbols, &mut output);
+    output
 }
 
 #[cfg(test)]

--- a/mcp/servers/mmcg/src/indexer/typescript.rs
+++ b/mcp/servers/mmcg/src/indexer/typescript.rs
@@ -3,8 +3,9 @@
 use super::common::{
     line_of, node_text, push_call_with_type, push_def, push_import, signature_until_body,
 };
-use super::LanguageExtractor;
+use super::{DocumentationTextBuilder, LanguageExtractor, RawConceptDocumentation};
 use crate::store::PendingFile;
+use std::collections::HashMap;
 use tree_sitter::{Node, Tree};
 
 pub struct TypescriptExtractor {
@@ -360,6 +361,171 @@ fn find_child_of_kind<'tree>(node: &Node<'tree>, target_kind: &str) -> Option<No
         }
     }
     None
+}
+
+fn documentation_nodes_adjacent(source: &[u8], left: &Node, right: &Node) -> bool {
+    if left.end_byte() > right.start_byte()
+        || right.start_position().row > left.end_position().row.saturating_add(1)
+    {
+        return false;
+    }
+    let gap = &source[left.end_byte()..right.start_byte()];
+    if !gap.iter().all(u8::is_ascii_whitespace) {
+        return false;
+    }
+    let mut newlines = 0usize;
+    let mut index = 0usize;
+    while index < gap.len() {
+        if gap[index] == b'\r' {
+            newlines += 1;
+            index += usize::from(gap.get(index + 1) == Some(&b'\n'));
+        } else if gap[index] == b'\n' {
+            newlines += 1;
+        }
+        index += 1;
+    }
+    newlines <= 1
+}
+
+fn documentation_comment_starts_line(source: &[u8], node: &Node) -> bool {
+    let line_start = source[..node.start_byte()]
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |index| index + 1);
+    source[line_start..node.start_byte()]
+        .iter()
+        .all(u8::is_ascii_whitespace)
+}
+
+fn is_jsdoc(node: &Node, source: &[u8]) -> bool {
+    node.kind() == "comment" && node_text(node, source).is_some_and(|text| text.starts_with("/**"))
+}
+
+fn is_file_header_jsdoc(node: &Node, source: &[u8]) -> bool {
+    let Some(text) = node_text(node, source) else {
+        return false;
+    };
+    let lower = text.to_ascii_lowercase();
+    lower.contains("@file")
+        || lower.contains("@fileoverview")
+        || lower.contains("@license")
+        || lower.contains("@copyright")
+        || lower.contains("copyright")
+        || lower.contains("licensed under")
+        || lower.contains("spdx-license-identifier")
+}
+
+fn push_jsdoc(builder: &mut DocumentationTextBuilder, node: &Node, source: &[u8]) {
+    let Some(text) = node_text(node, source) else {
+        return;
+    };
+    let body = text
+        .strip_prefix("/**")
+        .unwrap_or_default()
+        .strip_suffix("*/")
+        .unwrap_or_default();
+    for line in body.lines() {
+        let line = line.trim_start();
+        let line = line.strip_prefix('*').unwrap_or(line);
+        builder.push_line(line.strip_prefix(' ').unwrap_or(line).trim_end());
+    }
+}
+
+fn owned_symbol_nodes<'tree>(node: Node<'tree>) -> Vec<Node<'tree>> {
+    match node.kind() {
+        "export_statement" => node
+            .child_by_field_name("declaration")
+            .map(owned_symbol_nodes)
+            .unwrap_or_default(),
+        "function_declaration"
+        | "generator_function_declaration"
+        | "class_declaration"
+        | "abstract_class_declaration"
+        | "interface_declaration"
+        | "method_definition" => vec![node],
+        "lexical_declaration" | "variable_declaration" => {
+            let mut cursor = node.walk();
+            node.named_children(&mut cursor)
+                .filter(|child| {
+                    child.kind() == "variable_declarator"
+                        && child
+                            .child_by_field_name("value")
+                            .as_ref()
+                            .and_then(function_body_owner)
+                            .is_some()
+                })
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn symbol_index_for_declaration(
+    node: &Node,
+    source: &[u8],
+    symbols: &HashMap<(u32, &str), usize>,
+) -> Option<usize> {
+    let name = node
+        .child_by_field_name("name")
+        .and_then(|name| node_text(&name, source))
+        .unwrap_or("<anon>");
+    let line = node.start_position().row as u32 + 1;
+    symbols.get(&(line, name)).copied()
+}
+
+fn walk_concept_documentation(
+    node: Node,
+    source: &[u8],
+    symbols: &HashMap<(u32, &str), usize>,
+    output: &mut Vec<RawConceptDocumentation>,
+) {
+    let mut cursor = node.walk();
+    let children = node.named_children(&mut cursor).collect::<Vec<_>>();
+    for (index, wrapper) in children.iter().enumerate() {
+        let owners = owned_symbol_nodes(*wrapper);
+        if owners.is_empty() || index == 0 {
+            continue;
+        }
+        let comment = children[index - 1];
+        if !is_jsdoc(&comment, source)
+            || (node.kind() == "program" && is_file_header_jsdoc(&comment, source))
+            || !documentation_comment_starts_line(source, &comment)
+            || !documentation_nodes_adjacent(source, &comment, wrapper)
+        {
+            continue;
+        }
+        for owner in owners {
+            let Some(symbol_index) = symbol_index_for_declaration(&owner, source, symbols) else {
+                continue;
+            };
+            let mut builder = DocumentationTextBuilder::default();
+            push_jsdoc(&mut builder, &comment, source);
+            if let Some(candidate) = builder.finish(symbol_index) {
+                output.push(candidate);
+            }
+        }
+    }
+    for child in children {
+        walk_concept_documentation(child, source, symbols, output);
+    }
+}
+
+pub(super) fn collect_concept_documentation(
+    tree: &Tree,
+    source: &[u8],
+    pending: &PendingFile,
+) -> Vec<RawConceptDocumentation> {
+    let mut output = Vec::new();
+    let mut symbols = HashMap::with_capacity(pending.symbols.len());
+    for (index, symbol) in pending.symbols.iter().enumerate() {
+        if symbol.kind != "module" {
+            symbols
+                .entry((symbol.line_start, symbol.name.as_str()))
+                .or_insert(index);
+        }
+    }
+    walk_concept_documentation(tree.root_node(), source, &symbols, &mut output);
+    output
 }
 
 #[cfg(test)]

--- a/mcp/servers/mmcg/src/main.rs
+++ b/mcp/servers/mmcg/src/main.rs
@@ -1145,7 +1145,7 @@ fn run_cli_inner(
             let indexer = mmcg::indexer::Indexer::new(&root);
             let stats = indexer.index_all(&mut store, force)?;
             println!(
-                "indexed {} (unchanged {}, purged {}, skipped binary {}, skipped large {}, failed {}) / scanned {} | {} symbols | {} edges | {} concept rows (orphans purged {}, contract rebuilt {}) | {} task specs | {} history entries (skipped {}, truncated {}) | {} ms",
+                "indexed {} (unchanged {}, purged {}, skipped binary {}, skipped large {}, failed {}) / scanned {} | {} symbols | {} edges | {} concept rows (orphans purged {}, contract rebuilt {}) | {} documentation documents (languages {}, secret omitted {}, size omitted {}, unsupported files {}) | {} task specs | {} history entries (skipped {}, truncated {}) | {} ms",
                 stats.files_indexed,
                 stats.files_unchanged,
                 stats.files_purged,
@@ -1158,6 +1158,11 @@ fn run_cli_inner(
                 stats.concept_rows_indexed,
                 stats.concept_orphans_purged,
                 stats.concept_contract_rebuilt,
+                stats.concept_documentation_indexed,
+                stats.concept_documentation_supported_languages,
+                stats.concept_documentation_secret_omitted,
+                stats.concept_documentation_size_omitted,
+                stats.concept_documentation_unsupported_language_files,
                 stats.task_specs_indexed,
                 stats.history_entries_indexed,
                 stats.history_entries_skipped,

--- a/mcp/servers/mmcg/src/mcp.rs
+++ b/mcp/servers/mmcg/src/mcp.rs
@@ -2066,7 +2066,7 @@ fn schema_brief() -> Value {
 fn schema_concept() -> Value {
     json!({
         "name": "mmcg_concept",
-        "description": "Deterministic local concept retrieval over bounded normalized symbol names, repository paths, and declaration shapes. Uses SQLite FTS5 only: no embeddings, model calls, network access, source bodies, comments, literals, or defaults. Results are retrieval candidates, not confidence-ranked answers.",
+        "description": "Deterministic local concept retrieval over bounded normalized symbol names, repository paths, declaration shapes, and owned Rust/Python/JavaScript/TypeScript documentation tokens. Uses SQLite FTS5 only: no embeddings, model calls, network access, source bodies, raw comments/docstrings, literals, or defaults. Results are retrieval candidates, not confidence-ranked answers.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -3964,7 +3964,7 @@ mod tests {
         let (root, mut store) = impact_fixture("concept-shared");
         std::fs::write(
             root.join("src/app.py"),
-            "def value(secret: str = 'TOPSECRET', required: ImportantType = None):\n    return required\n",
+            "def value(secret: str = 'TOPSECRET', required: ImportantType = None):\n    \"\"\"retrievalquartz private operational phrase\"\"\"\n    return required\n",
         )
         .unwrap();
         std::fs::write(
@@ -3992,6 +3992,28 @@ mod tests {
         assert_eq!(actual["isError"], false);
         assert_eq!(unwrap_content(&actual), expected);
         assert_eq!(actual["structuredContent"], expected);
+
+        let documentation =
+            serde_json::to_value(build_concept_current(&mut store, "retrievalquartz", 10).unwrap())
+                .unwrap();
+        assert_eq!(
+            documentation["candidates"][0]["matched_fields"],
+            json!(["documentation"])
+        );
+        let rendered = documentation.to_string();
+        assert!(!rendered.contains("operational"));
+        assert!(!rendered.contains("phrase"));
+        let mcp_documentation = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut store,
+            &json!({
+                "name": "mmcg_concept",
+                "arguments": { "query": "retrievalquartz", "top": 10 }
+            }),
+        )
+        .unwrap();
+        assert_eq!(unwrap_content(&mcp_documentation), documentation);
+        assert_eq!(mcp_documentation["structuredContent"], documentation);
         std::fs::remove_dir_all(root).ok();
     }
 
@@ -4070,6 +4092,71 @@ mod tests {
         assert_eq!(unwrap_content(&result)["code"], "index_stale");
         assert_eq!(std::fs::read(&db).unwrap(), before);
 
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn concept_documentation_stats_contract_repairs_managed_and_preserves_custom_indexes() {
+        let (root, store) = impact_fixture("concept-documentation-stats-drift");
+        let db = store.db_path().to_path_buf();
+        drop(store);
+
+        let connection = rusqlite::Connection::open(&db).unwrap();
+        connection
+            .execute_batch("DROP TABLE concept_documentation_file_stats")
+            .unwrap();
+        drop(connection);
+        let mut managed = crate::store::Store::open_for_serve(&db, Some(&root)).unwrap();
+        assert!(managed.concept_schema_objects_current().unwrap());
+        assert!(!managed.concept_contract_current().unwrap());
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut managed,
+            &json!({ "name": "mmcg_concept", "arguments": { "query": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(result["isError"], false);
+        assert!(managed.concept_contract_current().unwrap());
+        assert_eq!(
+            managed
+                .meta_value(crate::store::CONCEPT_DOCUMENTATION_LANGUAGES_META_KEY)
+                .unwrap()
+                .as_deref(),
+            Some(crate::store::CONCEPT_DOCUMENTATION_SUPPORTED_LANGUAGES)
+        );
+        drop(managed);
+
+        let connection = rusqlite::Connection::open(&db).unwrap();
+        connection
+            .execute_batch("DROP TABLE concept_documentation_file_stats")
+            .unwrap();
+        drop(connection);
+        let source_paths = [
+            db.clone(),
+            db.with_extension("db-wal"),
+            db.with_extension("db-shm"),
+        ];
+        let before = source_paths
+            .iter()
+            .map(|path| std::fs::read(path).ok())
+            .collect::<Vec<_>>();
+        let mut custom = crate::store::Store::open_for_serve(&db, None).unwrap();
+        let result = handle_tools_call(
+            ProtocolVersion::Current,
+            &mut custom,
+            &json!({ "name": "mmcg_concept", "arguments": { "query": "value" } }),
+        )
+        .unwrap();
+        assert_eq!(result["isError"], true);
+        assert!(matches!(
+            unwrap_content(&result)["code"].as_str(),
+            Some("index_stale" | "schema_incompatible")
+        ));
+        let after = source_paths
+            .iter()
+            .map(|path| std::fs::read(path).ok())
+            .collect::<Vec<_>>();
+        assert_eq!(after, before);
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/mcp/servers/mmcg/src/queries.rs
+++ b/mcp/servers/mmcg/src/queries.rs
@@ -919,6 +919,7 @@ pub(crate) fn concept_verified(
         .begin_read_snapshot()
         .map_err(|_| ConceptError::SnapshotChanged)?;
     let search = store.search_concepts(&match_query, top);
+    let documentation_stats = store.concept_documentation_stats();
     let end = store.end_read_snapshot();
     let data_version_after = store.data_version().map_err(|_| {
         if store.interrupt_source().is_some() {
@@ -932,6 +933,13 @@ pub(crate) fn concept_verified(
         return Err(ConceptError::SnapshotChanged);
     }
     let hits = search.map_err(|_| {
+        if store.interrupt_source().is_some() {
+            ConceptError::WorkLimitExceeded
+        } else {
+            ConceptError::Internal
+        }
+    })?;
+    let documentation_stats = documentation_stats.map_err(|_| {
         if store.interrupt_source().is_some() {
             ConceptError::WorkLimitExceeded
         } else {
@@ -977,7 +985,23 @@ pub(crate) fn concept_verified(
     let mut precision_notes = vec![
         "bm25_score_is_query_local_lower_is_better_not_confidence".to_string(),
         "unicode_lowercase_without_canonical_equivalence".to_string(),
-        "documentation_search_reserved_empty".to_string(),
+        format!(
+            "documentation_search_supported_languages:{}",
+            crate::store::CONCEPT_DOCUMENTATION_SUPPORTED_LANGUAGES
+        ),
+        "documentation_search_bounded_normalized_tokens_only".to_string(),
+        format!(
+            "documentation_secret_omitted:{}",
+            documentation_stats.secret_omitted
+        ),
+        format!(
+            "documentation_size_omitted:{}",
+            documentation_stats.size_omitted
+        ),
+        format!(
+            "documentation_unsupported_language_files:{}",
+            documentation_stats.unsupported_language_files
+        ),
     ];
     if unsafe_omitted > 0 {
         precision_notes.push(format!("unsafe_candidates_omitted:{unsafe_omitted}"));

--- a/mcp/servers/mmcg/src/store.rs
+++ b/mcp/servers/mmcg/src/store.rs
@@ -27,10 +27,21 @@ use std::time::{Duration, Instant};
 
 const SCHEMA_VERSION: &str = "7";
 pub const CONCEPT_NORMALIZATION_META_KEY: &str = "concept_normalization_version";
-pub const CONCEPT_NORMALIZATION_VERSION: &str = "mmcg-concepts-v1";
+pub const CONCEPT_NORMALIZATION_VERSION: &str = "mmcg-concepts-v2";
+pub const CONCEPT_DOCUMENTATION_SUPPORTED_LANGUAGES: &str = "javascript,python,rust,tsx,typescript";
+pub const CONCEPT_DOCUMENTATION_INDEXED_META_KEY: &str = "concept_documentation_indexed_count";
+pub const CONCEPT_DOCUMENTATION_SECRET_OMITTED_META_KEY: &str =
+    "concept_documentation_secret_omitted_count";
+pub const CONCEPT_DOCUMENTATION_SIZE_OMITTED_META_KEY: &str =
+    "concept_documentation_size_omitted_count";
+pub const CONCEPT_DOCUMENTATION_UNSUPPORTED_META_KEY: &str =
+    "concept_documentation_unsupported_language_count";
+pub const CONCEPT_DOCUMENTATION_LANGUAGES_META_KEY: &str =
+    "concept_documentation_supported_languages";
 pub const CONCEPT_TERM_MAX_BYTES: usize = 64;
 pub const CONCEPT_SIGNATURE_MAX_BYTES: usize = 256;
-const CONCEPT_FIELD_MAX_BYTES: usize = 512;
+pub const CONCEPT_DOCUMENTATION_MAX_BYTES: usize = 512;
+const CONCEPT_FIELD_MAX_BYTES: usize = CONCEPT_DOCUMENTATION_MAX_BYTES;
 const CONCEPT_INDEX_TERM_LIMIT: usize = 128;
 const CONCEPT_SIGNATURE_SCAN_MAX_BYTES: usize = 64 * 1024;
 const CONCEPT_CONTRACT_DIRTY: &str = "dirty";
@@ -43,6 +54,7 @@ const CONCEPT_SCHEMA_DROP_SQL: &str = r#"
     DROP TRIGGER IF EXISTS symbol_concepts_ad;
     DROP TRIGGER IF EXISTS symbol_concepts_au;
     DROP TABLE IF EXISTS symbol_concepts_fts;
+    DROP TABLE IF EXISTS concept_documentation_file_stats;
     DROP TABLE IF EXISTS symbol_concepts;
 "#;
 const CONCEPT_SCHEMA_DDL: &str = r#"
@@ -54,6 +66,15 @@ const CONCEPT_SCHEMA_DDL: &str = r#"
         path_sort             TEXT NOT NULL,
         signature_search      TEXT NOT NULL,
         documentation_search  TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE concept_documentation_file_stats (
+        path                TEXT PRIMARY KEY
+                            REFERENCES files(path) ON DELETE CASCADE,
+        language_supported  INTEGER NOT NULL
+                            CHECK(language_supported IN (0, 1)),
+        indexed_documents   INTEGER NOT NULL CHECK(indexed_documents >= 0),
+        secret_omitted      INTEGER NOT NULL CHECK(secret_omitted >= 0),
+        size_omitted        INTEGER NOT NULL CHECK(size_omitted >= 0)
     );
     CREATE VIRTUAL TABLE symbol_concepts_fts USING fts5(
         name_search,
@@ -150,6 +171,7 @@ const CONCEPT_TRIGGER_NAMES: &[&str] = &[
 ];
 const CONCEPT_SCHEMA_OBJECTS: &[(&str, &str)] = &[
     ("table", "symbol_concepts"),
+    ("table", "concept_documentation_file_stats"),
     ("table", "symbol_concepts_fts"),
     ("table", "symbol_concepts_fts_config"),
     ("table", "symbol_concepts_fts_data"),
@@ -683,6 +705,34 @@ pub(crate) struct ConceptStoreHit {
 pub(crate) struct ConceptFinalizeStats {
     pub rows: u32,
     pub orphans_purged: u32,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ConceptDocumentationStats {
+    pub indexed_documents: u32,
+    pub secret_omitted: u32,
+    pub size_omitted: u32,
+    pub unsupported_language_files: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PendingConceptDocumentation {
+    pub symbol_index: usize,
+    pub documentation_search: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct PendingConceptCorpus {
+    pub language_supported: bool,
+    pub documents: Vec<PendingConceptDocumentation>,
+    pub secret_omitted: u32,
+    pub size_omitted: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NormalizedConceptDocumentation {
+    pub value: String,
+    pub truncated: bool,
 }
 
 fn lowercase_concept(value: &str) -> String {
@@ -1724,11 +1774,16 @@ fn redact_signature(value: &str, dialect: SignatureDialect) -> Option<String> {
     Some(output)
 }
 
-fn bounded_concept_field(value: &str, byte_limit: usize) -> Option<String> {
+fn bounded_concept_field_with_status(
+    value: &str,
+    byte_limit: usize,
+) -> Option<NormalizedConceptDocumentation> {
     let terms = concept_index_terms(value)?;
     let mut output = String::new();
+    let mut truncated = terms.len() > CONCEPT_INDEX_TERM_LIMIT;
     for term in terms.into_iter().take(CONCEPT_INDEX_TERM_LIMIT) {
         if term.len() > CONCEPT_TERM_MAX_BYTES {
+            truncated = true;
             continue;
         }
         let separator = usize::from(!output.is_empty());
@@ -1738,6 +1793,7 @@ fn bounded_concept_field(value: &str, byte_limit: usize) -> Option<String> {
             .saturating_add(term.len())
             > byte_limit
         {
+            truncated = true;
             break;
         }
         if separator == 1 {
@@ -1745,10 +1801,28 @@ fn bounded_concept_field(value: &str, byte_limit: usize) -> Option<String> {
         }
         output.push_str(&term);
     }
-    Some(output)
+    Some(NormalizedConceptDocumentation {
+        value: output,
+        truncated,
+    })
 }
 
-fn concept_document(name: &str, path: &str, signature: Option<&str>) -> ConceptDocument {
+fn bounded_concept_field(value: &str, byte_limit: usize) -> Option<String> {
+    bounded_concept_field_with_status(value, byte_limit).map(|field| field.value)
+}
+
+pub(crate) fn normalize_concept_documentation(
+    value: &str,
+) -> Option<NormalizedConceptDocumentation> {
+    bounded_concept_field_with_status(value, CONCEPT_FIELD_MAX_BYTES)
+}
+
+fn concept_document(
+    name: &str,
+    path: &str,
+    signature: Option<&str>,
+    documentation_search: &str,
+) -> ConceptDocument {
     let name_search = bounded_concept_field(name, CONCEPT_FIELD_MAX_BYTES).unwrap_or_default();
     let path_search = bounded_concept_field(path, CONCEPT_FIELD_MAX_BYTES).unwrap_or_default();
     let signature_search = signature
@@ -1760,7 +1834,7 @@ fn concept_document(name: &str, path: &str, signature: Option<&str>) -> ConceptD
         path_search,
         path_sort: concept_path_sort(path),
         signature_search,
-        documentation_search: String::new(),
+        documentation_search: documentation_search.to_string(),
     }
 }
 
@@ -1770,8 +1844,9 @@ fn insert_concept_document(
     name: &str,
     path: &str,
     signature: Option<&str>,
+    documentation_search: &str,
 ) -> SqlResult<()> {
-    let document = concept_document(name, path, signature);
+    let document = concept_document(name, path, signature, documentation_search);
     connection.execute(
         "INSERT INTO symbol_concepts(
              symbol_id, name_search, path_search, path_sort, signature_search,
@@ -1786,6 +1861,84 @@ fn insert_concept_document(
             document.documentation_search
         ],
     )?;
+    Ok(())
+}
+
+pub(crate) fn concept_documentation_language_supported(language: &str) -> bool {
+    matches!(
+        language,
+        "javascript" | "python" | "rust" | "tsx" | "typescript"
+    )
+}
+
+fn valid_documentation_search(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= CONCEPT_FIELD_MAX_BYTES
+        && value.split(' ').all(|term| {
+            !term.is_empty()
+                && term.len() <= CONCEPT_TERM_MAX_BYTES
+                && term
+                    .chars()
+                    .all(|character| character.is_alphanumeric() || character == '_')
+        })
+}
+
+fn concept_documentation_stats_on(connection: &Connection) -> SqlResult<ConceptDocumentationStats> {
+    connection.query_row(
+        "SELECT
+             COALESCE(SUM(indexed_documents), 0),
+             COALESCE(SUM(secret_omitted), 0),
+             COALESCE(SUM(size_omitted), 0),
+             COALESCE(SUM(CASE WHEN language_supported = 0 THEN 1 ELSE 0 END), 0)
+         FROM concept_documentation_file_stats",
+        [],
+        |row| {
+            let bounded = |value: i64| u32::try_from(value).unwrap_or(u32::MAX);
+            Ok(ConceptDocumentationStats {
+                indexed_documents: bounded(row.get(0)?),
+                secret_omitted: bounded(row.get(1)?),
+                size_omitted: bounded(row.get(2)?),
+                unsupported_language_files: bounded(row.get(3)?),
+            })
+        },
+    )
+}
+
+fn set_meta_on(connection: &Connection, key: &str, value: &str) -> SqlResult<()> {
+    connection.execute(
+        "INSERT INTO meta(key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![key, value],
+    )?;
+    Ok(())
+}
+
+fn update_concept_documentation_meta_on(connection: &Connection) -> SqlResult<()> {
+    let stats = concept_documentation_stats_on(connection)?;
+    for (key, value) in [
+        (
+            CONCEPT_DOCUMENTATION_LANGUAGES_META_KEY,
+            CONCEPT_DOCUMENTATION_SUPPORTED_LANGUAGES.to_string(),
+        ),
+        (
+            CONCEPT_DOCUMENTATION_INDEXED_META_KEY,
+            stats.indexed_documents.to_string(),
+        ),
+        (
+            CONCEPT_DOCUMENTATION_SECRET_OMITTED_META_KEY,
+            stats.secret_omitted.to_string(),
+        ),
+        (
+            CONCEPT_DOCUMENTATION_SIZE_OMITTED_META_KEY,
+            stats.size_omitted.to_string(),
+        ),
+        (
+            CONCEPT_DOCUMENTATION_UNSUPPORTED_META_KEY,
+            stats.unsupported_language_files.to_string(),
+        ),
+    ] {
+        set_meta_on(connection, key, &value)?;
+    }
     Ok(())
 }
 
@@ -3336,6 +3489,7 @@ impl Store {
         for shadow in CONCEPT_SHADOW_NAMES {
             retire_schema_object_name(&tx, shadow)?;
         }
+        retire_schema_object_name(&tx, "concept_documentation_file_stats")?;
         retire_schema_object_name(&tx, "symbol_concepts")?;
         tx.execute_batch(CONCEPT_SCHEMA_DDL)?;
         tx.execute(
@@ -4133,6 +4287,9 @@ impl Store {
                 params![file_path],
             )?;
             tx.execute("DELETE FROM files WHERE path = ?1", params![file_path])?;
+            if restore_contract && Self::concept_schema_objects_current_on(&tx)? {
+                update_concept_documentation_meta_on(&tx)?;
+            }
             if restore_contract {
                 Self::set_concept_contract_current(&tx)?;
             }
@@ -4150,6 +4307,57 @@ impl Store {
     /// Commit a parsed file's symbols and edges in a single transaction.
     /// Hot path during indexing — keep it batched.
     pub fn commit_file(&mut self, pending: PendingFile) -> SqlResult<()> {
+        let corpus = if concept_documentation_language_supported(&pending.language) {
+            None
+        } else {
+            Some(PendingConceptCorpus::default())
+        };
+        let result = self.commit_file_inner(pending, corpus);
+        if result.is_err() {
+            let _ = self.mark_concept_contract_dirty();
+        }
+        result
+    }
+
+    pub(crate) fn commit_file_with_concepts(
+        &mut self,
+        pending: PendingFile,
+        corpus: PendingConceptCorpus,
+    ) -> SqlResult<()> {
+        if corpus.language_supported != concept_documentation_language_supported(&pending.language)
+        {
+            return Err(rusqlite::Error::InvalidParameterName(
+                "concept documentation language support mismatch".to_string(),
+            ));
+        }
+        let result = self.commit_file_inner(pending, Some(corpus));
+        if result.is_err() {
+            let _ = self.mark_concept_contract_dirty();
+        }
+        result
+    }
+
+    fn commit_file_inner(
+        &mut self,
+        pending: PendingFile,
+        corpus: Option<PendingConceptCorpus>,
+    ) -> SqlResult<()> {
+        let mut documentation_by_symbol = vec![None; pending.symbols.len()];
+        if let Some(corpus) = corpus.as_ref() {
+            for document in &corpus.documents {
+                if document.symbol_index >= documentation_by_symbol.len()
+                    || documentation_by_symbol[document.symbol_index].is_some()
+                    || !valid_documentation_search(&document.documentation_search)
+                {
+                    return Err(rusqlite::Error::InvalidParameterName(
+                        "invalid normalized concept documentation".to_string(),
+                    ));
+                }
+                documentation_by_symbol[document.symbol_index] =
+                    Some(document.documentation_search.as_str());
+            }
+        }
+
         let tx = self.conn.transaction()?;
         let restore_contract = Self::incremental_concept_contract_current_on(&tx)?;
 
@@ -4173,7 +4381,7 @@ impl Store {
                 "INSERT INTO symbols(name, kind, file_path, line_start, line_end, signature, parent_id, language, decorators, production)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             )?;
-            for s in &pending.symbols {
+            for (symbol_index, s) in pending.symbols.iter().enumerate() {
                 let parent_id = s.parent_index.map(|i| symbol_ids[i]);
                 stmt.execute(params![
                     s.name,
@@ -4194,6 +4402,7 @@ impl Store {
                     &s.name,
                     &pending.path,
                     s.signature.as_deref(),
+                    documentation_by_symbol[symbol_index].unwrap_or_default(),
                 )?;
                 symbol_ids.push(symbol_id);
             }
@@ -4228,7 +4437,26 @@ impl Store {
             ],
         )?;
 
-        if restore_contract {
+        if let Some(corpus) = corpus.as_ref() {
+            tx.execute(
+                "INSERT INTO concept_documentation_file_stats(
+                     path, language_supported, indexed_documents,
+                     secret_omitted, size_omitted
+                 ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    &pending.path,
+                    i64::from(corpus.language_supported),
+                    corpus.documents.len() as u32,
+                    corpus.secret_omitted,
+                    corpus.size_omitted
+                ],
+            )?;
+            if restore_contract {
+                update_concept_documentation_meta_on(&tx)?;
+            }
+        }
+
+        if restore_contract && corpus.is_some() {
             Self::set_concept_contract_current(&tx)?;
         }
         tx.commit()?;
@@ -4266,7 +4494,7 @@ impl Store {
                 ],
             )?;
             let symbol_id = self.conn.last_insert_rowid();
-            insert_concept_document(&self.conn, symbol_id, name, file_path, signature)?;
+            insert_concept_document(&self.conn, symbol_id, name, file_path, signature, "")?;
             if restore_contract {
                 Self::set_concept_contract_current(&self.conn)?;
             }
@@ -4483,6 +4711,34 @@ impl Store {
                 )),
             ));
         }
+        let missing_documentation_stats: i64 = tx.query_row(
+            "SELECT COUNT(*)
+             FROM files f
+             LEFT JOIN concept_documentation_file_stats d ON d.path = f.path
+             WHERE d.path IS NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        let mismatched_documentation_counts: i64 = tx.query_row(
+            "SELECT COUNT(*)
+             FROM concept_documentation_file_stats d
+             WHERE d.indexed_documents <> (
+                 SELECT COUNT(*)
+                 FROM symbols s
+                 JOIN symbol_concepts c ON c.symbol_id = s.id
+                 WHERE s.file_path = d.path AND c.documentation_search <> ''
+             )",
+            [],
+            |row| row.get(0),
+        )?;
+        if missing_documentation_stats != 0 || mismatched_documentation_counts != 0 {
+            return Err(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+                Some(format!(
+                    "concept finalization found {missing_documentation_stats} files without documentation stats and {mismatched_documentation_counts} mismatched documentation counts"
+                )),
+            ));
+        }
         tx.execute(
             "INSERT INTO symbol_concepts_fts(symbol_concepts_fts) VALUES ('rebuild')",
             [],
@@ -4492,6 +4748,7 @@ impl Store {
              VALUES ('integrity-check', 1)",
             [],
         )?;
+        update_concept_documentation_meta_on(&tx)?;
         tx.execute(
             "INSERT INTO meta(key, value) VALUES (?1, ?2)
              ON CONFLICT(key) DO UPDATE SET value=excluded.value",
@@ -4520,6 +4777,10 @@ impl Store {
     pub fn concept_count(&self) -> SqlResult<u32> {
         self.conn
             .query_row("SELECT COUNT(*) FROM symbol_concepts", [], |row| row.get(0))
+    }
+
+    pub(crate) fn concept_documentation_stats(&self) -> SqlResult<ConceptDocumentationStats> {
+        concept_documentation_stats_on(&self.conn)
     }
 
     pub(crate) fn purge_orphan_concepts(&self) -> SqlResult<u32> {
@@ -9174,7 +9435,7 @@ mod tests {
     }
 
     fn concept_signature_terms_for(path: &str, signature: &str) -> Vec<String> {
-        concept_document("fixture", path, Some(signature))
+        concept_document("fixture", path, Some(signature), "")
             .signature_search
             .split_whitespace()
             .map(str::to_string)
@@ -9560,6 +9821,35 @@ mod tests {
             .unwrap();
         store.finalize_index_contracts_current().unwrap();
         assert!(store.concept_contract_current().unwrap());
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn concept_documentation_legacy_file_writer_cannot_finalize_current() {
+        let path = tmp_db("concept_documentation_legacy_file_writer");
+        let mut store = Store::open(&path).unwrap();
+        store
+            .commit_file(PendingFile {
+                path: "src/legacy.rs".to_string(),
+                mtime: 1,
+                content_sha256: "legacy-hash".to_string(),
+                language: "rust".to_string(),
+                symbols: vec![PendingSymbol {
+                    name: "legacy".to_string(),
+                    kind: "function".to_string(),
+                    line_start: 1,
+                    line_end: 2,
+                    signature: Some("fn legacy()".to_string()),
+                    parent_index: None,
+                    decorators: None,
+                }],
+                edges: Vec::new(),
+            })
+            .unwrap();
+
+        assert!(!store.concept_contract_current().unwrap());
+        assert!(store.finalize_index_contracts_current().is_err());
+        assert!(!store.concept_contract_current().unwrap());
         std::fs::remove_file(path).ok();
     }
 


### PR DESCRIPTION
## Summary

- index owned Rust docs, Python docstrings, and JavaScript/TypeScript JSDoc as bounded normalized concept tokens
- omit credential-shaped candidates and enforce 2 KiB candidate, 512-byte symbol, and 64 KiB file limits
- keep file transactions, managed refresh, custom-index fail-closed behavior, Task 006 response schema, ranking, limits, and tool count intact
- expose count-only documentation coverage and omission precision, with updated security and reference docs

## Verification

- focused documentation corpus: 8 passed
- extractor contract: 3 passed
- concept suite: 39 passed
- just check: 728 Rust, 26 npm, 1 Lens, 38 security workflow, and 37 eval tests passed
- production-style CLI retrieval smoke passed
- comment audit clean

No release, tag, merge, publication, or deployment was performed.