### PR TITLE
chore(release): prepare 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-08-25
+
 ### Added
+- Lens now includes an evidence-backed codebase Audit view with component maps,
+  dependency cycles, large-file pressure, author concentration, dead-code
+  candidates, change hotspots, and change-scoped security evidence. Optional AI
+  narratives are bound to the exact repository, revisions, worktree snapshot,
+  and project map; invalid or stale sidecars are ignored.
 - `mmcg_concept` and `mastermind concept` now return a bounded schema-v1 set of
   local symbol candidates from normalized names, repository paths, and
   declaration shapes. Rust outer docs, Python owned docstrings, and
@@ -52,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   staging backups if final cleanup fails.
 
 ### Changed
+- Lens now leads reviewers through Changed → Impacted → Boundary → Tests,
+  remains responsive down to 320 px, and keeps large dirty-worktree projections
+  bounded without hiding observed counts. Live and standalone views remain
+  offline and read-only.
 - Researcher and critic runtime prompts are compact evidence contracts without
   repeated examples or companion sections. Their behavioral and size ceilings
   are covered by deterministic and model-backed evals.
@@ -742,7 +753,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Seven prebuilt platform packages (`@xcraftmind/mmcg-*`) covering macOS (arm64, x64), Linux glibc and musl (x64, arm64), and Windows (x64). npm installs only the package matching the host's `os` / `cpu` / `libc`.
 - Install-mode-aware `setup claude` that writes the correct MCP `command` form for npx, global, project-local, and cargo installs.
 
-[Unreleased]: https://github.com/xcrft/mastermind/compare/npm-v2.0.1...HEAD
+[Unreleased]: https://github.com/xcrft/mastermind/compare/npm-v2.1.0...HEAD
+[2.1.0]: https://github.com/xcrft/mastermind/compare/npm-v2.0.1...npm-v2.1.0
 [2.0.1]: https://github.com/xcrft/mastermind/compare/npm-v2.0.0...npm-v2.0.1
 [2.0.0]: https://github.com/xcrft/mastermind/compare/npm-v1.2.1...npm-v2.0.0
 [1.2.1]: https://github.com/xcrft/mastermind/compare/npm-v1.2.0...npm-v1.2.1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@xcraftmind/mastermind"><img src="https://img.shields.io/badge/npm-v2.0.1-CB3837?logo=npm" alt="npm version 2.0.1"></a>
+  <a href="https://www.npmjs.com/package/@xcraftmind/mastermind"><img src="https://img.shields.io/badge/npm-v2.1.0-CB3837?logo=npm" alt="npm version 2.1.0"></a>
   <a href="https://crates.io/crates/mmcg"><img src="https://img.shields.io/crates/v/mmcg.svg" alt="crates.io version"></a>
   <a href="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml"><img src="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml/badge.svg" alt="CI status"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-4f46e5.svg" alt="MIT license"></a>

--- a/agents/claude-md/mastermind-workflow.md
+++ b/agents/claude-md/mastermind-workflow.md
@@ -2,7 +2,7 @@
 name: mastermind-workflow
 description: Compact project router for the Mastermind Direct, Verified, and Strict workflows.
 metadata:
-  version: 2.0.2
+  version: 2.1.0
   authors: [mastermind]
   tags: [claude-md, workflow, delegation, audit]
 ---

--- a/docs/examples/mastermind-review-pr.yml
+++ b/docs/examples/mastermind-review-pr.yml
@@ -40,7 +40,7 @@ jobs:
             install -m 0755 mcp/servers/mmcg/target/release/mmcg "$RUNNER_TEMP/mastermind-bin/mastermind"
             echo "MASTERMIND_BIN=$RUNNER_TEMP/mastermind-bin/mastermind" >> "$GITHUB_ENV"
           else
-            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@2.0.1
+            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@2.1.0
             echo "MASTERMIND_BIN=mastermind" >> "$GITHUB_ENV"
           fi
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ npx mastermind --version
 Cargo installation exposes the same binary as `mmcg`:
 
 ```bash
-cargo install mmcg --version 2.0.1 --locked
+cargo install mmcg --version 2.1.0 --locked
 mmcg --version
 ```
 

--- a/mcp/servers/mmcg/Cargo.lock
+++ b/mcp/servers/mmcg/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "mmcg"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/mcp/servers/mmcg/Cargo.toml
+++ b/mcp/servers/mmcg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmcg"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.96"
 build = "build.rs"

--- a/mcp/servers/mmcg/README.md
+++ b/mcp/servers/mmcg/README.md
@@ -2,7 +2,7 @@
 name: mmcg
 description: Mastermind Codegraph — local multi-language code indexer for Python, TypeScript/TSX, JavaScript/JSX, Vue SFC, Rust, C#, Go, Java, PHP, and C/C++. Stores symbols, calls, imports, evidence, and project history in SQLite and exposes 30 bounded MCP tools.
 metadata:
-  version: 2.0.1
+  version: 2.1.0
   authors:
     - mastermind
   tags:

--- a/mcp/servers/mmcg/assets/mastermind-review-pr.yml
+++ b/mcp/servers/mmcg/assets/mastermind-review-pr.yml
@@ -40,7 +40,7 @@ jobs:
             install -m 0755 mcp/servers/mmcg/target/release/mmcg "$RUNNER_TEMP/mastermind-bin/mastermind"
             echo "MASTERMIND_BIN=$RUNNER_TEMP/mastermind-bin/mastermind" >> "$GITHUB_ENV"
           else
-            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@2.0.1
+            npm install --global --ignore-scripts --no-audit --no-fund @xcraftmind/mastermind@2.1.0
             echo "MASTERMIND_BIN=mastermind" >> "$GITHUB_ENV"
           fi
 

--- a/mcp/servers/mmcg/templates/workflow.md
+++ b/mcp/servers/mmcg/templates/workflow.md
@@ -2,7 +2,7 @@
 name: mastermind-workflow
 description: Compact project router for the Mastermind Direct, Verified, and Strict workflows.
 metadata:
-  version: 2.0.2
+  version: 2.1.0
   authors: [mastermind]
   tags: [claude-md, workflow, delegation, audit]
 ---

--- a/npm/mastermind/README.md
+++ b/npm/mastermind/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@xcraftmind/mastermind"><img src="https://img.shields.io/badge/npm-v2.0.1-CB3837?logo=npm" alt="npm version 2.0.1"></a>
+  <a href="https://www.npmjs.com/package/@xcraftmind/mastermind"><img src="https://img.shields.io/badge/npm-v2.1.0-CB3837?logo=npm" alt="npm version 2.1.0"></a>
   <a href="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml"><img src="https://github.com/xcrft/mastermind/actions/workflows/ci-mmcg.yml/badge.svg" alt="CI status"></a>
   <a href="https://github.com/xcrft/mastermind/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-4f46e5.svg" alt="MIT license"></a>
 </p>

--- a/npm/mastermind/package.json
+++ b/npm/mastermind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mastermind",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Local codegraph and verifiable workflow for AI coding agents — project maps, change and test impact, MCP queries, Vue SFC indexing, and diff-backed implementation audits. Prebuilt binaries for macOS, Linux, and Windows.",
   "license": "MIT",
   "author": "xcraftmind",
@@ -42,12 +42,12 @@
     "mastermind"
   ],
   "optionalDependencies": {
-    "@xcraftmind/mmcg-darwin-arm64": "2.0.1",
-    "@xcraftmind/mmcg-darwin-x64": "2.0.1",
-    "@xcraftmind/mmcg-linux-x64-gnu": "2.0.1",
-    "@xcraftmind/mmcg-linux-arm64-gnu": "2.0.1",
-    "@xcraftmind/mmcg-linux-x64-musl": "2.0.1",
-    "@xcraftmind/mmcg-linux-arm64-musl": "2.0.1",
-    "@xcraftmind/mmcg-win32-x64-msvc": "2.0.1"
+    "@xcraftmind/mmcg-darwin-arm64": "2.1.0",
+    "@xcraftmind/mmcg-darwin-x64": "2.1.0",
+    "@xcraftmind/mmcg-linux-x64-gnu": "2.1.0",
+    "@xcraftmind/mmcg-linux-arm64-gnu": "2.1.0",
+    "@xcraftmind/mmcg-linux-x64-musl": "2.1.0",
+    "@xcraftmind/mmcg-linux-arm64-musl": "2.1.0",
+    "@xcraftmind/mmcg-win32-x64-msvc": "2.1.0"
   }
 }

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-darwin-arm64",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Prebuilt mmcg binary for macOS arm64 (Apple Silicon). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/darwin-x64/package.json
+++ b/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-darwin-x64",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Prebuilt mmcg binary for macOS x86_64 (Intel). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-arm64-gnu/package.json
+++ b/npm/platforms/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-arm64-gnu",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Prebuilt mmcg binary for Linux arm64 glibc. Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-arm64-musl/package.json
+++ b/npm/platforms/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-arm64-musl",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Prebuilt mmcg binary for Linux arm64 musl (Alpine, distroless). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-x64-gnu/package.json
+++ b/npm/platforms/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-x64-gnu",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Prebuilt mmcg binary for Linux x86_64 glibc. Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/linux-x64-musl/package.json
+++ b/npm/platforms/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-linux-x64-musl",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Prebuilt mmcg binary for Linux x86_64 musl (Alpine, distroless). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",

--- a/npm/platforms/win32-x64-msvc/package.json
+++ b/npm/platforms/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xcraftmind/mmcg-win32-x64-msvc",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Prebuilt mmcg binary for Windows x86_64 (MSVC). Internal — installed automatically as an optional dependency of @xcraftmind/mastermind.",
   "license": "MIT",
   "author": "xcraftmind",


### PR DESCRIPTION
## Summary

- bump mmcg, the npm root package, and all seven native packages to 2.1.0
- close the changelog for Lens Audit, bounded brief and concept queries, deterministic workflow audit, managed index refresh, install profiles, and graph-first routing
- align README badges, pinned install examples, crate metadata, and workflow template mirrors

## Verification

- `just check`
- `just package`
- `just publish-dry`
- `just npm-smoke-native`
- crate archive inspection and exact version metadata check
- all eight npm package versions and both release tags are unused
- independent release review: SHIP, no blockers

## Known limitation

The live Claude post-change model-backed eval was not rerun because the organization spend limit is exhausted. Deterministic prompt, routing, token-reporting, Rust, npm, packaging, security, and hosted CI gates remain in place.

## Release plan

After this PR is green and merged, push `npm-v2.1.0` and `mmcg-v2.1.0`. The tag workflows will publish exact verified artifacts and run public registry install smokes before the GitHub Release is created.
